### PR TITLE
refactor(eslint-config): move `types.d.ts` to `types.ts`

### DIFF
--- a/.changeset/big-chefs-call.md
+++ b/.changeset/big-chefs-call.md
@@ -1,0 +1,6 @@
+---
+"@bfra.me/eslint-config": minor
+---
+
+Move `types.d.ts` to `types.ts` and simplify types
+  

--- a/.changeset/empty-taxis-watch.md
+++ b/.changeset/empty-taxis-watch.md
@@ -1,0 +1,6 @@
+---
+"@bfra.me/eslint-config": patch
+---
+
+Add missing name to JSDoc config
+  

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,2 @@
 **/lib
-packages/eslint-config/src/types.d.ts
+packages/eslint-config/src/types.ts

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -2,6 +2,7 @@ import {defineConfig} from './packages/eslint-config'
 
 export default defineConfig(
   {
+    name: '@bfra.me/works',
     ignores: ['**/test/fixtures', '**/test/_fixtures'],
     typescript: {
       parserOptions: {
@@ -28,5 +29,9 @@ export default defineConfig(
         },
       ],
     },
+  },
+  {
+    name: '@bfra.me/works/eslint-config/types',
+    ignores: ['packages/eslint-config/src/types.ts'],
   },
 )

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "bootstrap": "pnpm run clean && pnpm install --frozen-lockfile --prefer-offline && pnpm run build",
     "build": "pnpm -r run build",
     "check-format": "prettier --check .",
-    "clean": "pnpx rimraf --glob \"**/node_modules/**/!(.pnpm)\" \"packages/*/lib\" \"packages/eslint-config/src/types.d.ts\" \"**/*.tsbuildinfo\"",
+    "clean": "pnpx rimraf --glob \"**/node_modules/**/!(.pnpm)\" \"packages/*/lib\" \"packages/eslint-config/src/types?(.d).ts\" \"**/*.tsbuildinfo\"",
     "dev": "pnpm --recursive --parallel --stream run dev",
     "format": "prettier --write .",
     "inspect-eslint-config": "eslint-config-inspector --config eslint.config.ts",

--- a/packages/eslint-config/.gitignore
+++ b/packages/eslint-config/.gitignore
@@ -1,1 +1,1 @@
-src/types.d.ts
+src/types.ts

--- a/packages/eslint-config/src/configs/jsdoc.ts
+++ b/packages/eslint-config/src/configs/jsdoc.ts
@@ -4,6 +4,7 @@ import type {Config} from '../types'
 export async function jsdoc(): Promise<Config[]> {
   return [
     {
+      name: '@bfra.me/jsdoc',
       plugins: {jsdoc: _jsdoc},
       rules: {
         'jsdoc/check-access': 'warn',

--- a/packages/eslint-config/src/define-config.ts
+++ b/packages/eslint-config/src/define-config.ts
@@ -16,7 +16,7 @@ import {
   typescript,
   vitest,
 } from './configs'
-import type {ComposableConfig, Config, ConfigNames} from './types'
+import type {Config, ConfigNames} from './types'
 import * as Env from './env'
 import {interopDefault} from './plugins'
 
@@ -132,7 +132,7 @@ export async function defineConfig(
   ...userConfigs: Awaitable<Config | Config[] | FlatConfigComposer<any, any> | Linter.Config[]>[]
   // @ts-expect-error - TypeScript insists that the return type should be `Promise<T>`, but it's actually
   // `FlatConfigComposer<>` which acts like a `Promise<T>`.
-): ComposableConfig {
+): FlatConfigComposer<Config, ConfigNames> {
   const {
     gitignore: enableGitignore = true,
     typescript: enableTypeScript = isPackageExists('typescript'),
@@ -204,10 +204,7 @@ export async function defineConfig(
     configs.push([optionsConfig])
   }
 
-  const composer = new FlatConfigComposer<Config, ConfigNames>().append(
-    ...configs,
-    ...(userConfigs as any),
-  )
+  const composer = new FlatConfigComposer<Config, ConfigNames>(...configs, ...(userConfigs as any))
 
   return composer
 }

--- a/packages/eslint-config/src/index.ts
+++ b/packages/eslint-config/src/index.ts
@@ -4,6 +4,6 @@ export * from './configs'
 export * from './define-config'
 export * from './env'
 export * from './globs'
-export * from './types.d'
+export * from './types'
 
 export default defineConfig()


### PR DESCRIPTION
* chore(eslint): ignore generated types
* chore: add missing name to JSDoc config