### PR TITLE
feat(semantic-release): add configuration composition utilities and tests

### DIFF
--- a/.ai/plan/refactor-semantic-release-1.md
+++ b/.ai/plan/refactor-semantic-release-1.md
@@ -64,7 +64,7 @@ Complete rewrite of the `@bfra.me/semantic-release` package to provide comprehen
 | TASK-012 | Create factory functions for JavaScript config files (release.config.mjs) with full typing | ✅ | 2024-12-28 |
 | TASK-013 | Implement configuration builder pattern for complex setups | ✅ | 2024-12-28 |
 | TASK-014 | Create preset factory functions for common workflows (npm, GitHub, monorepo) | ✅ | 2024-12-28 |
-| TASK-015 | Implement configuration composition utilities (merge, extend, override) | | |
+| TASK-015 | Implement configuration composition utilities (merge, extend, override) | ✅ | 2024-12-28 |
 | TASK-016 | Add configuration validation with detailed error messages and suggestions | | |
 | TASK-017 | Create type-safe plugin configuration helpers for popular plugins | | |
 | TASK-018 | Implement environment-based configuration switching (dev, staging, production) | | |

--- a/.changeset/honest-flowers-joke.md
+++ b/.changeset/honest-flowers-joke.md
@@ -9,4 +9,4 @@ Enhance TypeScript support and configuration utilities.
 - Add factory functions for JavaScript configuration files with TypeScript support.
 - Implement preset factory functions for common workflows like npm and GitHub releases.
 - Update tests to reflect changes in configuration structure and validation.
-- Modify build configuration to include new entry points for TypeScript files.
+- Implement configuration composition utilities for merging, extending, and overriding semantic-release configurations.

--- a/packages/semantic-release/src/composition/index.ts
+++ b/packages/semantic-release/src/composition/index.ts
@@ -1,0 +1,341 @@
+/**
+ * Configuration composition utilities for semantic-release.
+ *
+ * This module provides utilities for merging, extending, and overriding
+ * semantic-release configurations, enabling complex configuration scenarios
+ * where presets need to be combined with custom settings.
+ *
+ * @example
+ * ```typescript
+ * import {mergeConfigs, extendConfig} from '@bfra.me/semantic-release/composition'
+ * import {npmPreset, githubPreset} from '@bfra.me/semantic-release/presets'
+ *
+ * // Merge multiple configurations
+ * const merged = mergeConfigs(
+ *   npmPreset(),
+ *   githubPreset(),
+ *   { dryRun: true }
+ * )
+ *
+ * // Extend a base configuration
+ * const extended = extendConfig(npmPreset(), {
+ *   plugins: [['@semantic-release/npm', { npmPublish: false }]]
+ * })
+ * ```
+ */
+
+import type {BranchSpec, GlobalConfig, PluginSpec} from '../types/core.js'
+
+/**
+ * Options for configuration composition operations.
+ */
+export interface CompositionOptions {
+  /**
+   * How to handle plugin conflicts when merging configurations.
+   * - 'replace': Replace existing plugins entirely
+   * - 'merge': Merge plugin configurations (default)
+   * - 'append': Append new plugins to existing ones
+   * - 'prepend': Prepend new plugins before existing ones
+   */
+  pluginStrategy?: 'replace' | 'merge' | 'append' | 'prepend'
+
+  /**
+   * How to handle branch configuration conflicts.
+   * - 'replace': Replace with the new branch configuration
+   * - 'merge': Merge branch configurations (default)
+   */
+  branchStrategy?: 'replace' | 'merge'
+
+  /**
+   * Whether to perform deep validation on the result.
+   * @default true
+   */
+  validate?: boolean
+}
+
+/**
+ * Merge multiple semantic-release configurations.
+ *
+ * This function takes multiple configuration objects and merges them together,
+ * applying intelligent strategies for handling conflicts in plugins, branches,
+ * and other configuration options.
+ *
+ * @param config1 - First configuration object
+ * @param config2 - Second configuration object
+ * @param restConfigs - Additional configuration objects
+ * @returns A merged configuration object
+ *
+ * @example
+ * ```typescript
+ * const base = npmPreset()
+ * const custom = { dryRun: true, repositoryUrl: 'https://github.com/user/repo' }
+ * const merged = mergeConfigs(base, custom)
+ * ```
+ */
+export function mergeConfigs(
+  config1: GlobalConfig,
+  config2: GlobalConfig,
+  ...restConfigs: GlobalConfig[]
+): GlobalConfig {
+  return mergeConfigsWithOptions([config1, config2, ...restConfigs], {})
+}
+
+/**
+ * Merge multiple semantic-release configurations with options.
+ *
+ * @param configs - Array of configuration objects to merge
+ * @param options - Options controlling merge behavior
+ * @returns A merged configuration object
+ */
+export function mergeConfigsWithOptions(
+  configs: readonly [GlobalConfig, ...GlobalConfig[]],
+  options: CompositionOptions = {},
+): GlobalConfig {
+  const {pluginStrategy = 'merge', branchStrategy = 'merge', validate = true} = options
+
+  const result: GlobalConfig = {}
+
+  // Merge simple properties (last wins)
+  for (const config of configs) {
+    if (config.repositoryUrl != null) {
+      result.repositoryUrl = config.repositoryUrl
+    }
+    if (config.tagFormat != null) {
+      result.tagFormat = config.tagFormat
+    }
+    if (config.dryRun != null) {
+      result.dryRun = config.dryRun
+    }
+    if (config.ci != null) {
+      result.ci = config.ci
+    }
+  }
+
+  // Merge extends configuration
+  const allExtends = configs
+    .map(config => config.extends)
+    .filter((extend): extend is string | readonly string[] => extend != null)
+    .flat()
+
+  if (allExtends.length > 0) {
+    result.extends = allExtends.length === 1 ? allExtends[0] : allExtends
+  }
+
+  // Merge branches configuration
+  result.branches = mergeBranches(
+    configs.map(config => config.branches).filter(branches => branches != null),
+    branchStrategy,
+  )
+
+  // Merge plugins configuration
+  result.plugins = mergePlugins(
+    configs.map(config => config.plugins).filter(plugins => plugins != null),
+    pluginStrategy,
+  )
+
+  // Merge additional properties
+  for (const config of configs) {
+    for (const [key, value] of Object.entries(config)) {
+      if (
+        key !== 'extends' &&
+        key !== 'branches' &&
+        key !== 'repositoryUrl' &&
+        key !== 'tagFormat' &&
+        key !== 'plugins' &&
+        key !== 'dryRun' &&
+        key !== 'ci' &&
+        value != null
+      ) {
+        result[key] = value
+      }
+    }
+  }
+
+  // Clean up undefined values
+  Object.keys(result).forEach(key => {
+    if (result[key] === undefined) {
+      delete result[key]
+    }
+  })
+
+  // Note: Validation is deferred to avoid complex type dependencies
+  // Users can call validateConfig directly if needed
+  if (validate) {
+    // Validation will be implemented in TASK-016
+  }
+
+  return result
+}
+
+/**
+ * Extend a base configuration with additional options.
+ *
+ * This function takes a base configuration and extends it with additional options,
+ * using the same merging strategies as `mergeConfigs` but with a cleaner API
+ * for the common case of extending a single base configuration.
+ *
+ * @param base - Base configuration to extend
+ * @param extension - Extension configuration
+ * @param options - Options controlling merge behavior
+ * @returns An extended configuration object
+ *
+ * @example
+ * ```typescript
+ * const base = npmPreset()
+ * const extended = extendConfig(base, {
+ *   dryRun: true,
+ *   plugins: [['@semantic-release/npm', { npmPublish: false }]]
+ * })
+ * ```
+ */
+export function extendConfig(
+  base: GlobalConfig,
+  extension: GlobalConfig,
+  options: CompositionOptions = {},
+): GlobalConfig {
+  return mergeConfigsWithOptions([base, extension], options)
+}
+
+/**
+ * Override a base configuration with new options.
+ *
+ * This function provides complete replacement semantics, where the override
+ * configuration completely replaces matching properties in the base configuration.
+ * This is useful when you need to completely replace certain aspects like plugins.
+ *
+ * @param base - Base configuration to override
+ * @param override - Override configuration
+ * @param options - Options controlling override behavior
+ * @returns An overridden configuration object
+ *
+ * @example
+ * ```typescript
+ * const base = npmPreset()
+ * const overridden = overrideConfig(base, {
+ *   plugins: [['@semantic-release/git']] // Completely replaces plugins
+ * })
+ * ```
+ */
+export function overrideConfig(
+  base: GlobalConfig,
+  override: GlobalConfig,
+  options: Omit<CompositionOptions, 'pluginStrategy' | 'branchStrategy'> = {},
+): GlobalConfig {
+  return mergeConfigsWithOptions([base, override], {
+    ...options,
+    pluginStrategy: 'replace',
+    branchStrategy: 'replace',
+  })
+}
+
+/**
+ * Merge branch configurations using the specified strategy.
+ *
+ * @param branchConfigs - Array of branch configurations to merge
+ * @param strategy - Strategy for merging branches
+ * @returns Merged branch configuration
+ */
+function mergeBranches(
+  branchConfigs: NonNullable<GlobalConfig['branches']>[],
+  strategy: CompositionOptions['branchStrategy'],
+): GlobalConfig['branches'] {
+  if (branchConfigs.length === 0) {
+    return undefined
+  }
+
+  if (strategy === 'replace') {
+    return branchConfigs.at(-1)
+  }
+
+  // For merge strategy, combine all unique branches
+  const allBranches = branchConfigs.flat()
+  const uniqueBranches = new Map<string, string | BranchSpec>()
+
+  for (const branch of allBranches) {
+    const key = typeof branch === 'string' ? branch : branch.name
+    uniqueBranches.set(key, branch)
+  }
+
+  const result = Array.from(uniqueBranches.values())
+  return result
+}
+
+/**
+ * Merge plugin configurations using the specified strategy.
+ *
+ * @param pluginConfigs - Array of plugin configurations to merge
+ * @param strategy - Strategy for merging plugins
+ * @returns Merged plugin configuration
+ */
+function mergePlugins(
+  pluginConfigs: NonNullable<GlobalConfig['plugins']>[],
+  strategy: CompositionOptions['pluginStrategy'],
+): GlobalConfig['plugins'] {
+  if (pluginConfigs.length === 0) {
+    return undefined
+  }
+
+  if (strategy === 'replace') {
+    return pluginConfigs.at(-1)
+  }
+
+  if (strategy === 'append') {
+    return pluginConfigs.flat()
+  }
+
+  if (strategy === 'prepend') {
+    return pluginConfigs.reverse().flat()
+  }
+
+  // For merge strategy, intelligently merge plugins by name
+  const mergedPlugins = new Map<string, PluginSpec>()
+
+  for (const plugins of pluginConfigs) {
+    for (const plugin of plugins) {
+      const pluginName = typeof plugin === 'string' ? plugin : plugin[0]
+
+      const existing = mergedPlugins.get(pluginName)
+      if (existing === undefined) {
+        mergedPlugins.set(pluginName, plugin)
+      } else {
+        // Merge plugin configurations
+        const merged = mergePluginConfigurations(existing, plugin)
+        mergedPlugins.set(pluginName, merged)
+      }
+    }
+  }
+
+  return Array.from(mergedPlugins.values())
+}
+
+/**
+ * Merge two plugin configurations.
+ *
+ * @param existing - Existing plugin configuration
+ * @param newPlugin - New plugin configuration to merge
+ * @returns Merged plugin configuration
+ */
+function mergePluginConfigurations(existing: PluginSpec, newPlugin: PluginSpec): PluginSpec {
+  if (typeof existing === 'string' && typeof newPlugin === 'string') {
+    return newPlugin // New plugin name takes precedence
+  }
+
+  if (typeof existing === 'string') {
+    return newPlugin // New configuration takes precedence
+  }
+
+  if (typeof newPlugin === 'string') {
+    return newPlugin // Simple string configuration takes precedence
+  }
+
+  // Both are tuples, merge their configurations
+  const [, existingConfig] = existing
+  const [newName, newConfig] = newPlugin
+
+  const mergedConfig = {
+    ...existingConfig,
+    ...newConfig,
+  }
+
+  return [newName, mergedConfig]
+}

--- a/packages/semantic-release/src/index.ts
+++ b/packages/semantic-release/src/index.ts
@@ -1,3 +1,4 @@
+export * from './composition/index.js'
 export * from './config.js'
 export type * from './types.js'
 export * from './validation/index.js'

--- a/packages/semantic-release/test/composition.test.ts
+++ b/packages/semantic-release/test/composition.test.ts
@@ -1,0 +1,389 @@
+/**
+ * Tests for configuration composition utilities.
+ *
+ * These tests verify that the mergeConfigs, extendConfig, and overrideConfig
+ * functions work correctly with various configuration scenarios.
+ */
+
+import type {GlobalConfig} from '../src/types/core.js'
+
+import {describe, expect, it} from 'vitest'
+import {
+  extendConfig,
+  mergeConfigs,
+  mergeConfigsWithOptions,
+  overrideConfig,
+} from '../src/composition/index.js'
+
+describe('composition utilities', () => {
+  describe('mergeConfigs', () => {
+    it('should merge simple properties with last wins strategy', () => {
+      const config1: GlobalConfig = {
+        branches: ['main'],
+        repositoryUrl: 'https://github.com/user/repo1',
+        dryRun: false,
+      }
+
+      const config2: GlobalConfig = {
+        repositoryUrl: 'https://github.com/user/repo2',
+        dryRun: true,
+        // eslint-disable-next-line no-template-curly-in-string
+        tagFormat: 'v${version}',
+      }
+
+      const result = mergeConfigs(config1, config2)
+
+      expect(result).toEqual({
+        branches: ['main'],
+        repositoryUrl: 'https://github.com/user/repo2', // Last wins
+        dryRun: true, // Last wins
+        // eslint-disable-next-line no-template-curly-in-string
+        tagFormat: 'v${version}',
+      })
+    })
+
+    it('should merge extends configurations', () => {
+      const config1: GlobalConfig = {
+        extends: '@bfra.me/semantic-release',
+        branches: ['main'],
+      }
+
+      const config2: GlobalConfig = {
+        extends: 'semantic-release-monorepo',
+        dryRun: true,
+      }
+
+      const result = mergeConfigs(config1, config2)
+
+      expect(result).toEqual({
+        extends: ['@bfra.me/semantic-release', 'semantic-release-monorepo'],
+        branches: ['main'],
+        dryRun: true,
+      })
+    })
+
+    it('should merge branches by default', () => {
+      const config1: GlobalConfig = {
+        branches: ['main'],
+      }
+
+      const config2: GlobalConfig = {
+        branches: ['develop'],
+      }
+
+      const result = mergeConfigs(config1, config2)
+
+      expect(result).toEqual({
+        branches: ['main', 'develop'],
+      })
+    })
+
+    it('should merge plugins by default', () => {
+      const config1: GlobalConfig = {
+        plugins: [
+          '@semantic-release/commit-analyzer',
+          ['@semantic-release/npm', {npmPublish: true}],
+        ],
+      }
+
+      const config2: GlobalConfig = {
+        plugins: [
+          '@semantic-release/release-notes-generator',
+          ['@semantic-release/npm', {npmPublish: false}], // Should merge with existing
+        ],
+      }
+
+      const result = mergeConfigs(config1, config2)
+
+      expect(result.plugins).toEqual([
+        '@semantic-release/commit-analyzer',
+        ['@semantic-release/npm', {npmPublish: false}], // Merged configuration
+        '@semantic-release/release-notes-generator',
+      ])
+    })
+
+    it('should handle multiple configurations', () => {
+      const config1: GlobalConfig = {
+        branches: ['main'],
+        dryRun: false,
+      }
+
+      const config2: GlobalConfig = {
+        branches: ['develop'],
+        // eslint-disable-next-line no-template-curly-in-string
+        tagFormat: 'v${version}',
+      }
+
+      const config3: GlobalConfig = {
+        dryRun: true,
+        repositoryUrl: 'https://github.com/user/repo',
+      }
+
+      const result = mergeConfigs(config1, config2, config3)
+
+      expect(result).toEqual({
+        branches: ['main', 'develop'],
+        dryRun: true, // Last wins
+        // eslint-disable-next-line no-template-curly-in-string
+        tagFormat: 'v${version}',
+        repositoryUrl: 'https://github.com/user/repo',
+      })
+    })
+  })
+
+  describe('mergeConfigsWithOptions', () => {
+    it('should replace branches when strategy is replace', () => {
+      const config1: GlobalConfig = {
+        branches: ['main'],
+      }
+
+      const config2: GlobalConfig = {
+        branches: ['develop'],
+      }
+
+      const result = mergeConfigsWithOptions([config1, config2], {
+        branchStrategy: 'replace',
+      })
+
+      expect(result).toEqual({
+        branches: ['develop'], // Replaced
+      })
+    })
+
+    it('should replace plugins when strategy is replace', () => {
+      const config1: GlobalConfig = {
+        plugins: ['@semantic-release/commit-analyzer'],
+      }
+
+      const config2: GlobalConfig = {
+        plugins: ['@semantic-release/release-notes-generator'],
+      }
+
+      const result = mergeConfigsWithOptions([config1, config2], {
+        pluginStrategy: 'replace',
+      })
+
+      expect(result).toEqual({
+        plugins: ['@semantic-release/release-notes-generator'], // Replaced
+      })
+    })
+
+    it('should append plugins when strategy is append', () => {
+      const config1: GlobalConfig = {
+        plugins: ['@semantic-release/commit-analyzer'],
+      }
+
+      const config2: GlobalConfig = {
+        plugins: ['@semantic-release/release-notes-generator'],
+      }
+
+      const result = mergeConfigsWithOptions([config1, config2], {
+        pluginStrategy: 'append',
+      })
+
+      expect(result).toEqual({
+        plugins: ['@semantic-release/commit-analyzer', '@semantic-release/release-notes-generator'],
+      })
+    })
+
+    it('should prepend plugins when strategy is prepend', () => {
+      const config1: GlobalConfig = {
+        plugins: ['@semantic-release/commit-analyzer'],
+      }
+
+      const config2: GlobalConfig = {
+        plugins: ['@semantic-release/release-notes-generator'],
+      }
+
+      const result = mergeConfigsWithOptions([config1, config2], {
+        pluginStrategy: 'prepend',
+      })
+
+      expect(result).toEqual({
+        plugins: ['@semantic-release/release-notes-generator', '@semantic-release/commit-analyzer'],
+      })
+    })
+  })
+
+  describe('extendConfig', () => {
+    it('should extend base configuration with additional options', () => {
+      const base: GlobalConfig = {
+        branches: ['main'],
+        plugins: ['@semantic-release/commit-analyzer'],
+      }
+
+      const extension: GlobalConfig = {
+        dryRun: true,
+        plugins: ['@semantic-release/release-notes-generator'],
+      }
+
+      const result = extendConfig(base, extension)
+
+      expect(result).toEqual({
+        branches: ['main'],
+        dryRun: true,
+        plugins: ['@semantic-release/commit-analyzer', '@semantic-release/release-notes-generator'],
+      })
+    })
+
+    it('should pass options to merge function', () => {
+      const base: GlobalConfig = {
+        plugins: ['@semantic-release/commit-analyzer'],
+      }
+
+      const extension: GlobalConfig = {
+        plugins: ['@semantic-release/release-notes-generator'],
+      }
+
+      const result = extendConfig(base, extension, {
+        pluginStrategy: 'replace',
+      })
+
+      expect(result).toEqual({
+        plugins: ['@semantic-release/release-notes-generator'], // Replaced
+      })
+    })
+  })
+
+  describe('overrideConfig', () => {
+    it('should override base configuration with replace strategies', () => {
+      const base: GlobalConfig = {
+        branches: ['main'],
+        plugins: ['@semantic-release/commit-analyzer'],
+        dryRun: false,
+      }
+
+      const override: GlobalConfig = {
+        branches: ['develop'],
+        plugins: ['@semantic-release/release-notes-generator'],
+      }
+
+      const result = overrideConfig(base, override)
+
+      expect(result).toEqual({
+        branches: ['develop'], // Replaced
+        plugins: ['@semantic-release/release-notes-generator'], // Replaced
+        dryRun: false, // Preserved
+      })
+    })
+
+    it('should preserve simple properties', () => {
+      const base: GlobalConfig = {
+        branches: ['main'],
+        repositoryUrl: 'https://github.com/user/repo',
+        dryRun: false,
+      }
+
+      const override: GlobalConfig = {
+        dryRun: true,
+        // eslint-disable-next-line no-template-curly-in-string
+        tagFormat: 'v${version}',
+      }
+
+      const result = overrideConfig(base, override)
+
+      expect(result).toEqual({
+        branches: ['main'], // Preserved
+        repositoryUrl: 'https://github.com/user/repo', // Preserved
+        dryRun: true, // Overridden
+        // eslint-disable-next-line no-template-curly-in-string
+        tagFormat: 'v${version}', // Added
+      })
+    })
+  })
+
+  describe('edge cases', () => {
+    it('should handle empty configurations', () => {
+      const config1: GlobalConfig = {}
+      const config2: GlobalConfig = {}
+
+      const result = mergeConfigs(config1, config2)
+
+      expect(result).toEqual({})
+    })
+
+    it('should handle single branch returning single value', () => {
+      const config: GlobalConfig = {
+        branches: ['main'],
+      }
+
+      const result = mergeConfigs(config, {})
+
+      expect(result).toEqual({
+        branches: ['main'], // Array preserved
+      })
+    })
+
+    it('should handle branch objects', () => {
+      const config1: GlobalConfig = {
+        branches: [{name: 'main', channel: 'latest'}],
+      }
+
+      const config2: GlobalConfig = {
+        branches: [{name: 'develop', channel: 'beta'}],
+      }
+
+      const result = mergeConfigs(config1, config2)
+
+      expect(result).toEqual({
+        branches: [
+          {name: 'main', channel: 'latest'},
+          {name: 'develop', channel: 'beta'},
+        ],
+      })
+    })
+
+    it('should handle mixed branch types', () => {
+      const config1: GlobalConfig = {
+        branches: ['main'],
+      }
+
+      const config2: GlobalConfig = {
+        branches: [{name: 'develop', channel: 'beta'}],
+      }
+
+      const result = mergeConfigs(config1, config2)
+
+      expect(result).toEqual({
+        branches: ['main', {name: 'develop', channel: 'beta'}],
+      })
+    })
+
+    it('should handle plugin string to tuple conversion', () => {
+      const config1: GlobalConfig = {
+        plugins: ['@semantic-release/npm'],
+      }
+
+      const config2: GlobalConfig = {
+        plugins: ['@semantic-release/npm'], // Same plugin as string
+      }
+
+      const result = mergeConfigs(config1, config2)
+
+      expect(result).toEqual({
+        plugins: ['@semantic-release/npm'], // No duplication
+      })
+    })
+
+    it('should merge plugin configurations correctly', () => {
+      const config1: GlobalConfig = {
+        plugins: [['@semantic-release/npm', {npmPublish: true, tarballDir: 'dist'}]],
+      }
+
+      const config2: GlobalConfig = {
+        plugins: [['@semantic-release/npm', {npmPublish: false}]],
+      }
+
+      const result = mergeConfigs(config1, config2)
+
+      expect(result).toEqual({
+        plugins: [
+          [
+            '@semantic-release/npm',
+            {npmPublish: false, tarballDir: 'dist'}, // Merged configuration
+          ],
+        ],
+      })
+    })
+  })
+})


### PR DESCRIPTION
- Implement configuration composition utilities for merging, extending, and overriding semantic-release configurations.
- Create tests for mergeConfigs, extendConfig, and overrideConfig functions to verify their functionality.
- Update index.ts to export new composition utilities.

Relates to TASK-015 on #1758.