### PR TITLE
fix(eslint): allow separate type imports for duplicate imports rule

### DIFF
--- a/.changeset/early-snakes-taste.md
+++ b/.changeset/early-snakes-taste.md
@@ -1,0 +1,6 @@
+---
+"@bfra.me/eslint-config": patch
+---
+
+Updated the 'no-duplicate-imports' rule to allow separate type imports.
+  

--- a/packages/eslint-config/src/configs/javascript.ts
+++ b/packages/eslint-config/src/configs/javascript.ts
@@ -85,7 +85,7 @@ export async function javascript(options: JavaScriptOptions = {}): Promise<Confi
             'no-dupe-class-members': 'error',
             'no-dupe-keys': 'error',
             'no-duplicate-case': 'error',
-            'no-duplicate-imports': 'error',
+            'no-duplicate-imports': ['error', {allowSeparateTypeImports: true}],
             'no-empty': ['error', {allowEmptyCatch: true}],
             'no-empty-character-class': 'error',
             'no-empty-pattern': 'error',


### PR DESCRIPTION
- Updated the 'no-duplicate-imports' rule to allow separate type imports.

## Description

<!-- Provide a clear and concise description of your changes -->

## Type of Change

<!-- Please delete options that are not relevant -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Dependency update
- [ ] Repository configuration

## Changes Made

<!-- List the changes you've made -->

-

## Testing

<!-- Describe the tests you've done -->

- [ ] I have tested these changes locally
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a changeset describing the changes (if applicable)

## Additional Context

<!-- Add any other context about the pull request here -->
