### PR TITLE
fix(eslint): add custom regex matching for type-aware rules

### DIFF
--- a/.changeset/little-mammals-follow.md
+++ b/.changeset/little-mammals-follow.md
@@ -1,0 +1,6 @@
+---
+"@bfra.me/eslint-config": patch
+---
+
+Ignore 'Component' and 'Icon' parameter names when enforcing conventions. 
+  

--- a/packages/eslint-config/src/configs/typescript.ts
+++ b/packages/eslint-config/src/configs/typescript.ts
@@ -27,6 +27,10 @@ const TypeAwareRules: Config['rules'] = {
       selector: 'typeLike',
     },
     {
+      filter: {
+        match: false,
+        regex: '(Component|Icon)$',
+      },
       format: ['camelCase'],
       leadingUnderscore: 'allow',
       selector: 'parameter',


### PR DESCRIPTION
- Add custom regex matching for 'Component' and 'Icon' in type-aware rules