### PR TITLE
fix(eslint-config): disable TypeScript rules for Markdown linting

### DIFF
--- a/.changeset/old-spoons-allow.md
+++ b/.changeset/old-spoons-allow.md
@@ -1,0 +1,6 @@
+---
+"@bfra.me/eslint-config": patch
+---
+
+Disable TypeScript rules for Markdown linting.
+  

--- a/packages/eslint-config/src/configs/markdown.ts
+++ b/packages/eslint-config/src/configs/markdown.ts
@@ -90,17 +90,17 @@ export async function markdown(options: MarkdownOptions = {}): Promise<Config[]>
               ecmaFeatures: {
                 impliedStrict: true,
               },
-              // Explicitly disable project for these files to prevent type-aware linting
-              project: false,
             },
           },
           rules: {
             // Only disable non-type-aware rules we want to skip for markdown code blocks
 
+            '@typescript-eslint/no-namespace': 'off',
             '@typescript-eslint/consistent-type-imports': 'off',
             '@typescript-eslint/explicit-function-return-type': 'off',
             '@typescript-eslint/no-redeclare': 'off',
             '@typescript-eslint/no-require-imports': 'off',
+            '@typescript-eslint/no-unused-expressions': 'off',
             '@typescript-eslint/no-unused-vars': 'off',
             '@typescript-eslint/no-use-before-define': 'off',
             '@typescript-eslint/no-var-requires': 'off',


### PR DESCRIPTION
- Disable '@typescript-eslint/no-namespace' rule for Markdown files.
- Disable '@typescript-eslint/no-unused-expressions' rule for Markdown files.