### PR TITLE
feat(scripts): modify `clean-changesets` to remove empty changesets

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -326,6 +326,9 @@ importers:
 
   scripts:
     dependencies:
+      '@changesets/parse':
+        specifier: 0.4.1
+        version: 0.4.1
       consola:
         specifier: 3.4.2
         version: 3.4.2

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -18,6 +18,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@changesets/parse": "0.4.1",
     "consola": "3.4.2"
   }
 }


### PR DESCRIPTION
- Add detection and deletion of changesets with empty frontmatter.
- Implement logic to delete changesets that become empty after cleaning.
- Update tests to cover new functionality for empty changeset handling.