### PR TITLE
fix(eslint-config): exclude postUpgradeTasks.commands arrays

### DIFF
--- a/.changeset/cool-shirts-joke.md
+++ b/.changeset/cool-shirts-joke.md
@@ -1,0 +1,6 @@
+---
+"@bfra.me/eslint-config": patch
+---
+
+Ignore `postUpgradeTasks.commands` arrays when sorting Renovate configs.
+  

--- a/.changeset/grumpy-peaches-share.md
+++ b/.changeset/grumpy-peaches-share.md
@@ -1,6 +1,0 @@
----
-"@bfra.me/eslint-config": patch
----
-
-Fix to not sort `postUpgradeTasks.commands` arrays in Renovate configs.
-  

--- a/.changeset/grumpy-peaches-share.md
+++ b/.changeset/grumpy-peaches-share.md
@@ -1,0 +1,6 @@
+---
+"@bfra.me/eslint-config": patch
+---
+
+Fix to not sort `postUpgradeTasks.commands` arrays in Renovate configs.
+  

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -21,6 +21,7 @@
       matchPackageNames: ['@anthropic-ai/sdk'],
       matchUpdateTypes: ['minor'],
       automerge: true,
+      dependencyDashboardApproval: false,
     },
     {
       description: 'Enable SemVer digest pinning of bfra.me Renovate config presets.',

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "lint-staged": {
     "*.{js,json,jsx,md,toml,ts,tsx,yml,yaml}": [
-      "eslint --flag v10_config_lookup_from_file --fix --ignore-pattern 'packages/create/templates/**' --no-warn-ignored"
+      "eslint --flag v10_config_lookup_from_file --fix --ignore-pattern 'packages/create/templates/**' --ignore-pattern '**/fixtures/input/**' --no-warn-ignored"
     ]
   },
   "prettier": "@bfra.me/prettier-config/prettier.config",

--- a/packages/eslint-config/src/configs/sort.ts
+++ b/packages/eslint-config/src/configs/sort.ts
@@ -100,9 +100,9 @@ export async function sortRenovateConfig(): Promise<Config[]> {
         'jsonc/sort-array-values': [
           'error',
           {
-            // Don't sort 'extends' arrays, as order matters
+            // Don't sort 'extends' or 'postUpgradeTasks.commands' arrays, as order matters
             order: {type: 'asc'},
-            pathPattern: '^(?!extends$).*',
+            pathPattern: '^(?!extends$|postUpgradeTasks\.commands$).*',
           },
         ],
         'jsonc/sort-keys': [

--- a/packages/eslint-config/test/fixtures/input/renovate.json5
+++ b/packages/eslint-config/test/fixtures/input/renovate.json5
@@ -1,0 +1,19 @@
+{
+  "extends": [
+    "github>bfra-me/renovate-config#v4",
+    "github>sanity-io/renovate-config:semantic-commit-type",
+    "security:openssf-scorecard",
+    "npm:unpublishSafe"
+  ],
+  postUpgradeTasks: {
+    "commands": [
+      "pnpm test",
+      "pnpm lint:fix",
+    ],
+    "fileFilters": [
+      "packages/eslint-config/**",
+      "packages/create/**"
+    ]
+  },
+  $schema: 'https://docs.renovatebot.com/renovate-schema.json',
+}

--- a/packages/eslint-config/test/fixtures/output/all/renovate.json5
+++ b/packages/eslint-config/test/fixtures/output/all/renovate.json5
@@ -1,0 +1,13 @@
+{
+  $schema: 'https://docs.renovatebot.com/renovate-schema.json',
+  extends: [
+    'github>bfra-me/renovate-config#v4',
+    'github>sanity-io/renovate-config:semantic-commit-type',
+    'security:openssf-scorecard',
+    'npm:unpublishSafe',
+  ],
+  postUpgradeTasks: {
+    commands: ['pnpm test', 'pnpm lint:fix'],
+    fileFilters: ['packages/create/**', 'packages/eslint-config/**'],
+  },
+}

--- a/packages/eslint-config/test/fixtures/output/default/renovate.json5
+++ b/packages/eslint-config/test/fixtures/output/default/renovate.json5
@@ -1,0 +1,13 @@
+{
+  $schema: 'https://docs.renovatebot.com/renovate-schema.json',
+  extends: [
+    'github>bfra-me/renovate-config#v4',
+    'github>sanity-io/renovate-config:semantic-commit-type',
+    'security:openssf-scorecard',
+    'npm:unpublishSafe',
+  ],
+  postUpgradeTasks: {
+    commands: ['pnpm test', 'pnpm lint:fix'],
+    fileFilters: ['packages/create/**', 'packages/eslint-config/**'],
+  },
+}

--- a/packages/eslint-config/test/fixtures/output/js/renovate.json5
+++ b/packages/eslint-config/test/fixtures/output/js/renovate.json5
@@ -1,0 +1,13 @@
+{
+  $schema: 'https://docs.renovatebot.com/renovate-schema.json',
+  extends: [
+    'github>bfra-me/renovate-config#v4',
+    'github>sanity-io/renovate-config:semantic-commit-type',
+    'security:openssf-scorecard',
+    'npm:unpublishSafe',
+  ],
+  postUpgradeTasks: {
+    commands: ['pnpm test', 'pnpm lint:fix'],
+    fileFilters: ['packages/create/**', 'packages/eslint-config/**'],
+  },
+}

--- a/packages/eslint-config/test/fixtures/output/no-prettier/renovate.json5
+++ b/packages/eslint-config/test/fixtures/output/no-prettier/renovate.json5
@@ -1,0 +1,19 @@
+{
+  $schema: 'https://docs.renovatebot.com/renovate-schema.json',
+  "extends": [
+    "github>bfra-me/renovate-config#v4",
+    "github>sanity-io/renovate-config:semantic-commit-type",
+    "security:openssf-scorecard",
+    "npm:unpublishSafe"
+  ],
+  postUpgradeTasks: {
+    "commands": [
+      "pnpm test",
+      "pnpm lint:fix",
+    ],
+    "fileFilters": [
+      "packages/create/**",
+      "packages/eslint-config/**"
+    ]
+  },
+}

--- a/packages/eslint-config/test/fixtures/output/ts-override/renovate.json5
+++ b/packages/eslint-config/test/fixtures/output/ts-override/renovate.json5
@@ -1,0 +1,13 @@
+{
+  $schema: 'https://docs.renovatebot.com/renovate-schema.json',
+  extends: [
+    'github>bfra-me/renovate-config#v4',
+    'github>sanity-io/renovate-config:semantic-commit-type',
+    'security:openssf-scorecard',
+    'npm:unpublishSafe',
+  ],
+  postUpgradeTasks: {
+    commands: ['pnpm test', 'pnpm lint:fix'],
+    fileFilters: ['packages/create/**', 'packages/eslint-config/**'],
+  },
+}

--- a/packages/eslint-config/test/fixtures/output/ts-strict-with-react/renovate.json5
+++ b/packages/eslint-config/test/fixtures/output/ts-strict-with-react/renovate.json5
@@ -1,0 +1,13 @@
+{
+  $schema: 'https://docs.renovatebot.com/renovate-schema.json',
+  extends: [
+    'github>bfra-me/renovate-config#v4',
+    'github>sanity-io/renovate-config:semantic-commit-type',
+    'security:openssf-scorecard',
+    'npm:unpublishSafe',
+  ],
+  postUpgradeTasks: {
+    commands: ['pnpm test', 'pnpm lint:fix'],
+    fileFilters: ['packages/create/**', 'packages/eslint-config/**'],
+  },
+}

--- a/packages/eslint-config/test/fixtures/output/ts-strict/renovate.json5
+++ b/packages/eslint-config/test/fixtures/output/ts-strict/renovate.json5
@@ -1,0 +1,13 @@
+{
+  $schema: 'https://docs.renovatebot.com/renovate-schema.json',
+  extends: [
+    'github>bfra-me/renovate-config#v4',
+    'github>sanity-io/renovate-config:semantic-commit-type',
+    'security:openssf-scorecard',
+    'npm:unpublishSafe',
+  ],
+  postUpgradeTasks: {
+    commands: ['pnpm test', 'pnpm lint:fix'],
+    fileFilters: ['packages/create/**', 'packages/eslint-config/**'],
+  },
+}


### PR DESCRIPTION
- Add Renovate configuration files for various setups.
- Update ESLint commands to include additional ignore patterns.
- Ensure `postUpgradeTasks.commands` arrays are not sorted in Renovate configs.