### PR TITLE
ci(release): simplify trigger-org-renovate job 

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -131,21 +131,6 @@ jobs:
   trigger-org-renovate:
     name: Trigger Renovate
     if: github.repository == 'bfra-me/works' && needs.manage-release.outputs.published == 'true'
-    runs-on: ubuntu-latest
     needs: manage-release
-    steps:
-      - id: get-workflow-access-token
-        name: Get Workflow Access Token
-        uses: actions/create-github-app-token@a8d616148505b5069dccd32f177bb87d7f39123b # v2.1.1
-        with:
-          app-id: ${{ secrets.APPLICATION_ID }}
-          private-key: ${{ secrets.APPLICATION_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
-
-      - name: Dispatch Renovate workflow in the .github repository
-        env:
-          GH_TOKEN: ${{ steps.get-workflow-access-token.outputs.token }}
-          ORG: ${{ github.repository_owner }}
-        run: |
-          echo "Triggering workflow_dispatch for $ORG/.github"
-          gh workflow run renovate.yaml --repo $ORG/.github
+    secrets: inherit
+    uses: bfra-me/.github/.github/workflows/trigger-org-renovate.yaml@5b99871fcafe4ba4c574449365db1afabb7509d7 # v4.1.0


### PR DESCRIPTION
- Removed unnecessary steps for obtaining workflow access token.
- Inherited secrets for the trigger-org-renovate job.
- Updated to use the external trigger-org-renovate workflow.