### PR TITLE
fix(eslint-config): update JSONC and stylistic rules for consistency

### DIFF
--- a/.changeset/real-months-enter.md
+++ b/.changeset/real-months-enter.md
@@ -1,0 +1,6 @@
+---
+"@bfra.me/eslint-config": minor
+---
+
+Disable Stylistic options if Prettier is enabled and get Stylistic options closely matching Prettier config.
+  

--- a/packages/eslint-config/src/configs/jsonc.ts
+++ b/packages/eslint-config/src/configs/jsonc.ts
@@ -77,7 +77,7 @@ export async function jsonc(options: JsoncOptions = {}): Promise<Config[]> {
                   'jsonc/indent': ['error', indent],
                   'jsonc/key-spacing': ['error', {afterColon: true, beforeColon: false}],
                   'jsonc/object-curly-newline': ['error', {consistent: true, multiline: true}],
-                  'jsonc/object-curly-spacing': ['error', 'always'],
+                  'jsonc/object-curly-spacing': ['error', 'never'],
                   'jsonc/object-property-newline': ['error', {allowAllPropertiesOnSameLine: true}],
                   'jsonc/quote-props': 'error',
                   'jsonc/quotes': 'error',

--- a/packages/eslint-config/src/configs/stylistic.ts
+++ b/packages/eslint-config/src/configs/stylistic.ts
@@ -49,7 +49,28 @@ export async function stylistic(options: StylisticOptions = {}): Promise<Config[
       rules: {
         ...config.rules,
 
+        '@stylistic/arrow-parens': ['error', 'as-needed'],
+        '@stylistic/brace-style': ['error', '1tbs', {allowSingleLine: true}],
         '@stylistic/generator-star-spacing': ['error', {after: true, before: false}],
+        '@stylistic/member-delimiter-style': [
+          'error',
+          {
+            multiline: {delimiter: 'none', requireLast: false},
+            singleline: {delimiter: 'semi', requireLast: false},
+          },
+        ],
+        '@stylistic/object-curly-spacing': ['error', 'never'],
+        '@stylistic/operator-linebreak': [
+          'error',
+          'after',
+          {overrides: {':': 'before', '?': 'before', '|': 'before'}},
+        ],
+        '@stylistic/quote-props': ['error', 'as-needed'],
+        '@stylistic/quotes': [
+          'error',
+          quotes,
+          {allowTemplateLiterals: 'always', avoidEscape: true},
+        ],
         '@stylistic/yield-star-spacing': ['error', {after: true, before: false}],
 
         ...overrides,

--- a/packages/eslint-config/src/define-config.ts
+++ b/packages/eslint-config/src/define-config.ts
@@ -86,7 +86,7 @@ export async function defineConfig<C extends Config = Config, CN extends ConfigN
     )
 
   const stylisticOptions =
-    options.stylistic === false
+    options.stylistic === false || enablePrettier
       ? false
       : typeof options.stylistic === 'object'
         ? options.stylistic

--- a/packages/eslint-config/test/fixtures/output/all/tsx.tsx
+++ b/packages/eslint-config/test/fixtures/output/all/tsx.tsx
@@ -5,7 +5,7 @@ export function Component1() {
 export function jsx2() {
   const props = {a: 1, b: 2}
   return (
-    <a foo="bar" bar="foo">
+    <a foo="bar" bar={`foo`}>
       <div {...props} a={1} b="2">
         Inline Text
       </div>

--- a/packages/eslint-config/test/fixtures/output/all/typescript.ts
+++ b/packages/eslint-config/test/fixtures/output/all/typescript.ts
@@ -55,7 +55,6 @@ class Animal {
   constructor(name: string) {
     this.name = name
   }
-
   protected makeSound(sound: string) {
     log(`${this.name} says ${sound}`)
   }
@@ -66,7 +65,6 @@ class Dog extends Animal {
   constructor(private alias: string) {
     super(alias)
   }
-
   bark() {
     this.makeSound('Woof!')
   }

--- a/packages/eslint-config/test/fixtures/output/default/tsx.tsx
+++ b/packages/eslint-config/test/fixtures/output/default/tsx.tsx
@@ -5,7 +5,7 @@ export function Component1() {
 export function jsx2() {
   const props = {a: 1, b: 2}
   return (
-    <a foo="bar" bar="foo">
+    <a foo="bar" bar={`foo`}>
       <div {...props} a={1} b="2">
         Inline Text
       </div>

--- a/packages/eslint-config/test/fixtures/output/default/typescript.ts
+++ b/packages/eslint-config/test/fixtures/output/default/typescript.ts
@@ -55,7 +55,6 @@ class Animal {
   constructor(name: string) {
     this.name = name
   }
-
   protected makeSound(sound: string) {
     log(`${this.name} says ${sound}`)
   }
@@ -66,7 +65,6 @@ class Dog extends Animal {
   constructor(private alias: string) {
     super(alias)
   }
-
   bark() {
     this.makeSound('Woof!')
   }

--- a/packages/eslint-config/test/fixtures/output/js/tsx.tsx
+++ b/packages/eslint-config/test/fixtures/output/js/tsx.tsx
@@ -5,7 +5,7 @@ export function Component1() {
 export function jsx2() {
   const props = {a: 1, b: 2}
   return (
-    <a foo="bar" bar="foo">
+    <a foo="bar" bar={`foo`}>
       <div {...props} a={1} b="2">
         Inline Text
       </div>

--- a/packages/eslint-config/test/fixtures/output/ts-override/tsx.tsx
+++ b/packages/eslint-config/test/fixtures/output/ts-override/tsx.tsx
@@ -5,7 +5,7 @@ export function Component1() {
 export function jsx2() {
   const props = {a: 1, b: 2}
   return (
-    <a foo="bar" bar="foo">
+    <a foo="bar" bar={`foo`}>
       <div {...props} a={1} b="2">
         Inline Text
       </div>

--- a/packages/eslint-config/test/fixtures/output/ts-override/typescript.ts
+++ b/packages/eslint-config/test/fixtures/output/ts-override/typescript.ts
@@ -55,7 +55,6 @@ class Animal {
   constructor(name: string) {
     this.name = name
   }
-
   protected makeSound(sound: string) {
     log(`${this.name} says ${sound}`)
   }
@@ -66,7 +65,6 @@ class Dog extends Animal {
   constructor(private alias: string) {
     super(alias)
   }
-
   bark() {
     this.makeSound('Woof!')
   }

--- a/packages/eslint-config/test/fixtures/output/ts-strict-with-react/tsx.tsx
+++ b/packages/eslint-config/test/fixtures/output/ts-strict-with-react/tsx.tsx
@@ -5,7 +5,7 @@ export function Component1() {
 export function jsx2() {
   const props = {a: 1, b: 2}
   return (
-    <a foo="bar" bar="foo">
+    <a foo="bar" bar={`foo`}>
       <div {...props} a={1} b="2">
         Inline Text
       </div>

--- a/packages/eslint-config/test/fixtures/output/ts-strict-with-react/typescript.ts
+++ b/packages/eslint-config/test/fixtures/output/ts-strict-with-react/typescript.ts
@@ -55,7 +55,6 @@ class Animal {
   constructor(name: string) {
     this.name = name
   }
-
   protected makeSound(sound: string) {
     log(`${this.name} says ${sound}`)
   }
@@ -66,7 +65,6 @@ class Dog extends Animal {
   constructor(private readonly alias: string) {
     super(alias)
   }
-
   bark() {
     this.makeSound('Woof!')
   }

--- a/packages/eslint-config/test/fixtures/output/ts-strict/tsx.tsx
+++ b/packages/eslint-config/test/fixtures/output/ts-strict/tsx.tsx
@@ -5,7 +5,7 @@ export function Component1() {
 export function jsx2() {
   const props = {a: 1, b: 2}
   return (
-    <a foo="bar" bar="foo">
+    <a foo="bar" bar={`foo`}>
       <div {...props} a={1} b="2">
         Inline Text
       </div>

--- a/packages/eslint-config/test/fixtures/output/ts-strict/typescript.ts
+++ b/packages/eslint-config/test/fixtures/output/ts-strict/typescript.ts
@@ -55,7 +55,6 @@ class Animal {
   constructor(name: string) {
     this.name = name
   }
-
   protected makeSound(sound: string) {
     log(`${this.name} says ${sound}`)
   }
@@ -66,7 +65,6 @@ class Dog extends Animal {
   constructor(private readonly alias: string) {
     super(alias)
   }
-
   bark() {
     this.makeSound('Woof!')
   }

--- a/packages/eslint-config/test/types.ts
+++ b/packages/eslint-config/test/types.ts
@@ -2,5 +2,6 @@ import type {Linter} from 'eslint'
 import type {Config} from '../src'
 
 // Make sure they are compatible
+// eslint-disable-next-line import-x/newline-after-import
 ;((): Linter.Config => ({}) as Config)()
 ;((): Config => ({}) as Linter.Config)()


### PR DESCRIPTION
- Change 'jsonc/object-curly-spacing' rule to 'never' for JSONC files.
- Add new stylistic rules for arrow-parens, brace-style, member-delimiter-style, object-curly-spacing, operator-linebreak, and quote-props.
- Adjust stylistic options handling in defineConfig to support Prettier integration.
- Ensure compatibility checks in types.ts are properly commented.