### PR TITLE
fix(eslint-config): disable type-aware linting for markdown code blocks

### DIFF
--- a/.changeset/markdown-eslint-fix.md
+++ b/.changeset/markdown-eslint-fix.md
@@ -1,0 +1,5 @@
+---
+"@bfra.me/eslint-config": patch
+---
+
+Fix markdown configuration to properly disable type-aware linting for code blocks within markdown files.


### PR DESCRIPTION
Creates a changeset to update the ESLint configuration for markdown files,
ensuring that type-checking is properly disabled for code blocks within
markdown documents.

## Description

<!-- Provide a clear and concise description of your changes -->

## Type of Change

<!-- Please delete options that are not relevant -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Dependency update
- [ ] Repository configuration

## Changes Made

<!-- List the changes you've made -->

-

## Testing

<!-- Describe the tests you've done -->

- [ ] I have tested these changes locally
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a changeset describing the changes (if applicable)

## Additional Context

<!-- Add any other context about the pull request here -->
