### PR TITLE
feat(semantic-release): add TypeScript interfaces and schemas

### DIFF
--- a/.ai/plan/refactor-semantic-release-1.md
+++ b/.ai/plan/refactor-semantic-release-1.md
@@ -2,15 +2,15 @@
 goal: Rewrite @bfra.me/semantic-release with comprehensive TypeScript support and plugin development toolkit
 version: 1.0
 date_created: 2025-08-30
-last_updated: 2025-08-30
+last_updated: 2025-08-31
 owner: Marcus R. Brown
-status: Planned
+status: In Progress
 tags: [refactor, typescript, semantic-release, plugin-development, configuration]
 ---
 
 # Refactor @bfra.me/semantic-release Package
 
-![Status: Planned](https://img.shields.io/badge/status-Planned-blue)
+![Status: In Progress](https://img.shields.io/badge/status-In%20Progress-yellow)
 
 Complete rewrite of the `@bfra.me/semantic-release` package to provide comprehensive TypeScript support for the semantic-release ecosystem, including fully typed configuration objects, factory functions for JavaScript config files, plugin development toolkit, shareable presets, and configuration composition utilities with comprehensive testing and documentation.
 
@@ -39,20 +39,20 @@ Complete rewrite of the `@bfra.me/semantic-release` package to provide comprehen
 
 ### Implementation Phase 1: Core Type System & Configuration
 
-- GOAL-001: Establish comprehensive TypeScript type system for semantic-release ecosystem
+- GOAL-001: Establish comprehensive TypeScript type system for semantic-release ecosystem ✅ **COMPLETED**
 
 | Task | Description | Completed | Date |
 |------|-------------|-----------|------|
-| TASK-001 | Research and document all semantic-release core configuration options and types | | |
-| TASK-002 | Create comprehensive TypeScript interfaces for semantic-release global configuration | | |
-| TASK-003 | Implement typed interfaces for @semantic-release/commit-analyzer plugin configuration | | |
-| TASK-004 | Implement typed interfaces for @semantic-release/release-notes-generator plugin configuration | | |
-| TASK-005 | Implement typed interfaces for @semantic-release/changelog plugin configuration | | |
-| TASK-006 | Implement typed interfaces for @semantic-release/npm plugin configuration | | |
-| TASK-007 | Implement typed interfaces for @semantic-release/github plugin configuration | | |
-| TASK-008 | Implement typed interfaces for @semantic-release/git plugin configuration | | |
-| TASK-009 | Create extensible plugin registry system for third-party plugin type declarations | | |
-| TASK-010 | Implement runtime validation schemas using Zod or similar for all configuration types | | |
+| TASK-001 | Research and document all semantic-release core configuration options and types | ✅ | 2025-08-31 |
+| TASK-002 | Create comprehensive TypeScript interfaces for semantic-release global configuration | ✅ | 2025-08-31 |
+| TASK-003 | Implement typed interfaces for @semantic-release/commit-analyzer plugin configuration | ✅ | 2025-08-31 |
+| TASK-004 | Implement typed interfaces for @semantic-release/release-notes-generator plugin configuration | ✅ | 2025-08-31 |
+| TASK-005 | Implement typed interfaces for @semantic-release/changelog plugin configuration | ✅ | 2025-08-31 |
+| TASK-006 | Implement typed interfaces for @semantic-release/npm plugin configuration | ✅ | 2025-08-31 |
+| TASK-007 | Implement typed interfaces for @semantic-release/github plugin configuration | ✅ | 2025-08-31 |
+| TASK-008 | Implement typed interfaces for @semantic-release/git plugin configuration | ✅ | 2025-08-31 |
+| TASK-009 | Create extensible plugin registry system for third-party plugin type declarations | ✅ | 2025-08-31 |
+| TASK-010 | Implement runtime validation schemas using Zod or similar for all configuration types | ✅ | 2025-08-31 |
 
 ### Implementation Phase 2: Factory Functions & Configuration API
 

--- a/packages/semantic-release/package.json
+++ b/packages/semantic-release/package.json
@@ -44,7 +44,9 @@
     "@bfra.me/semantic-release": "workspace:*",
     "@bfra.me/tsconfig": "workspace:*",
     "semantic-release": "24.2.7",
-    "tsup": "8.5.0"
+    "tsup": "8.5.0",
+    "type-fest": "4.41.0",
+    "zod": "4.0.17"
   },
   "peerDependencies": {
     "semantic-release": ">=23"

--- a/packages/semantic-release/src/index.ts
+++ b/packages/semantic-release/src/index.ts
@@ -1,2 +1,3 @@
 export * from './config.js'
 export type * from './types.js'
+export * from './validation/index.js'

--- a/packages/semantic-release/src/types/core.ts
+++ b/packages/semantic-release/src/types/core.ts
@@ -1,0 +1,264 @@
+/**
+ * Core TypeScript types for semantic-release global configuration.
+ *
+ * This module provides comprehensive type definitions for semantic-release v23+
+ * configuration options, ensuring type safety and preventing runtime errors.
+ *
+ * @see https://semantic-release.gitbook.io/semantic-release/usage/configuration
+ */
+
+import type {LiteralUnion} from 'type-fest'
+
+/**
+ * Branch specification for semantic-release branches configuration.
+ */
+export interface BranchSpec {
+  /**
+   * The name of the branch.
+   */
+  name: string
+
+  /**
+   * The range of versions to be released from this branch.
+   * Used for maintenance releases.
+   */
+  range?: string
+
+  /**
+   * The npm distribution channel to publish releases from this branch.
+   */
+  channel?: string | false
+
+  /**
+   * Whether this branch should publish prereleases.
+   */
+  prerelease?: boolean | string
+}
+
+/**
+ * Branch configuration - can be a string, object, or array of either.
+ */
+export type BranchConfig = string | BranchSpec | readonly (string | BranchSpec)[]
+
+/**
+ * Plugin specification type that can be either:
+ * - A string (plugin name)
+ * - A tuple of [plugin name, plugin options]
+ */
+export type PluginSpec<TOptions = Record<string, unknown>> = string | readonly [string, TOptions]
+
+/**
+ * Environment variable configuration for semantic-release.
+ */
+export interface EnvironmentConfig {
+  /**
+   * The Git repository URL.
+   */
+  SEMANTIC_RELEASE_REPOSITORY_URL?: string
+
+  /**
+   * GitHub authentication token.
+   */
+  GITHUB_TOKEN?: string
+
+  /**
+   * GitLab authentication token.
+   */
+  GITLAB_TOKEN?: string
+
+  /**
+   * npm authentication token.
+   */
+  NPM_TOKEN?: string
+
+  /**
+   * Additional environment variables that plugins might use.
+   */
+  [key: string]: string | undefined
+}
+
+/**
+ * Core semantic-release global configuration interface.
+ *
+ * This interface defines all the configuration options that can be used
+ * to configure semantic-release behavior.
+ */
+export interface GlobalConfig {
+  /**
+   * List of modules or file paths containing shareable configurations.
+   * If multiple shareable configurations are set, they will be imported
+   * in the order defined with each configuration option taking precedence.
+   */
+  extends?: string | readonly string[]
+
+  /**
+   * The branches on which releases should happen.
+   *
+   * @default ['+([0-9])?(.{+([0-9]),x}).x', 'master', 'main', 'next', 'next-major', {name: 'beta', prerelease: true}, {name: 'alpha', prerelease: true}]
+   */
+  branches?: BranchConfig
+
+  /**
+   * The Git repository URL.
+   * Can be set via SEMANTIC_RELEASE_REPOSITORY_URL environment variable.
+   */
+  repositoryUrl?: string
+
+  /**
+   * The Git tag format used to identify releases.
+   *
+   * @default 'v${version}'
+   */
+  tagFormat?: string
+
+  /**
+   * List of plugins to use during the release process.
+   * If not specified, uses the default plugin list.
+   *
+   * @default ['@semantic-release/commit-analyzer', '@semantic-release/release-notes-generator', '@semantic-release/npm', '@semantic-release/github']
+   */
+  plugins?: readonly PluginSpec[]
+
+  /**
+   * Dry-run mode. Skip publishing, print next version and release notes.
+   *
+   * @default false
+   */
+  dryRun?: boolean
+
+  /**
+   * Set to false to skip Continuous Integration environment verifications.
+   * This allows for making releases from a local machine.
+   *
+   * @default true
+   */
+  ci?: boolean
+
+  /**
+   * Set to true when the ci option is set to false.
+   * Internal property used by semantic-release.
+   */
+  noCi?: boolean
+
+  /**
+   * Global plugin configuration options.
+   * These options will be passed to all plugins.
+   */
+  preset?: LiteralUnion<
+    | 'angular'
+    | 'atom'
+    | 'codemirror'
+    | 'ember'
+    | 'eslint'
+    | 'express'
+    | 'jquery'
+    | 'jshint'
+    | 'conventionalcommits',
+    string
+  >
+
+  /**
+   * Additional configuration options that might be used by plugins.
+   * This allows for forward compatibility with new options.
+   */
+  [key: string]: unknown
+}
+
+/**
+ * Branded type for validated semantic-release configuration.
+ * This ensures that configurations have been validated at runtime.
+ */
+export interface ValidatedConfig extends GlobalConfig {
+  readonly __validated: true
+}
+
+/**
+ * Type guard to check if a configuration has been validated.
+ */
+export function isValidatedConfig(config: GlobalConfig): config is ValidatedConfig {
+  return '__validated' in config && config.__validated === true
+}
+
+/**
+ * Context objects that are passed to plugins during different lifecycle phases.
+ */
+export interface BaseContext {
+  /**
+   * The semantic-release configuration.
+   */
+  options: GlobalConfig
+
+  /**
+   * Environment variables.
+   */
+  env: EnvironmentConfig
+
+  /**
+   * The current working directory.
+   */
+  cwd: string
+
+  /**
+   * Logger instance for outputting messages.
+   */
+  logger: {
+    log: (message: string, ...args: unknown[]) => void
+    error: (message: string, ...args: unknown[]) => void
+    success: (message: string, ...args: unknown[]) => void
+  }
+}
+
+/**
+ * Release information object.
+ */
+export interface Release {
+  /**
+   * The release version.
+   */
+  version: string
+
+  /**
+   * The Git tag for this release.
+   */
+  gitTag: string
+
+  /**
+   * The Git commit hash for this release.
+   */
+  gitHead: string
+
+  /**
+   * The release notes for this release.
+   */
+  notes: string
+
+  /**
+   * The release channel (npm dist-tag).
+   */
+  channel?: string
+
+  /**
+   * The release name.
+   */
+  name?: string
+}
+
+/**
+ * Last release information.
+ */
+export interface LastRelease extends Release {
+  /**
+   * The channels on which the release was published.
+   */
+  channels: string[]
+}
+
+/**
+ * Next release information.
+ */
+export interface NextRelease extends Release {
+  /**
+   * The type of release (major, minor, patch).
+   */
+  type: 'major' | 'minor' | 'patch'
+}

--- a/packages/semantic-release/src/types/index.ts
+++ b/packages/semantic-release/src/types/index.ts
@@ -1,0 +1,31 @@
+/**
+ * TypeScript types for semantic-release configuration and ecosystem.
+ *
+ * This module provides comprehensive type definitions for:
+ * - Core semantic-release configuration options
+ * - Plugin-specific configuration interfaces
+ * - Extensible plugin registry system
+ * - Runtime validation schemas with Zod
+ */
+
+// Core types
+export type * from './core.js'
+
+// Plugin registry system (must come before plugin-specific types to avoid conflicts)
+export type {
+  CustomPluginRegistry,
+  ExtractPluginConfig,
+  ExtractPluginName,
+  KnownPluginRegistry,
+  PluginDefinition,
+  PluginLifecycleHooks,
+  ValidPlugin,
+} from './plugin-registry.js'
+
+// Plugin-specific types
+export type * from './plugins/changelog.js'
+export type * from './plugins/commit-analyzer.js'
+export type * from './plugins/git.js'
+export type * from './plugins/github.js'
+export type * from './plugins/npm.js'
+export type * from './plugins/release-notes-generator.js'

--- a/packages/semantic-release/src/types/plugin-registry.ts
+++ b/packages/semantic-release/src/types/plugin-registry.ts
@@ -1,0 +1,243 @@
+/**
+ * Extensible plugin registry system for third-party plugin type declarations.
+ *
+ * This module provides a system for registering custom plugin types that can be used
+ * throughout the semantic-release configuration with full TypeScript support.
+ */
+
+import type {LiteralUnion} from 'type-fest'
+import type {BaseContext} from './core.js'
+import type {ChangelogConfig} from './plugins/changelog.js'
+import type {
+  AnalyzeCommitsContext,
+  AnalyzeCommitsResult,
+  CommitAnalyzerConfig,
+} from './plugins/commit-analyzer.js'
+import type {GitConfig} from './plugins/git.js'
+import type {GithubConfig} from './plugins/github.js'
+import type {NpmConfig} from './plugins/npm.js'
+import type {
+  GenerateNotesContext,
+  GenerateNotesResult,
+  ReleaseNotesGeneratorConfig,
+} from './plugins/release-notes-generator.js'
+
+/**
+ * Plugin lifecycle hooks with their expected function signatures.
+ */
+export interface PluginLifecycleHooks {
+  /**
+   * Verify conditions step - validates plugin configuration and environment.
+   */
+  verifyConditions?: (
+    pluginConfig: Record<string, unknown>,
+    context: BaseContext,
+  ) => Promise<void> | void
+
+  /**
+   * Analyze commits step - determines the type of release based on commits.
+   */
+  analyzeCommits?: (
+    pluginConfig: Record<string, unknown>,
+    context: AnalyzeCommitsContext,
+  ) => Promise<AnalyzeCommitsResult> | AnalyzeCommitsResult
+
+  /**
+   * Verify release step - validates the release before proceeding.
+   */
+  verifyRelease?: (
+    pluginConfig: Record<string, unknown>,
+    context: BaseContext,
+  ) => Promise<void> | void
+
+  /**
+   * Generate notes step - creates release notes.
+   */
+  generateNotes?: (
+    pluginConfig: Record<string, unknown>,
+    context: GenerateNotesContext,
+  ) => Promise<GenerateNotesResult> | GenerateNotesResult
+
+  /**
+   * Prepare step - prepares the release (e.g., update files, create changelog).
+   */
+  prepare?: (pluginConfig: Record<string, unknown>, context: BaseContext) => Promise<void> | void
+
+  /**
+   * Publish step - publishes the release.
+   */
+  publish?: (
+    pluginConfig: Record<string, unknown>,
+    context: BaseContext,
+  ) => Promise<{name: string; url: string} | void> | {name: string; url: string} | void
+
+  /**
+   * Success step - called after a successful release.
+   */
+  success?: (pluginConfig: Record<string, unknown>, context: BaseContext) => Promise<void> | void
+
+  /**
+   * Fail step - called when the release process fails.
+   */
+  fail?: (pluginConfig: Record<string, unknown>, context: BaseContext) => Promise<void> | void
+}
+
+/**
+ * Registry of known semantic-release plugins with their configuration types.
+ */
+export interface KnownPluginRegistry {
+  /**
+   * @semantic-release/commit-analyzer - Analyzes commits to determine release type.
+   */
+  '@semantic-release/commit-analyzer': CommitAnalyzerConfig
+
+  /**
+   * @semantic-release/release-notes-generator - Generates release notes.
+   */
+  '@semantic-release/release-notes-generator': ReleaseNotesGeneratorConfig
+
+  /**
+   * @semantic-release/changelog - Creates or updates changelog file.
+   */
+  '@semantic-release/changelog': ChangelogConfig
+
+  /**
+   * @semantic-release/npm - Publishes to npm registry.
+   */
+  '@semantic-release/npm': NpmConfig
+
+  /**
+   * @semantic-release/github - Creates GitHub releases.
+   */
+  '@semantic-release/github': GithubConfig
+
+  /**
+   * @semantic-release/git - Commits files to Git repository.
+   */
+  '@semantic-release/git': GitConfig
+}
+
+/**
+ * Custom plugin configuration registry.
+ *
+ * Third-party packages can extend this interface to add their own plugin types:
+ *
+ * @example
+ * ```typescript
+ * declare module '@bfra.me/semantic-release' {
+ *   interface CustomPluginRegistry {
+ *     'semantic-release-license': {
+ *       license: {
+ *         path?: string
+ *       }
+ *     }
+ *   }
+ * }
+ * ```
+ */
+export interface CustomPluginRegistry {}
+
+/**
+ * Combined plugin registry including both known and custom plugins.
+ */
+export interface PluginRegistry extends KnownPluginRegistry, CustomPluginRegistry {}
+
+/**
+ * Type for plugin names that can be used in configuration.
+ */
+export type PluginName = LiteralUnion<keyof PluginRegistry, string>
+
+/**
+ * Type for getting plugin configuration type by plugin name.
+ */
+export type PluginConfigFor<TPlugin extends PluginName> = TPlugin extends keyof PluginRegistry
+  ? PluginRegistry[TPlugin]
+  : Record<string, unknown>
+
+/**
+ * Plugin specification that can be either a plugin name or a tuple of [name, config].
+ */
+export type PluginSpec<TPlugin extends PluginName = PluginName> =
+  | TPlugin
+  | readonly [TPlugin, PluginConfigFor<TPlugin>]
+
+/**
+ * Utility type to extract plugin name from a plugin specification.
+ */
+export type ExtractPluginName<TSpec extends PluginSpec> = TSpec extends readonly [
+  infer TName,
+  unknown,
+]
+  ? TName
+  : TSpec
+
+/**
+ * Utility type to extract plugin configuration from a plugin specification.
+ */
+export type ExtractPluginConfig<TSpec extends PluginSpec> = TSpec extends readonly [
+  infer _TName extends PluginName,
+  infer TConfig,
+]
+  ? TConfig
+  : TSpec extends PluginName
+    ? PluginConfigFor<TSpec>
+    : never
+
+/**
+ * Type guard to check if a plugin specification includes configuration.
+ */
+export function hasPluginConfig<TSpec extends PluginSpec>(
+  spec: TSpec,
+): spec is TSpec & readonly [PluginName, Record<string, unknown>] {
+  return Array.isArray(spec) && spec.length === 2
+}
+
+/**
+ * Utility function to get plugin name from a specification.
+ */
+export function getPluginName<TSpec extends PluginSpec>(spec: TSpec): ExtractPluginName<TSpec> {
+  return (Array.isArray(spec) ? spec[0] : spec) as ExtractPluginName<TSpec>
+}
+
+/**
+ * Utility function to get plugin configuration from a specification.
+ */
+export function getPluginConfig<TSpec extends PluginSpec>(spec: TSpec): ExtractPluginConfig<TSpec> {
+  return (Array.isArray(spec) ? spec[1] : {}) as ExtractPluginConfig<TSpec>
+}
+
+/**
+ * Plugin definition interface for creating custom plugins.
+ */
+export interface PluginDefinition extends Partial<PluginLifecycleHooks> {
+  /**
+   * Plugin configuration schema (optional, for validation).
+   */
+  configSchema?: unknown
+
+  /**
+   * Plugin metadata.
+   */
+  metadata?: {
+    name: string
+    version: string
+    description?: string
+    author?: string
+    homepage?: string
+  }
+}
+
+/**
+ * Type for validating plugin implementations.
+ */
+export type ValidPlugin = PluginDefinition &
+  (
+    | {verifyConditions: NonNullable<PluginLifecycleHooks['verifyConditions']>}
+    | {analyzeCommits: NonNullable<PluginLifecycleHooks['analyzeCommits']>}
+    | {verifyRelease: NonNullable<PluginLifecycleHooks['verifyRelease']>}
+    | {generateNotes: NonNullable<PluginLifecycleHooks['generateNotes']>}
+    | {prepare: NonNullable<PluginLifecycleHooks['prepare']>}
+    | {publish: NonNullable<PluginLifecycleHooks['publish']>}
+    | {success: NonNullable<PluginLifecycleHooks['success']>}
+    | {fail: NonNullable<PluginLifecycleHooks['fail']>}
+  )

--- a/packages/semantic-release/src/types/plugins/changelog.ts
+++ b/packages/semantic-release/src/types/plugins/changelog.ts
@@ -1,0 +1,99 @@
+/**
+ * TypeScript interface for @semantic-release/changelog plugin configuration.
+ *
+ * This plugin creates or updates a changelog file.
+ *
+ * @see https://github.com/semantic-release/changelog
+ */
+
+/**
+ * Configuration for @semantic-release/changelog plugin.
+ */
+export interface ChangelogConfig {
+  /**
+   * File path to create or update the changelog.
+   *
+   * @default 'CHANGELOG.md'
+   */
+  changelogFile?: string
+
+  /**
+   * Title for the changelog file.
+   *
+   * @default '# Changelog'
+   */
+  changelogTitle?: string
+
+  /**
+   * Additional options that might be used by future versions.
+   */
+  [key: string]: unknown
+}
+
+/**
+ * Context passed to changelog plugins during the prepare step.
+ */
+export interface ChangelogContext {
+  /**
+   * The semantic-release configuration options.
+   */
+  options: Record<string, unknown>
+
+  /**
+   * Information about the next release.
+   */
+  nextRelease: {
+    version: string
+    gitTag: string
+    type: 'major' | 'minor' | 'patch'
+    notes: string
+  }
+
+  /**
+   * Information about the last release.
+   */
+  lastRelease: {
+    version: string
+    gitTag: string
+    gitHead: string
+  }
+
+  /**
+   * Array of commit objects since the last release.
+   */
+  commits: {
+    hash: string
+    message: string
+    author: {
+      name: string
+      email: string
+    }
+    committerDate: string
+    [key: string]: unknown
+  }[]
+
+  /**
+   * Environment variables.
+   */
+  env: Record<string, string | undefined>
+
+  /**
+   * Current working directory.
+   */
+  cwd: string
+
+  /**
+   * Logger instance.
+   */
+  logger: {
+    log: (message: string, ...args: unknown[]) => void
+    error: (message: string, ...args: unknown[]) => void
+    success: (message: string, ...args: unknown[]) => void
+  }
+}
+
+/**
+ * Result returned by the changelog prepare step.
+ * Usually undefined as the plugin modifies files directly.
+ */
+export type ChangelogResult = void

--- a/packages/semantic-release/src/types/plugins/commit-analyzer.ts
+++ b/packages/semantic-release/src/types/plugins/commit-analyzer.ts
@@ -1,0 +1,233 @@
+/**
+ * TypeScript interface for @semantic-release/commit-analyzer plugin configuration.
+ *
+ * This plugin determines the type of release based on commit messages.
+ *
+ * @see https://github.com/semantic-release/commit-analyzer
+ */
+
+import type {LiteralUnion} from 'type-fest'
+
+/**
+ * Rule for determining release type based on commit properties.
+ */
+export interface ReleaseRule {
+  /**
+   * The commit type (e.g., 'feat', 'fix', 'docs').
+   */
+  type?: string
+
+  /**
+   * The commit scope.
+   */
+  scope?: string
+
+  /**
+   * The subject of the commit.
+   */
+  subject?: string
+
+  /**
+   * The release type to trigger (major, minor, patch, or false for no release).
+   */
+  release: 'major' | 'minor' | 'patch' | false
+
+  /**
+   * Additional properties for matching commits.
+   */
+  [key: string]: unknown
+}
+
+/**
+ * Parser options for conventional-commits-parser.
+ */
+export interface ParserOptions {
+  /**
+   * Keywords to identify breaking changes.
+   *
+   * @default ['BREAKING CHANGE', 'BREAKING CHANGES']
+   */
+  noteKeywords?: string[]
+
+  /**
+   * Pattern for parsing commit header.
+   */
+  headerPattern?: RegExp
+
+  /**
+   * Correspondence between commit header and parsed values.
+   */
+  headerCorrespondence?: string[]
+
+  /**
+   * Pattern for parsing references in commit message.
+   */
+  referenceActions?: string[]
+
+  /**
+   * Whether to include the merge commits.
+   */
+  mergePattern?: RegExp
+
+  /**
+   * Correspondence for merge commits.
+   */
+  mergeCorrespondence?: string[]
+
+  /**
+   * Pattern for parsing revert commits.
+   */
+  revertPattern?: RegExp
+
+  /**
+   * Correspondence for revert commits.
+   */
+  revertCorrespondence?: string[]
+
+  /**
+   * Field names to include in parsed commit.
+   */
+  fieldPattern?: RegExp
+
+  /**
+   * Whether to warn about malformed commits.
+   */
+  warn?: boolean
+
+  /**
+   * Additional parser options.
+   */
+  [key: string]: unknown
+}
+
+/**
+ * Configuration for @semantic-release/commit-analyzer plugin.
+ */
+export interface CommitAnalyzerConfig {
+  /**
+   * Conventional-changelog preset name.
+   *
+   * @default 'angular'
+   */
+  preset?: LiteralUnion<
+    | 'angular'
+    | 'atom'
+    | 'codemirror'
+    | 'ember'
+    | 'eslint'
+    | 'express'
+    | 'jquery'
+    | 'jshint'
+    | 'conventionalcommits',
+    string
+  >
+
+  /**
+   * npm package name of a custom conventional-changelog preset.
+   * Cannot be used together with 'preset'.
+   */
+  config?: string
+
+  /**
+   * Additional conventional-commits-parser options.
+   * Extends the ones loaded by preset or config.
+   */
+  parserOpts?: ParserOptions
+
+  /**
+   * External module, path to a module, or array of rules for determining release type.
+   *
+   * Rules are checked in order, and the first matching rule determines the release type.
+   */
+  releaseRules?: string | ReleaseRule[]
+
+  /**
+   * Additional configuration passed to the conventional-changelog preset.
+   * Used for example with conventional-changelog-conventionalcommits.
+   */
+  presetConfig?: Record<string, unknown>
+
+  /**
+   * Additional options that might be used by future versions or custom presets.
+   */
+  [key: string]: unknown
+}
+
+/**
+ * Context passed to commit analyzer plugins.
+ */
+export interface AnalyzeCommitsContext {
+  /**
+   * The semantic-release configuration options.
+   */
+  options: {
+    preset?: string
+    [key: string]: unknown
+  }
+
+  /**
+   * Array of commit objects since the last release.
+   */
+  commits: {
+    /**
+     * The commit hash.
+     */
+    hash: string
+
+    /**
+     * The commit message.
+     */
+    message: string
+
+    /**
+     * The commit author.
+     */
+    author: {
+      name: string
+      email: string
+    }
+
+    /**
+     * The commit date.
+     */
+    committerDate: string
+
+    /**
+     * Additional commit properties.
+     */
+    [key: string]: unknown
+  }[]
+
+  /**
+   * Information about the last release.
+   */
+  lastRelease: {
+    version: string
+    gitTag: string
+    gitHead: string
+  }
+
+  /**
+   * Environment variables.
+   */
+  env: Record<string, string | undefined>
+
+  /**
+   * Current working directory.
+   */
+  cwd: string
+
+  /**
+   * Logger instance.
+   */
+  logger: {
+    log: (message: string, ...args: unknown[]) => void
+    error: (message: string, ...args: unknown[]) => void
+    success: (message: string, ...args: unknown[]) => void
+  }
+}
+
+/**
+ * Result returned by the analyzeCommits step.
+ */
+export type AnalyzeCommitsResult = 'major' | 'minor' | 'patch' | null

--- a/packages/semantic-release/src/types/plugins/git.ts
+++ b/packages/semantic-release/src/types/plugins/git.ts
@@ -1,0 +1,130 @@
+/**
+ * TypeScript interface for @semantic-release/git plugin configuration.
+ *
+ * This plugin commits files to the Git repository during the prepare step.
+ *
+ * @see https://github.com/semantic-release/git
+ */
+
+/**
+ * Configuration for @semantic-release/git plugin.
+ */
+export interface GitConfig {
+  /**
+   * Files to commit to the Git repository.
+   * Can include glob patterns.
+   *
+   * @default ['CHANGELOG.md', 'package.json', 'package-lock.json', 'npm-shrinkwrap.json']
+   */
+  assets?: string | string[]
+
+  /**
+   * Commit message template.
+   *
+   * @default 'chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}'
+   */
+  message?: string
+
+  /**
+   * Additional options that might be used by future versions.
+   */
+  [key: string]: unknown
+}
+
+/**
+ * Context passed to Git plugins during verify conditions.
+ */
+export interface GitVerifyConditionsContext {
+  /**
+   * The semantic-release configuration options.
+   */
+  options: Record<string, unknown>
+
+  /**
+   * Environment variables.
+   */
+  env: Record<string, string | undefined>
+
+  /**
+   * Current working directory.
+   */
+  cwd: string
+
+  /**
+   * Logger instance.
+   */
+  logger: {
+    log: (message: string, ...args: unknown[]) => void
+    error: (message: string, ...args: unknown[]) => void
+    success: (message: string, ...args: unknown[]) => void
+  }
+}
+
+/**
+ * Context passed to Git plugins during prepare step.
+ */
+export interface GitPrepareContext {
+  /**
+   * The semantic-release configuration options.
+   */
+  options: Record<string, unknown>
+
+  /**
+   * Information about the next release.
+   */
+  nextRelease: {
+    version: string
+    gitTag: string
+    type: 'major' | 'minor' | 'patch'
+    notes: string
+    channel?: string
+  }
+
+  /**
+   * Information about the last release.
+   */
+  lastRelease: {
+    version: string
+    gitTag: string
+    gitHead: string
+  }
+
+  /**
+   * Array of commit objects since the last release.
+   */
+  commits: {
+    hash: string
+    message: string
+    author: {
+      name: string
+      email: string
+    }
+    committerDate: string
+    [key: string]: unknown
+  }[]
+
+  /**
+   * Environment variables.
+   */
+  env: Record<string, string | undefined>
+
+  /**
+   * Current working directory.
+   */
+  cwd: string
+
+  /**
+   * Logger instance.
+   */
+  logger: {
+    log: (message: string, ...args: unknown[]) => void
+    error: (message: string, ...args: unknown[]) => void
+    success: (message: string, ...args: unknown[]) => void
+  }
+}
+
+/**
+ * Result returned by the Git prepare step.
+ * Usually undefined as the plugin modifies the Git repository directly.
+ */
+export type GitResult = void

--- a/packages/semantic-release/src/types/plugins/github.ts
+++ b/packages/semantic-release/src/types/plugins/github.ts
@@ -1,0 +1,275 @@
+/**
+ * TypeScript interface for @semantic-release/github plugin configuration.
+ *
+ * This plugin publishes GitHub releases and verifies GitHub authentication.
+ *
+ * @see https://github.com/semantic-release/github
+ */
+
+/**
+ * Asset configuration for GitHub releases.
+ */
+export interface GithubAsset {
+  /**
+   * Path to the asset file(s). Can include glob patterns.
+   */
+  path: string
+
+  /**
+   * Name of the asset in the GitHub release.
+   */
+  name?: string
+
+  /**
+   * Label for the asset in the GitHub release.
+   */
+  label?: string
+}
+
+/**
+ * Configuration for @semantic-release/github plugin.
+ */
+export interface GithubConfig {
+  /**
+   * GitHub API URL.
+   *
+   * @default 'https://api.github.com'
+   */
+  githubUrl?: string
+
+  /**
+   * GitHub API endpoint path prefix.
+   *
+   * @default '/api/v3'
+   */
+  githubApiPathPrefix?: string
+
+  /**
+   * Proxy URL for GitHub API requests.
+   */
+  proxy?: string
+
+  /**
+   * Assets to upload to the GitHub release.
+   * Can be a string (glob pattern), array of strings, or array of asset objects.
+   */
+  assets?: string | string[] | GithubAsset[]
+
+  /**
+   * Labels to add to pull requests and issues.
+   */
+  labels?: string[]
+
+  /**
+   * Template for the GitHub release name.
+   *
+   * @default '${nextRelease.gitTag}'
+   */
+  releasedLabels?: string[]
+
+  /**
+   * Comment on resolved issues and merged pull requests.
+   *
+   * @default true
+   */
+  addReleases?: 'bottom' | 'top' | false
+
+  /**
+   * Draft release instead of publishing immediately.
+   *
+   * @default false
+   */
+  draft?: boolean
+
+  /**
+   * Template for issue and pull request comments.
+   */
+  successComment?: string | false
+
+  /**
+   * Template for issue comments when a release fails.
+   */
+  failComment?: string | false
+
+  /**
+   * Template for the release title.
+   */
+  failTitle?: string
+
+  /**
+   * Template for issue labels when a release fails.
+   */
+  failLabels?: string[]
+
+  /**
+   * Template for discussion category when a release is published.
+   */
+  discussionCategoryName?: string
+
+  /**
+   * Additional options that might be used by future versions.
+   */
+  [key: string]: unknown
+}
+
+/**
+ * Context passed to GitHub plugins during verify conditions.
+ */
+export interface GithubVerifyConditionsContext {
+  /**
+   * The semantic-release configuration options.
+   */
+  options: {
+    repositoryUrl?: string
+    [key: string]: unknown
+  }
+
+  /**
+   * Environment variables.
+   */
+  env: {
+    GITHUB_TOKEN?: string
+    GH_TOKEN?: string
+    [key: string]: string | undefined
+  }
+
+  /**
+   * Current working directory.
+   */
+  cwd: string
+
+  /**
+   * Logger instance.
+   */
+  logger: {
+    log: (message: string, ...args: unknown[]) => void
+    error: (message: string, ...args: unknown[]) => void
+    success: (message: string, ...args: unknown[]) => void
+  }
+}
+
+/**
+ * Context passed to GitHub plugins during publish step.
+ */
+export interface GithubPublishContext {
+  /**
+   * The semantic-release configuration options.
+   */
+  options: Record<string, unknown>
+
+  /**
+   * Information about the next release.
+   */
+  nextRelease: {
+    version: string
+    gitTag: string
+    type: 'major' | 'minor' | 'patch'
+    notes: string
+    channel?: string
+  }
+
+  /**
+   * Information about the last release.
+   */
+  lastRelease: {
+    version: string
+    gitTag: string
+    gitHead: string
+  }
+
+  /**
+   * Array of releases published in previous steps.
+   */
+  releases: {
+    name: string
+    url: string
+    [key: string]: unknown
+  }[]
+
+  /**
+   * Environment variables.
+   */
+  env: Record<string, string | undefined>
+
+  /**
+   * Current working directory.
+   */
+  cwd: string
+
+  /**
+   * Logger instance.
+   */
+  logger: {
+    log: (message: string, ...args: unknown[]) => void
+    error: (message: string, ...args: unknown[]) => void
+    success: (message: string, ...args: unknown[]) => void
+  }
+}
+
+/**
+ * Context passed to GitHub plugins during success step.
+ */
+export interface GithubSuccessContext extends GithubPublishContext {
+  /**
+   * Array of releases published by the publish step.
+   */
+  releases: {
+    name: string
+    url: string
+    [key: string]: unknown
+  }[]
+}
+
+/**
+ * Context passed to GitHub plugins during fail step.
+ */
+export interface GithubFailContext {
+  /**
+   * The semantic-release configuration options.
+   */
+  options: Record<string, unknown>
+
+  /**
+   * The error that caused the failure.
+   */
+  errors: Error[]
+
+  /**
+   * Environment variables.
+   */
+  env: Record<string, string | undefined>
+
+  /**
+   * Current working directory.
+   */
+  cwd: string
+
+  /**
+   * Logger instance.
+   */
+  logger: {
+    log: (message: string, ...args: unknown[]) => void
+    error: (message: string, ...args: unknown[]) => void
+    success: (message: string, ...args: unknown[]) => void
+  }
+}
+
+/**
+ * Result returned by the GitHub publish step.
+ */
+export interface GithubPublishResult {
+  /**
+   * The name of the GitHub release.
+   */
+  name: string
+
+  /**
+   * The URL of the GitHub release.
+   */
+  url: string
+
+  /**
+   * The ID of the GitHub release.
+   */
+  id?: number
+}

--- a/packages/semantic-release/src/types/plugins/npm.ts
+++ b/packages/semantic-release/src/types/plugins/npm.ts
@@ -1,0 +1,160 @@
+/**
+ * TypeScript interface for @semantic-release/npm plugin configuration.
+ *
+ * This plugin publishes npm packages and verifies npm registry authentication.
+ *
+ * @see https://github.com/semantic-release/npm
+ */
+
+import type {LiteralUnion} from 'type-fest'
+
+/**
+ * Configuration for @semantic-release/npm plugin.
+ */
+export interface NpmConfig {
+  /**
+   * Directory path to publish.
+   *
+   * @default '.'
+   */
+  pkgRoot?: string
+
+  /**
+   * Whether to publish the package to the npm registry.
+   *
+   * @default true
+   */
+  npmPublish?: boolean
+
+  /**
+   * The npm tag to publish to.
+   *
+   * @default 'latest' for regular releases, or the prerelease identifier for prerelease versions
+   */
+  tarballDir?: string
+
+  /**
+   * Additional options that might be used by future versions.
+   */
+  [key: string]: unknown
+}
+
+/**
+ * Context passed to npm plugins during verify conditions.
+ */
+export interface NpmVerifyConditionsContext {
+  /**
+   * The semantic-release configuration options.
+   */
+  options: {
+    npmPublish?: boolean
+    pkgRoot?: string
+    [key: string]: unknown
+  }
+
+  /**
+   * Environment variables.
+   */
+  env: {
+    NPM_TOKEN?: string
+    [key: string]: string | undefined
+  }
+
+  /**
+   * Current working directory.
+   */
+  cwd: string
+
+  /**
+   * Logger instance.
+   */
+  logger: {
+    log: (message: string, ...args: unknown[]) => void
+    error: (message: string, ...args: unknown[]) => void
+    success: (message: string, ...args: unknown[]) => void
+  }
+}
+
+/**
+ * Context passed to npm plugins during prepare step.
+ */
+export interface NpmPrepareContext {
+  /**
+   * The semantic-release configuration options.
+   */
+  options: Record<string, unknown>
+
+  /**
+   * Information about the next release.
+   */
+  nextRelease: {
+    version: string
+    gitTag: string
+    type: 'major' | 'minor' | 'patch'
+    channel?: string
+  }
+
+  /**
+   * Information about the last release.
+   */
+  lastRelease: {
+    version: string
+    gitTag: string
+    gitHead: string
+  }
+
+  /**
+   * Environment variables.
+   */
+  env: Record<string, string | undefined>
+
+  /**
+   * Current working directory.
+   */
+  cwd: string
+
+  /**
+   * Logger instance.
+   */
+  logger: {
+    log: (message: string, ...args: unknown[]) => void
+    error: (message: string, ...args: unknown[]) => void
+    success: (message: string, ...args: unknown[]) => void
+  }
+}
+
+/**
+ * Context passed to npm plugins during publish step.
+ */
+export interface NpmPublishContext extends NpmPrepareContext {
+  /**
+   * Information about the next release.
+   */
+  nextRelease: {
+    version: string
+    gitTag: string
+    type: 'major' | 'minor' | 'patch'
+    channel?: string
+    notes: string
+  }
+}
+
+/**
+ * Result returned by the npm publish step.
+ */
+export interface NpmPublishResult {
+  /**
+   * The name of the published package.
+   */
+  name: string
+
+  /**
+   * The URL of the published package.
+   */
+  url: string
+
+  /**
+   * The npm dist-tag the package was published to.
+   */
+  channel: LiteralUnion<'latest' | 'next' | 'beta' | 'alpha', string>
+}

--- a/packages/semantic-release/src/types/plugins/release-notes-generator.ts
+++ b/packages/semantic-release/src/types/plugins/release-notes-generator.ts
@@ -1,0 +1,233 @@
+/**
+ * TypeScript interface for @semantic-release/release-notes-generator plugin configuration.
+ *
+ * This plugin generates release notes based on commit messages.
+ *
+ * @see https://github.com/semantic-release/release-notes-generator
+ */
+
+import type {LiteralUnion} from 'type-fest'
+
+/**
+ * Writer options for customizing the release notes output.
+ */
+export interface WriterOptions {
+  /**
+   * Main template for the release notes.
+   */
+  mainTemplate?: string
+
+  /**
+   * Template for each commit group.
+   */
+  commitGroupsTemplate?: string
+
+  /**
+   * Template for each commit.
+   */
+  commitTemplate?: string
+
+  /**
+   * Template for the header.
+   */
+  headerTemplate?: string
+
+  /**
+   * Template for the footer.
+   */
+  footerTemplate?: string
+
+  /**
+   * How to group commits.
+   */
+  groupBy?: string
+
+  /**
+   * How to sort commit groups.
+   */
+  commitGroupsSort?: string | ((a: unknown, b: unknown) => number)
+
+  /**
+   * How to sort commits within groups.
+   */
+  commitsSort?: string | string[] | ((a: unknown, b: unknown) => number)
+
+  /**
+   * How to sort notes within commits.
+   */
+  noteGroupsSort?: string | ((a: unknown, b: unknown) => number)
+
+  /**
+   * How to sort notes.
+   */
+  notesSort?: string | ((a: unknown, b: unknown) => number)
+
+  /**
+   * Transform function for commits.
+   */
+  transform?: (commit: unknown, context: unknown) => unknown
+
+  /**
+   * Additional writer options.
+   */
+  [key: string]: unknown
+}
+
+/**
+ * Configuration for @semantic-release/release-notes-generator plugin.
+ */
+export interface ReleaseNotesGeneratorConfig {
+  /**
+   * Conventional-changelog preset name.
+   *
+   * @default 'angular'
+   */
+  preset?: LiteralUnion<
+    | 'angular'
+    | 'atom'
+    | 'codemirror'
+    | 'ember'
+    | 'eslint'
+    | 'express'
+    | 'jquery'
+    | 'jshint'
+    | 'conventionalcommits',
+    string
+  >
+
+  /**
+   * npm package name of a custom conventional-changelog preset.
+   * Cannot be used together with 'preset'.
+   */
+  config?: string
+
+  /**
+   * Additional conventional-commits-parser options.
+   */
+  parserOpts?: {
+    /**
+     * Keywords to identify breaking changes.
+     */
+    noteKeywords?: string[]
+
+    /**
+     * Additional parser options.
+     */
+    [key: string]: unknown
+  }
+
+  /**
+   * Additional conventional-changelog-writer options.
+   */
+  writerOpts?: WriterOptions
+
+  /**
+   * Additional configuration passed to the conventional-changelog preset.
+   */
+  presetConfig?: Record<string, unknown>
+
+  /**
+   * Path to a Handlebars template file for customizing the release notes.
+   */
+  linkCompare?: boolean
+
+  /**
+   * Whether to include references in the release notes.
+   */
+  linkReferences?: boolean
+
+  /**
+   * Additional options that might be used by future versions.
+   */
+  [key: string]: unknown
+}
+
+/**
+ * Context passed to release notes generator plugins.
+ */
+export interface GenerateNotesContext {
+  /**
+   * The semantic-release configuration options.
+   */
+  options: {
+    preset?: string
+    repositoryUrl?: string
+    [key: string]: unknown
+  }
+
+  /**
+   * Array of commit objects since the last release.
+   */
+  commits: {
+    /**
+     * The commit hash.
+     */
+    hash: string
+
+    /**
+     * The commit message.
+     */
+    message: string
+
+    /**
+     * The commit author.
+     */
+    author: {
+      name: string
+      email: string
+    }
+
+    /**
+     * The commit date.
+     */
+    committerDate: string
+
+    /**
+     * Additional commit properties.
+     */
+    [key: string]: unknown
+  }[]
+
+  /**
+   * Information about the last release.
+   */
+  lastRelease: {
+    version: string
+    gitTag: string
+    gitHead: string
+    notes?: string
+  }
+
+  /**
+   * Information about the next release.
+   */
+  nextRelease: {
+    version: string
+    gitTag: string
+    type: 'major' | 'minor' | 'patch'
+  }
+
+  /**
+   * Environment variables.
+   */
+  env: Record<string, string | undefined>
+
+  /**
+   * Current working directory.
+   */
+  cwd: string
+
+  /**
+   * Logger instance.
+   */
+  logger: {
+    log: (message: string, ...args: unknown[]) => void
+    error: (message: string, ...args: unknown[]) => void
+    success: (message: string, ...args: unknown[]) => void
+  }
+}
+
+/**
+ * Result returned by the generateNotes step.
+ */
+export type GenerateNotesResult = string

--- a/packages/semantic-release/src/validation/index.ts
+++ b/packages/semantic-release/src/validation/index.ts
@@ -1,0 +1,20 @@
+/**
+ * Runtime validation schemas for semantic-release configuration types.
+ *
+ * This module provides Zod schemas for validating configuration objects at runtime,
+ * ensuring type safety and providing helpful error messages for invalid configurations.
+ */
+
+export {branchSpecSchema, globalConfigSchema, pluginSpecSchema} from './schemas/core.js'
+export {
+  changelogConfigSchema,
+  commitAnalyzerConfigSchema,
+  gitConfigSchema,
+  githubConfigSchema,
+  npmConfigSchema,
+  releaseNotesGeneratorConfigSchema,
+} from './schemas/plugins.js'
+export {validateConfig, ValidationError} from './validator.js'
+
+// Re-export Zod types for convenience
+export type {z} from 'zod'

--- a/packages/semantic-release/src/validation/schemas/core.ts
+++ b/packages/semantic-release/src/validation/schemas/core.ts
@@ -1,0 +1,52 @@
+/**
+ * Zod schemas for core semantic-release configuration types.
+ */
+
+import {z} from 'zod'
+
+/**
+ * Schema for branch specification configuration.
+ */
+export const branchSpecSchema = z.union([
+  z.string().min(1),
+  z.object({
+    name: z.string().min(1),
+    channel: z.string().optional(),
+    range: z.string().optional(),
+    prerelease: z.union([z.boolean(), z.string()]).optional(),
+  }),
+])
+
+/**
+ * Schema for plugin specification validation.
+ */
+export const pluginSpecSchema = z.union([
+  z.string().min(1),
+  z.tuple([z.string().min(1), z.record(z.string(), z.unknown())]),
+])
+
+/**
+ * Schema for global semantic-release configuration.
+ */
+export const globalConfigSchema = z.object({
+  // Core configuration
+  extends: z.union([z.string(), z.array(z.string())]).optional(),
+  branches: z.array(branchSpecSchema).optional(),
+  repositoryUrl: z.string().url().optional(),
+  tagFormat: z.string().optional(),
+  plugins: z.array(pluginSpecSchema).optional(),
+
+  // CI environment
+  ci: z.boolean().optional(),
+  dryRun: z.boolean().optional(),
+  debug: z.boolean().optional(),
+
+  // Git configuration
+  preset: z.string().optional(),
+  presetConfig: z.record(z.string(), z.unknown()).optional(),
+
+  // Advanced options
+  noCi: z.boolean().optional(),
+
+  // Environment variables will be validated separately
+})

--- a/packages/semantic-release/src/validation/schemas/plugins.ts
+++ b/packages/semantic-release/src/validation/schemas/plugins.ts
@@ -1,0 +1,127 @@
+/**
+ * Zod schemas for semantic-release plugin configurations.
+ */
+
+import {z} from 'zod'
+
+/**
+ * Schema for @semantic-release/commit-analyzer configuration.
+ */
+export const commitAnalyzerConfigSchema = z.object({
+  preset: z.string().optional(),
+  config: z.record(z.string(), z.unknown()).optional(),
+  parserOpts: z.record(z.string(), z.unknown()).optional(),
+  releaseRules: z
+    .array(
+      z.object({
+        type: z.string().optional(),
+        scope: z.string().optional(),
+        subject: z.string().optional(),
+        release: z
+          .union([z.literal('major'), z.literal('minor'), z.literal('patch'), z.literal(false)])
+          .optional(),
+        breaking: z.boolean().optional(),
+        revert: z.boolean().optional(),
+      }),
+    )
+    .optional(),
+  presetConfig: z.record(z.string(), z.unknown()).optional(),
+})
+
+/**
+ * Schema for @semantic-release/release-notes-generator configuration.
+ */
+export const releaseNotesGeneratorConfigSchema = z.object({
+  preset: z.string().optional(),
+  config: z.record(z.string(), z.unknown()).optional(),
+  parserOpts: z.record(z.string(), z.unknown()).optional(),
+  writerOpts: z
+    .object({
+      groupBy: z.string().optional(),
+      commitGroupsSort: z.union([z.string(), z.unknown()]).optional(),
+      commitsSort: z.union([z.string(), z.unknown()]).optional(),
+      noteGroupsSort: z.union([z.string(), z.unknown()]).optional(),
+      notesSort: z.union([z.string(), z.unknown()]).optional(),
+      generateOn: z.union([z.string(), z.unknown()]).optional(),
+      finalizeContext: z.unknown().optional(),
+      debug: z.unknown().optional(),
+      reverse: z.boolean().optional(),
+      includeDetails: z.boolean().optional(),
+      ignoreReverted: z.boolean().optional(),
+      doFlush: z.boolean().optional(),
+      mainTemplate: z.string().optional(),
+      headerPartial: z.string().optional(),
+      commitPartial: z.string().optional(),
+      footerPartial: z.string().optional(),
+      partials: z.record(z.string(), z.string()).optional(),
+      transform: z.record(z.string(), z.unknown()).optional(),
+    })
+    .optional(),
+  presetConfig: z.record(z.string(), z.unknown()).optional(),
+  linkCompare: z.boolean().optional(),
+  linkReferences: z.boolean().optional(),
+  host: z.string().optional(),
+  owner: z.string().optional(),
+  repository: z.string().optional(),
+  repoUrl: z.string().optional(),
+  commit: z.string().optional(),
+  issue: z.string().optional(),
+  userUrlFormat: z.string().optional(),
+})
+
+/**
+ * Schema for @semantic-release/changelog configuration.
+ */
+export const changelogConfigSchema = z.object({
+  changelogFile: z.string().optional(),
+  changelogTitle: z.string().optional(),
+})
+
+/**
+ * Schema for @semantic-release/npm configuration.
+ */
+export const npmConfigSchema = z.object({
+  npmPublish: z.boolean().optional(),
+  pkgRoot: z.string().optional(),
+  tarballDir: z.string().optional(),
+})
+
+/**
+ * Schema for @semantic-release/github configuration.
+ */
+export const githubConfigSchema = z.object({
+  githubUrl: z.string().optional(),
+  githubApiPathPrefix: z.string().optional(),
+  proxy: z.union([z.string(), z.record(z.string(), z.unknown())]).optional(),
+  assets: z
+    .array(
+      z.union([
+        z.string(),
+        z.object({
+          path: z.string(),
+          name: z.string().optional(),
+          label: z.string().optional(),
+        }),
+      ]),
+    )
+    .optional(),
+  successComment: z.union([z.string(), z.literal(false)]).optional(),
+  failTitle: z.string().optional(),
+  failComment: z.union([z.string(), z.literal(false)]).optional(),
+  labels: z.union([z.array(z.string()), z.literal(false)]).optional(),
+  assignees: z.array(z.string()).optional(),
+  releasedLabels: z.union([z.array(z.string()), z.literal(false)]).optional(),
+  addReleases: z.union([z.literal('bottom'), z.literal('top'), z.literal(false)]).optional(),
+  draftRelease: z.boolean().optional(),
+  releaseBodyTemplate: z.string().optional(),
+  releaseNameTemplate: z.string().optional(),
+  discussionCategoryName: z.string().optional(),
+})
+
+/**
+ * Schema for @semantic-release/git configuration.
+ */
+export const gitConfigSchema = z.object({
+  assets: z.array(z.string()).optional(),
+  message: z.string().optional(),
+})

--- a/packages/semantic-release/src/validation/validator.ts
+++ b/packages/semantic-release/src/validation/validator.ts
@@ -1,0 +1,165 @@
+/**
+ * Configuration validation utilities using Zod schemas.
+ */
+
+import {z} from 'zod'
+import {globalConfigSchema} from './schemas/core.js'
+import {
+  changelogConfigSchema,
+  commitAnalyzerConfigSchema,
+  gitConfigSchema,
+  githubConfigSchema,
+  npmConfigSchema,
+  releaseNotesGeneratorConfigSchema,
+} from './schemas/plugins.js'
+
+/**
+ * Custom validation error class with detailed error information.
+ */
+export class ValidationError extends Error {
+  readonly zodError: z.ZodError
+  readonly path?: string
+
+  constructor(message: string, zodError: z.ZodError, path?: string) {
+    super(message)
+    this.name = 'ValidationError'
+    this.zodError = zodError
+    this.path = path
+  }
+
+  /**
+   * Get formatted error messages for display.
+   */
+  getFormattedErrors(): string[] {
+    return this.zodError.issues.map(issue => {
+      const path = issue.path.length > 0 ? issue.path.join('.') : 'root'
+      return `${path}: ${issue.message}`
+    })
+  }
+}
+
+/**
+ * Plugin configuration schema registry.
+ */
+const pluginSchemas = {
+  '@semantic-release/commit-analyzer': commitAnalyzerConfigSchema,
+  '@semantic-release/release-notes-generator': releaseNotesGeneratorConfigSchema,
+  '@semantic-release/changelog': changelogConfigSchema,
+  '@semantic-release/npm': npmConfigSchema,
+  '@semantic-release/github': githubConfigSchema,
+  '@semantic-release/git': gitConfigSchema,
+} as const
+
+/**
+ * Validate a global semantic-release configuration.
+ */
+export function validateConfig(config: unknown):
+  | {
+      success: true
+      data: z.infer<typeof globalConfigSchema>
+    }
+  | {
+      success: false
+      error: ValidationError
+    } {
+  try {
+    const result = globalConfigSchema.parse(config)
+    return {success: true, data: result}
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return {
+        success: false,
+        error: new ValidationError('Invalid semantic-release configuration', error, 'global'),
+      }
+    }
+    throw error
+  }
+}
+
+/**
+ * Validate a plugin configuration by plugin name.
+ */
+export function validatePluginConfig(
+  pluginName: string,
+  config: unknown,
+):
+  | {
+      success: true
+      data: unknown
+    }
+  | {
+      success: false
+      error: ValidationError
+    } {
+  const schema = pluginSchemas[pluginName as keyof typeof pluginSchemas]
+
+  if (schema === undefined) {
+    // For unknown plugins, we can't validate the configuration
+    // but we don't want to fail validation either
+    return {success: true, data: config}
+  }
+
+  try {
+    const result = schema.parse(config)
+    return {success: true, data: result}
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return {
+        success: false,
+        error: new ValidationError(
+          `Invalid configuration for plugin ${pluginName}`,
+          error,
+          pluginName,
+        ),
+      }
+    }
+    throw error
+  }
+}
+
+/**
+ * Validate a complete semantic-release configuration including plugins.
+ */
+export function validateCompleteConfig(config: unknown):
+  | {
+      success: true
+      data: z.infer<typeof globalConfigSchema>
+    }
+  | {
+      success: false
+      errors: ValidationError[]
+    } {
+  const errors: ValidationError[] = []
+
+  // Validate global config
+  const globalResult = validateConfig(config)
+  if (!globalResult.success) {
+    errors.push(globalResult.error)
+    return {success: false, errors}
+  }
+
+  // Validate plugin configurations
+  if (globalResult.data.plugins) {
+    for (const [index, plugin] of globalResult.data.plugins.entries()) {
+      if (Array.isArray(plugin) && plugin.length === 2) {
+        const [pluginName, pluginConfig] = plugin
+        const pluginResult = validatePluginConfig(pluginName, pluginConfig)
+        if (!pluginResult.success) {
+          // Add context about which plugin in the array failed
+          const contextualError = new ValidationError(
+            `Plugin at index ${index}: ${pluginResult.error.message}`,
+            pluginResult.error.zodError,
+            `plugins.${index}`,
+          )
+          errors.push(contextualError)
+        }
+      }
+    }
+  }
+
+  if (errors.length > 0) {
+    return {success: false, errors}
+  }
+
+  return {success: true, data: globalResult.data}
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -348,6 +348,12 @@ importers:
       tsup:
         specifier: 8.5.0
         version: 8.5.0(@microsoft/api-extractor@7.52.11(@types/node@22.17.1))(jiti@2.1.2)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.1)
+      type-fest:
+        specifier: 4.41.0
+        version: 4.41.0
+      zod:
+        specifier: <4.0.0
+        version: 3.25.76
 
   packages/tsconfig:
     devDependencies:


### PR DESCRIPTION
- Introduced a plugin registry system with extensible plugin lifecycle hooks.
- Created TypeScript interfaces for the following plugins:
  - @semantic-release/changelog
  - @semantic-release/commit-analyzer
  - @semantic-release/git
  - @semantic-release/github
  - @semantic-release/npm
  - @semantic-release/release-notes-generator
- Implemented Zod validation schemas for core and plugin configurations.
- Added runtime validation utilities to ensure type safety and provide error messages for invalid configurations.
- Updated pnpm-lock.yaml to include new dependencies: type-fest and zod.

Closes #1757.