### PR TITLE
ci(docs): replace `withastro/action` with direct build and upload

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -18,17 +18,26 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - name: Checkout repository
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - name: Prepare job
+        uses: ./.github/actions/pnpm-install
+
       - id: vars
         run: |
           short_sha=$(git rev-parse --short ${{ github.sha }})
           echo "SHORT_SHA=$short_sha" >> $GITHUB_OUTPUT
-      - uses: withastro/action@a4407e937037e68022f04ae1c068d3634f08bc8d # v4.2.1
+
+      - name: Build Docs
         env:
           PUBLIC_COMMIT_HASH: ${{ steps.vars.outputs.SHORT_SHA }}
+        run: pnpm --filter docs run build
+
+      - name: Upload Pages Artifact
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
         with:
-          package-manager: pnpm@latest
-          path: docs
+          path: docs/dist/
 
   deploy:
     needs: build


### PR DESCRIPTION
- Rename steps for clarity in the build job
- Update artifact upload path to 'docs/dist/'