### PR TITLE
feat(eslint-config): integrate eslint-plugin-erasable-syntax-only

### DIFF
--- a/.changeset/sparkly-monkeys-wonder.md
+++ b/.changeset/sparkly-monkeys-wonder.md
@@ -1,0 +1,6 @@
+---
+"@bfra.me/eslint-config": minor
+---
+
+Integrate the `eslint-plugin-erasable-syntax-only` plugin.
+  

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -86,6 +86,7 @@
     "eslint": "9.39.1",
     "eslint-config-prettier": "10.1.8",
     "eslint-plugin-astro": "1.5.0",
+    "eslint-plugin-erasable-syntax-only": "0.4.0",
     "eslint-plugin-node-dependencies": "1.2.0",
     "eslint-plugin-pnpm": "1.3.0",
     "eslint-plugin-prettier": "5.5.4",

--- a/packages/eslint-config/scripts/generate-types.ts
+++ b/packages/eslint-config/scripts/generate-types.ts
@@ -14,7 +14,10 @@ const configs = await composeConfig(
   },
   ...Object.values(allConfigs).map(async f => {
     if (f === allConfigs.typescript) {
-      return (f as typeof allConfigs.typescript)({tsconfigPath: './tsconfig.json'})
+      return (f as typeof allConfigs.typescript)({
+        erasableSyntaxOnly: true,
+        tsconfigPath: './tsconfig.json',
+      })
     }
     return f()
   }),

--- a/packages/eslint-config/src/config.d.ts
+++ b/packages/eslint-config/src/config.d.ts
@@ -85,6 +85,7 @@ export type ConfigNames =
   | '@bfra.me/typescript/parser'
   | '@bfra.me/typescript/rules'
   | '@bfra.me/typescript/type-aware-rules'
+  | '@bfra.me/typescript/erasable-syntax-only'
   | '@bfra.me/unicorn'
   | '@bfra.me/vitest/plugins'
   | '@bfra.me/vitest'

--- a/packages/eslint-config/src/options.ts
+++ b/packages/eslint-config/src/options.ts
@@ -73,6 +73,22 @@ export interface OptionsPerfectionist {
 }
 
 /**
+ * Provides an option to enable erasable syntax only rules in the ESLint configuration.
+ * When `erasableSyntaxOnly` is set to `true`, the ESLint configuration will include
+ * rules from the `eslint-plugin-erasable-syntax-only` plugin, which focuses on enforcing
+ * syntax that can be safely removed without affecting the program's behavior.
+ */
+export interface OptionsTypeScriptErasableSyntaxOnly {
+  /**
+   * Enable erasable syntax only rules.
+   *
+   * @see https://github.com/JoshuaKGoldberg/eslint-plugin-erasable-syntax-only
+   * @default false
+   */
+  erasableSyntaxOnly?: boolean
+}
+
+/**
  * Provides options to configure the TypeScript parser and type-aware linting rules.
  *
  * The `parserOptions` property allows specifying additional options to be passed to the TypeScript parser.
@@ -129,8 +145,8 @@ export interface OptionsTypeScriptWithTypes {
  * Represents the options for configuring TypeScript support in the ESLint configuration.
  */
 export type OptionsTypeScript =
-  | (OptionsTypeScriptParserOptions & OptionsOverrides)
-  | (OptionsTypeScriptWithTypes & OptionsOverrides)
+  | (OptionsTypeScriptParserOptions & OptionsOverrides & OptionsTypeScriptErasableSyntaxOnly)
+  | (OptionsTypeScriptWithTypes & OptionsOverrides & OptionsTypeScriptErasableSyntaxOnly)
 
 export interface OptionsStylistic {
   stylistic?: boolean | StylisticConfig

--- a/packages/eslint-config/src/rules.d.ts
+++ b/packages/eslint-config/src/rules.d.ts
@@ -1702,6 +1702,26 @@ export interface Rules {
    */
   'eqeqeq'?: Linter.RuleEntry<Eqeqeq>
   /**
+   * Avoid using TypeScript's enums.
+   * @see https://github.com/JoshuaKGoldberg/eslint-plugin-erasable-syntax-only/blob/main/docs/rules/enums.md
+   */
+  'erasable-syntax-only/enums'?: Linter.RuleEntry<[]>
+  /**
+   * Avoid using TypeScript's import aliases.
+   * @see https://github.com/JoshuaKGoldberg/eslint-plugin-erasable-syntax-only/blob/main/docs/rules/import-aliases.md
+   */
+  'erasable-syntax-only/import-aliases'?: Linter.RuleEntry<[]>
+  /**
+   * Avoid using TypeScript's namespaces.
+   * @see https://github.com/JoshuaKGoldberg/eslint-plugin-erasable-syntax-only/blob/main/docs/rules/namespaces.md
+   */
+  'erasable-syntax-only/namespaces'?: Linter.RuleEntry<[]>
+  /**
+   * Avoid using TypeScript's class parameter properties.
+   * @see https://github.com/JoshuaKGoldberg/eslint-plugin-erasable-syntax-only/blob/main/docs/rules/parameter-properties.md
+   */
+  'erasable-syntax-only/parameter-properties'?: Linter.RuleEntry<[]>
+  /**
    * require a `eslint-enable` comment for every `eslint-disable` comment
    * @see https://eslint-community.github.io/eslint-plugin-eslint-comments/rules/disable-enable-pair.html
    */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -299,6 +299,9 @@ importers:
       eslint-plugin-astro:
         specifier: 1.5.0
         version: 1.5.0(eslint@9.39.1(jiti@2.6.1))
+      eslint-plugin-erasable-syntax-only:
+        specifier: 0.4.0
+        version: 0.4.0(@typescript-eslint/parser@8.46.4(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
       eslint-plugin-node-dependencies:
         specifier: 1.2.0
         version: 1.2.0(eslint@9.39.1(jiti@2.6.1))
@@ -2074,6 +2077,10 @@ packages:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
 
+  cached-factory@0.1.0:
+    resolution: {integrity: sha512-IGOSWu+NuED5UzCRmBeqQPZ8z7SkgrD/nN67W2iY1Qv83CVhevyMexkGclJ86saXisIqxoOnbeiTWvsCHRqJBw==}
+    engines: {node: '>=18'}
+
   callsites@3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
@@ -2577,6 +2584,14 @@ packages:
     resolution: {integrity: sha512-fBVTXQ2y48TVLT0+4A6PFINp7GcdIailHAXbvPBixE7x+YpYnNQhFZxTdvnb+aWk+COgNebQKen/7m4dmgyWAw==}
     peerDependencies:
       eslint: '*'
+
+  eslint-plugin-erasable-syntax-only@0.4.0:
+    resolution: {integrity: sha512-7dx2gpfVn0FFEGukLqsF/izW4hGvSaySNOkcuSCO4q6Khh0ecOGYlRhW9hhDUtNryuKc+cXd1WFiQdpae3xzaQ==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      '@typescript-eslint/parser': '>=8'
+      eslint: '>=9'
+      typescript: '>=5'
 
   eslint-plugin-es-x@7.8.0:
     resolution: {integrity: sha512-7Ds8+wAAoV3T+LAKeu39Y5BzXCrGKrcISfgKEqTS4BDN8SFEDQd0S43jiQ8vIa3wUKD07qitZdfzlenSi8/0qQ==}
@@ -7749,6 +7764,8 @@ snapshots:
 
   cac@6.7.14: {}
 
+  cached-factory@0.1.0: {}
+
   callsites@3.1.0: {}
 
   camelcase@8.0.0: {}
@@ -8192,6 +8209,16 @@ snapshots:
     dependencies:
       '@es-joy/jsdoccomment': 0.50.2
       eslint: 9.39.1(jiti@2.6.1)
+
+  eslint-plugin-erasable-syntax-only@0.4.0(@typescript-eslint/parser@8.46.4(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3):
+    dependencies:
+      '@typescript-eslint/parser': 8.46.4(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.46.4(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
+      cached-factory: 0.1.0
+      eslint: 9.39.1(jiti@2.6.1)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
 
   eslint-plugin-es-x@7.8.0(eslint@9.39.1(jiti@2.6.1)):
     dependencies:


### PR DESCRIPTION
- Add eslint-plugin-erasable-syntax-only as a dependency.
- Update ESLint configuration to support erasable syntax only rules.
- Extend TypeScript options to include erasable syntax only settings.
- Modify rules to include new rules from the erasable syntax only plugin.