### PR TITLE
chore(eslint-config): remove `require()` shim and `external` config.

### DIFF
--- a/.changeset/cool-mangos-change.md
+++ b/.changeset/cool-mangos-change.md
@@ -1,0 +1,6 @@
+---
+"@bfra.me/eslint-config": minor
+---
+
+Remove `require()` shim and `external` config.
+  

--- a/packages/eslint-config/tsup.config.ts
+++ b/packages/eslint-config/tsup.config.ts
@@ -1,13 +1,9 @@
 import {defineConfig} from 'tsup'
 
 export default defineConfig({
-  banner: {
-    js: "import {createRequire} from 'node:module';const require=createRequire(import.meta.url);",
-  },
   clean: true,
   dts: true,
   entry: ['src/index.ts'],
-  external: ['eslint-config-prettier', 'eslint-plugin-prettier'],
   format: ['esm'],
   outDir: 'lib',
   sourcemap: true,


### PR DESCRIPTION
- Remove banner configuration for module loading.
- Remove external dependencies from the build configuration.