### PR TITLE
ci(main): replace validate step with pretest in prepare job

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -29,8 +29,8 @@ jobs:
       - name: Prepare job
         uses: ./.github/actions/pnpm-install
 
-      - name: Validate
-        run: pnpm run validate
+      - name: Pretest
+        run: pnpm run pretest
 
   lint:
     name: Lint


### PR DESCRIPTION
- Replace the 'Validate' step with 'Pretest' in the CI workflow.