### PR TITLE
chore(scripts): add utility for cleaning private package entries from changesets

### DIFF
--- a/.github/workflows/renovate-changeset.yaml
+++ b/.github/workflows/renovate-changeset.yaml
@@ -45,4 +45,21 @@ jobs:
 
       - name: Run changesets-renovate
         if: steps.filter.outputs.changes == 'true'
+        env:
+          SKIP_COMMIT: 'TRUE'
+          SORT_CHANGESETS: 'TRUE'
         run: pnpx @scaleway/changesets-renovate
+
+      - name: Clean private package entries from changesets
+        if: steps.filter.outputs.changes == 'true'
+        env:
+          PRIVATE_PACKAGES: '@api/test-utils'
+        run: pnpm tsx scripts/src/clean-changesets.ts
+
+      - name: Commit and push changes
+        if: steps.filter.outputs.changes == 'true'
+        run: |
+          SHORT_HASH=$(git rev-parse --short HEAD)
+          git add .changeset/
+          git commit -m "chore: add changeset renovate-${SHORT_HASH}" || echo "No changes to commit"
+          git push

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ _fixtures
 .tsup
 bfra.me-*.tgz
 .cache
+coverage/

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -11,6 +11,8 @@ export const config = defineConfig({
         './packages/*/tsconfig.json',
         './packages/*/tsconfig.eslint.json',
         './packages/api-core/test-utils/tsconfig.json',
+        './scripts/tsconfig.json',
+        './scripts/tsconfig.eslint.json',
       ],
       projectService: false,
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -352,6 +352,34 @@ importers:
         specifier: 1.0.0
         version: 1.0.0(ajv@8.17.1)
 
+  scripts:
+    dependencies:
+      consola:
+        specifier: 3.4.2
+        version: 3.4.2
+    devDependencies:
+      '@bfra.me/eslint-config':
+        specifier: workspace:*
+        version: link:../packages/eslint-config
+      '@bfra.me/tsconfig':
+        specifier: workspace:*
+        version: link:../packages/tsconfig
+      '@types/node':
+        specifier: 22.13.14
+        version: 22.13.14
+      eslint:
+        specifier: 9.24.0
+        version: 9.24.0(jiti@2.4.2)
+      tsx:
+        specifier: 4.19.3
+        version: 4.19.3
+      typescript:
+        specifier: 5.8.3
+        version: 5.8.3
+      vitest:
+        specifier: 3.1.1
+        version: 3.1.1(@types/debug@4.1.12)(@types/node@22.13.14)(jiti@2.4.2)(tsx@4.19.3)(yaml@2.7.1)
+
 packages:
 
   '@ampproject/remapping@2.3.0':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,4 @@
 packages:
   - .
   - 'packages/*'
+  - scripts

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@bfra.me/scripts",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    "./clean-changesets": "./src/clean-changesets.ts"
+  },
+  "scripts": {
+    "lint": "eslint .",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "consola": "3.4.2"
+  },
+  "devDependencies": {
+    "@bfra.me/eslint-config": "workspace:*",
+    "@bfra.me/tsconfig": "workspace:*",
+    "@types/node": "22.13.14",
+    "eslint": "9.24.0",
+    "tsx": "4.19.3",
+    "typescript": "5.8.3",
+    "vitest": "3.1.1"
+  }
+}

--- a/scripts/readme.md
+++ b/scripts/readme.md
@@ -1,0 +1,60 @@
+# @bfra.me/scripts
+
+> Internal utility scripts for bfra.me monorepo.
+
+## Available Scripts
+
+### clean-changesets
+
+A utility script to clean private package entries from changeset files. This is particularly useful when working with Renovate and private packages that should not be included in versioning.
+
+#### Usage
+
+```sh
+# Using tsx directly
+pnpm tsx scripts/src/clean-changesets.ts
+
+# Or through the package export
+pnpm tsx -e "import '@bfra.me/scripts/clean-changesets'"
+```
+
+#### Configuration
+
+The script can be configured using environment variables:
+
+- `PRIVATE_PACKAGES`: Comma-separated list of private package names to remove from changesets (default: `@api/test-utils`)
+- `DRY_RUN`: Set to `true` to preview changes without applying them (default: `false`)
+
+#### Examples
+
+```sh
+# Remove entries for multiple private packages
+PRIVATE_PACKAGES="@api/test-utils,@api/other-private" pnpm tsx scripts/src/clean-changesets.ts
+
+# Preview changes without applying them
+DRY_RUN=true pnpm tsx scripts/src/clean-changesets.ts
+```
+
+## Development
+
+### Install
+
+```sh
+pnpm install
+```
+
+### Test
+
+```sh
+pnpm test
+```
+
+### Lint
+
+```sh
+pnpm lint
+```
+
+## License
+
+[MIT](../license.md)

--- a/scripts/src/clean-changesets.ts
+++ b/scripts/src/clean-changesets.ts
@@ -1,0 +1,97 @@
+#!/usr/bin/env tsx
+
+import {readdir, readFile, writeFile} from 'node:fs/promises'
+import {join} from 'node:path'
+import process from 'node:process'
+import {consola} from 'consola'
+
+const CHANGESET_DIR = '.changeset'
+
+interface ChangesetFile {
+  path: string
+  content: string
+}
+
+async function getChangesetFiles(): Promise<ChangesetFile[]> {
+  try {
+    const files = await readdir(CHANGESET_DIR)
+    const changesetFiles = files.filter(file => file.endsWith('.md'))
+
+    const fileContents = await Promise.all(
+      changesetFiles.map(async file => ({
+        path: join(CHANGESET_DIR, file),
+        content: await readFile(join(CHANGESET_DIR, file), 'utf8'),
+      })),
+    )
+
+    return fileContents
+  } catch (error) {
+    consola.error('Failed to read changeset files:', error)
+    throw error
+  }
+}
+
+function cleanChangesetContent(content: string, privatePackages: string[]): string {
+  const lines = content.split('\n')
+  const newLines = lines.filter(line => {
+    // Skip lines that contain any of the private packages
+    return !privatePackages.some(pkg => line.includes(pkg))
+  })
+
+  return newLines.join('\n')
+}
+
+async function writeChangesetFile(
+  file: ChangesetFile,
+  cleanedContent: string,
+  dryRun: boolean,
+): Promise<void> {
+  try {
+    if (dryRun) {
+      consola.info(`[DRY RUN] Would write to ${file.path}`)
+      return
+    }
+
+    await writeFile(file.path, cleanedContent, 'utf8')
+    consola.success(`Cleaned ${file.path}`)
+  } catch (error) {
+    consola.error(`Failed to write changes to ${file.path}:`, error)
+    throw error
+  }
+}
+
+async function main(): Promise<void> {
+  try {
+    // Get private packages from environment variable, fallback to default
+    const privatePackagesEnv = process.env['PRIVATE_PACKAGES']
+    const privatePackages = privatePackagesEnv ? privatePackagesEnv.split(',') : ['@api/test-utils']
+
+    // Check if dry-run mode is enabled
+    const dryRun = process.env['DRY_RUN'] === 'true'
+    if (dryRun) {
+      consola.info('Running in dry-run mode (no changes will be made)')
+    }
+
+    consola.info('Cleaning changesets for private packages:', privatePackages)
+
+    const changesetFiles = await getChangesetFiles()
+
+    for (const file of changesetFiles) {
+      const cleanedContent = cleanChangesetContent(file.content, privatePackages)
+
+      // Only write if content was actually changed
+      if (cleanedContent === file.content) {
+        consola.info(`No changes needed for ${file.path}`)
+      } else {
+        await writeChangesetFile(file, cleanedContent, dryRun)
+      }
+    }
+
+    consola.success('Changeset cleaning completed successfully')
+  } catch (error) {
+    consola.error('Failed to clean changesets:', error)
+    process.exit(1)
+  }
+}
+
+await main()

--- a/scripts/test/clean-changesets.test.ts
+++ b/scripts/test/clean-changesets.test.ts
@@ -1,0 +1,110 @@
+import process from 'node:process'
+import fs from 'fs-extra'
+import {tsImport} from 'tsx/esm/api'
+import {afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi} from 'vitest'
+
+// Mock consola to prevent console output during tests
+vi.mock('consola', () => ({
+  consola: {
+    info: vi.fn(),
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}))
+
+const cleanup = async () => fs.rm('.changeset', {force: true, recursive: true})
+
+beforeAll(async () => {
+  await cleanup()
+})
+
+afterAll(async () => {
+  await cleanup()
+})
+
+// Helper function to run the script with tsx
+async function runCleanChangesetsScript(options: {
+  privatePackages?: string
+  dryRun?: boolean
+  expectError?: boolean
+}) {
+  const {privatePackages = '@api/test-utils', dryRun = false} = options
+  const originalEnv = {...process.env}
+
+  process.env['PRIVATE_PACKAGES'] = privatePackages
+  if (dryRun) {
+    process.env['DRY_RUN'] = 'true'
+  }
+
+  try {
+    // Use tsImport to load the script directly
+    await tsImport('../src/clean-changesets', import.meta.url)
+  } finally {
+    process.env = originalEnv
+  }
+}
+
+describe('clean-changesets', () => {
+  const mockChangesetContent = `---
+'@api/test-utils': patch
+'@bfra.me/api-core': patch
+---
+
+Updated dependency \`@readme/oas-to-har\` to \`25.0.4\`.
+Updated dependency \`oas\` to \`26.0.4\`.
+`
+
+  beforeEach(async () => {
+    await cleanup()
+    await fs.ensureDir('.changeset')
+    await fs.writeFile('.changeset/test.md', mockChangesetContent)
+  })
+
+  afterEach(async () => {
+    await cleanup()
+  })
+
+  it('should remove private package entries from changeset files', async () => {
+    await runCleanChangesetsScript({privatePackages: '@api/test-utils'})
+
+    const result = await fs.readFile('.changeset/test.md', 'utf8')
+    expect(result).toContain('@bfra.me/api-core')
+    expect(result).not.toContain('@api/test-utils')
+  })
+
+  it('should handle multiple private packages', async () => {
+    await runCleanChangesetsScript({privatePackages: '@api/test-utils,@api/other-private'})
+
+    const result = await fs.readFile('.changeset/test.md', 'utf8')
+    expect(result).toContain('@bfra.me/api-core')
+    expect(result).not.toContain('@api/test-utils')
+    expect(result).not.toContain('@api/other-private')
+  })
+
+  it('should handle file system errors gracefully', async () => {
+    await cleanup()
+    await expect(runCleanChangesetsScript({expectError: true})).rejects.toThrow()
+  })
+
+  it('should not modify files if no private packages are found', async () => {
+    const contentWithoutPrivate = `---
+'@bfra.me/api-core': patch
+---
+
+Updated dependency \`@readme/oas-to-har\` to \`25.0.4\`.
+`
+    await fs.writeFile('.changeset/test.md', contentWithoutPrivate)
+
+    await runCleanChangesetsScript({privatePackages: '@api/test-utils'})
+
+    const result = await fs.readFile('.changeset/test.md', 'utf8')
+    expect(result).toBe(contentWithoutPrivate)
+  })
+
+  it('should not write changes in dry-run mode', async () => {
+    await runCleanChangesetsScript({dryRun: true})
+
+    const result = await fs.readFile('.changeset/test.md', 'utf8')
+    expect(result).toBe(mockChangesetContent)
+  })
+})

--- a/scripts/tsconfig.eslint.json
+++ b/scripts/tsconfig.eslint.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "http://json.schemastore.org/tsconfig",
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["./test/**/*.ts"]
+}

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "http://json.schemastore.org/tsconfig",
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src"
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
- Introduced a new script to clean private package entries from changeset files, enhancing versioning accuracy for private packages.
- Updated ESLint configuration to include new script TypeScript configurations.
- Added new package.json and tsconfig files for the scripts directory, along with a README for usage instructions.
- Updated .gitignore to include coverage directory and modified pnpm workspace to include scripts.

This change improves the management of changesets in the monorepo, ensuring that private packages are excluded from versioning where necessary.

## Description

<!-- Provide a clear and concise description of your changes -->

## Type of Change

<!-- Please delete options that are not relevant -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Dependency update
- [ ] Repository configuration

## Changes Made

<!-- List the changes you've made -->

-

## Testing

<!-- Describe the tests you've done -->

- [ ] I have tested these changes locally
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a changeset describing the changes (if applicable)

## Additional Context

<!-- Add any other context about the pull request here -->
