### PR TITLE
fix(eslint-config): rename Next.js plugin to `@next/next`

### DIFF
--- a/.changeset/bumpy-rings-beg.md
+++ b/.changeset/bumpy-rings-beg.md
@@ -1,0 +1,6 @@
+---
+"@bfra.me/eslint-config": patch
+---
+
+Rename the Next.js plugin to `@next/next` for compatibility with existing setups.
+  

--- a/packages/eslint-config/src/configs/nextjs.ts
+++ b/packages/eslint-config/src/configs/nextjs.ts
@@ -40,7 +40,7 @@ export async function nextjs(options: NextjsOptions = {}): Promise<Config[]> {
       return [
         {
           name: '@bfra.me/nextjs/setup',
-          plugins: {next: pluginNextJs},
+          plugins: {'@next/next': pluginNextJs},
         },
         {
           name: '@bfra.me/nextjs/rules',

--- a/packages/eslint-config/src/rules.d.ts
+++ b/packages/eslint-config/src/rules.d.ts
@@ -10,6 +10,110 @@ export interface Rules {
    */
   '@bfra.me/missing-module-for-config'?: Linter.RuleEntry<BfraMeMissingModuleForConfig>
   /**
+   * Enforce font-display behavior with Google Fonts.
+   * @see https://nextjs.org/docs/messages/google-font-display
+   */
+  '@next/next/google-font-display'?: Linter.RuleEntry<[]>
+  /**
+   * Ensure `preconnect` is used with Google Fonts.
+   * @see https://nextjs.org/docs/messages/google-font-preconnect
+   */
+  '@next/next/google-font-preconnect'?: Linter.RuleEntry<[]>
+  /**
+   * Enforce `id` attribute on `next/script` components with inline content.
+   * @see https://nextjs.org/docs/messages/inline-script-id
+   */
+  '@next/next/inline-script-id'?: Linter.RuleEntry<[]>
+  /**
+   * Prefer `next/script` component when using the inline script for Google Analytics.
+   * @see https://nextjs.org/docs/messages/next-script-for-ga
+   */
+  '@next/next/next-script-for-ga'?: Linter.RuleEntry<[]>
+  /**
+   * Prevent assignment to the `module` variable.
+   * @see https://nextjs.org/docs/messages/no-assign-module-variable
+   */
+  '@next/next/no-assign-module-variable'?: Linter.RuleEntry<[]>
+  /**
+   * Prevent Client Components from being async functions.
+   * @see https://nextjs.org/docs/messages/no-async-client-component
+   */
+  '@next/next/no-async-client-component'?: Linter.RuleEntry<[]>
+  /**
+   * Prevent usage of `next/script`'s `beforeInteractive` strategy outside of `pages/_document.js`.
+   * @see https://nextjs.org/docs/messages/no-before-interactive-script-outside-document
+   */
+  '@next/next/no-before-interactive-script-outside-document'?: Linter.RuleEntry<[]>
+  /**
+   * Prevent manual stylesheet tags.
+   * @see https://nextjs.org/docs/messages/no-css-tags
+   */
+  '@next/next/no-css-tags'?: Linter.RuleEntry<[]>
+  /**
+   * Prevent importing `next/document` outside of `pages/_document.js`.
+   * @see https://nextjs.org/docs/messages/no-document-import-in-page
+   */
+  '@next/next/no-document-import-in-page'?: Linter.RuleEntry<[]>
+  /**
+   * Prevent duplicate usage of `<Head>` in `pages/_document.js`.
+   * @see https://nextjs.org/docs/messages/no-duplicate-head
+   */
+  '@next/next/no-duplicate-head'?: Linter.RuleEntry<[]>
+  /**
+   * Prevent usage of `<head>` element.
+   * @see https://nextjs.org/docs/messages/no-head-element
+   */
+  '@next/next/no-head-element'?: Linter.RuleEntry<[]>
+  /**
+   * Prevent usage of `next/head` in `pages/_document.js`.
+   * @see https://nextjs.org/docs/messages/no-head-import-in-document
+   */
+  '@next/next/no-head-import-in-document'?: Linter.RuleEntry<[]>
+  /**
+   * Prevent usage of `<a>` elements to navigate to internal Next.js pages.
+   * @see https://nextjs.org/docs/messages/no-html-link-for-pages
+   */
+  '@next/next/no-html-link-for-pages'?: Linter.RuleEntry<NextNextNoHtmlLinkForPages>
+  /**
+   * Prevent usage of `<img>` element due to slower LCP and higher bandwidth.
+   * @see https://nextjs.org/docs/messages/no-img-element
+   */
+  '@next/next/no-img-element'?: Linter.RuleEntry<[]>
+  /**
+   * Prevent page-only custom fonts.
+   * @see https://nextjs.org/docs/messages/no-page-custom-font
+   */
+  '@next/next/no-page-custom-font'?: Linter.RuleEntry<[]>
+  /**
+   * Prevent usage of `next/script` in `next/head` component.
+   * @see https://nextjs.org/docs/messages/no-script-component-in-head
+   */
+  '@next/next/no-script-component-in-head'?: Linter.RuleEntry<[]>
+  /**
+   * Prevent usage of `styled-jsx` in `pages/_document.js`.
+   * @see https://nextjs.org/docs/messages/no-styled-jsx-in-document
+   */
+  '@next/next/no-styled-jsx-in-document'?: Linter.RuleEntry<[]>
+  /**
+   * Prevent synchronous scripts.
+   * @see https://nextjs.org/docs/messages/no-sync-scripts
+   */
+  '@next/next/no-sync-scripts'?: Linter.RuleEntry<[]>
+  /**
+   * Prevent usage of `<title>` with `Head` component from `next/document`.
+   * @see https://nextjs.org/docs/messages/no-title-in-document-head
+   */
+  '@next/next/no-title-in-document-head'?: Linter.RuleEntry<[]>
+  /**
+   * Prevent common typos in Next.js data fetching functions.
+   */
+  '@next/next/no-typos'?: Linter.RuleEntry<[]>
+  /**
+   * Prevent duplicate polyfills from Polyfill.io.
+   * @see https://nextjs.org/docs/messages/no-unwanted-polyfillio
+   */
+  '@next/next/no-unwanted-polyfillio'?: Linter.RuleEntry<[]>
+  /**
    * Require that function overload signatures be consecutive
    * @see https://typescript-eslint.io/rules/adjacent-overload-signatures
    */
@@ -2257,110 +2361,6 @@ export interface Rules {
    * @deprecated
    */
   'newline-per-chained-call'?: Linter.RuleEntry<NewlinePerChainedCall>
-  /**
-   * Enforce font-display behavior with Google Fonts.
-   * @see https://nextjs.org/docs/messages/google-font-display
-   */
-  'next/google-font-display'?: Linter.RuleEntry<[]>
-  /**
-   * Ensure `preconnect` is used with Google Fonts.
-   * @see https://nextjs.org/docs/messages/google-font-preconnect
-   */
-  'next/google-font-preconnect'?: Linter.RuleEntry<[]>
-  /**
-   * Enforce `id` attribute on `next/script` components with inline content.
-   * @see https://nextjs.org/docs/messages/inline-script-id
-   */
-  'next/inline-script-id'?: Linter.RuleEntry<[]>
-  /**
-   * Prefer `next/script` component when using the inline script for Google Analytics.
-   * @see https://nextjs.org/docs/messages/next-script-for-ga
-   */
-  'next/next-script-for-ga'?: Linter.RuleEntry<[]>
-  /**
-   * Prevent assignment to the `module` variable.
-   * @see https://nextjs.org/docs/messages/no-assign-module-variable
-   */
-  'next/no-assign-module-variable'?: Linter.RuleEntry<[]>
-  /**
-   * Prevent Client Components from being async functions.
-   * @see https://nextjs.org/docs/messages/no-async-client-component
-   */
-  'next/no-async-client-component'?: Linter.RuleEntry<[]>
-  /**
-   * Prevent usage of `next/script`'s `beforeInteractive` strategy outside of `pages/_document.js`.
-   * @see https://nextjs.org/docs/messages/no-before-interactive-script-outside-document
-   */
-  'next/no-before-interactive-script-outside-document'?: Linter.RuleEntry<[]>
-  /**
-   * Prevent manual stylesheet tags.
-   * @see https://nextjs.org/docs/messages/no-css-tags
-   */
-  'next/no-css-tags'?: Linter.RuleEntry<[]>
-  /**
-   * Prevent importing `next/document` outside of `pages/_document.js`.
-   * @see https://nextjs.org/docs/messages/no-document-import-in-page
-   */
-  'next/no-document-import-in-page'?: Linter.RuleEntry<[]>
-  /**
-   * Prevent duplicate usage of `<Head>` in `pages/_document.js`.
-   * @see https://nextjs.org/docs/messages/no-duplicate-head
-   */
-  'next/no-duplicate-head'?: Linter.RuleEntry<[]>
-  /**
-   * Prevent usage of `<head>` element.
-   * @see https://nextjs.org/docs/messages/no-head-element
-   */
-  'next/no-head-element'?: Linter.RuleEntry<[]>
-  /**
-   * Prevent usage of `next/head` in `pages/_document.js`.
-   * @see https://nextjs.org/docs/messages/no-head-import-in-document
-   */
-  'next/no-head-import-in-document'?: Linter.RuleEntry<[]>
-  /**
-   * Prevent usage of `<a>` elements to navigate to internal Next.js pages.
-   * @see https://nextjs.org/docs/messages/no-html-link-for-pages
-   */
-  'next/no-html-link-for-pages'?: Linter.RuleEntry<NextNoHtmlLinkForPages>
-  /**
-   * Prevent usage of `<img>` element due to slower LCP and higher bandwidth.
-   * @see https://nextjs.org/docs/messages/no-img-element
-   */
-  'next/no-img-element'?: Linter.RuleEntry<[]>
-  /**
-   * Prevent page-only custom fonts.
-   * @see https://nextjs.org/docs/messages/no-page-custom-font
-   */
-  'next/no-page-custom-font'?: Linter.RuleEntry<[]>
-  /**
-   * Prevent usage of `next/script` in `next/head` component.
-   * @see https://nextjs.org/docs/messages/no-script-component-in-head
-   */
-  'next/no-script-component-in-head'?: Linter.RuleEntry<[]>
-  /**
-   * Prevent usage of `styled-jsx` in `pages/_document.js`.
-   * @see https://nextjs.org/docs/messages/no-styled-jsx-in-document
-   */
-  'next/no-styled-jsx-in-document'?: Linter.RuleEntry<[]>
-  /**
-   * Prevent synchronous scripts.
-   * @see https://nextjs.org/docs/messages/no-sync-scripts
-   */
-  'next/no-sync-scripts'?: Linter.RuleEntry<[]>
-  /**
-   * Prevent usage of `<title>` with `Head` component from `next/document`.
-   * @see https://nextjs.org/docs/messages/no-title-in-document-head
-   */
-  'next/no-title-in-document-head'?: Linter.RuleEntry<[]>
-  /**
-   * Prevent common typos in Next.js data fetching functions.
-   */
-  'next/no-typos'?: Linter.RuleEntry<[]>
-  /**
-   * Prevent duplicate polyfills from Polyfill.io.
-   * @see https://nextjs.org/docs/messages/no-unwanted-polyfillio
-   */
-  'next/no-unwanted-polyfillio'?: Linter.RuleEntry<[]>
   /**
    * Disallow the use of `alert`, `confirm`, and `prompt`
    * @see https://eslint.org/docs/latest/rules/no-alert
@@ -6132,6 +6132,8 @@ export interface Rules {
 /* ======= Declarations ======= */
 // ----- @bfra.me/missing-module-for-config -----
 type BfraMeMissingModuleForConfig = []|[string[]]
+// ----- @next/next/no-html-link-for-pages -----
+type NextNextNoHtmlLinkForPages = []|[(string | string[])]
 // ----- @typescript-eslint/array-type -----
 type TypescriptEslintArrayType = []|[{
   
@@ -9232,8 +9234,6 @@ type NewlineAfterVar = []|[("never" | "always")]
 type NewlinePerChainedCall = []|[{
   ignoreChainWithDepth?: number
 }]
-// ----- next/no-html-link-for-pages -----
-type NextNoHtmlLinkForPages = []|[(string | string[])]
 // ----- no-bitwise -----
 type NoBitwise = []|[{
   allow?: ("^" | "|" | "&" | "<<" | ">>" | ">>>" | "^=" | "|=" | "&=" | "<<=" | ">>=" | ">>>=" | "~")[]


### PR DESCRIPTION
- Rename the Next.js plugin to `@next/next` for compatibility with existing setups.
- Add new ESLint rules for Next.js to enhance linting capabilities.