### PR TITLE
fix(eslint-config): skip diagnostic if auto package install succeeds

### DIFF
--- a/.changeset/open-baboons-grow.md
+++ b/.changeset/open-baboons-grow.md
@@ -1,0 +1,12 @@
+---
+"@bfra.me/eslint-config": minor
+---
+
+Improve automatic package installation behavior to skip ESLint errors on success
+
+**Breaking Change:** The `tryInstall()` function now returns a discriminated union type `{success: true} | {success: false; output: string} | null` instead of `string | null`.
+
+**Key Changes:**
+
+- **Conditional error reporting**: The `missing-module-for-config` ESLint rule no longer reports errors when packages are successfully installed via `--fix` mode
+- **Better error messages**: Failed installations now include detailed error output in the ESLint error message

--- a/packages/eslint-config/src/rules/missing-module-for-config.ts
+++ b/packages/eslint-config/src/rules/missing-module-for-config.ts
@@ -2,10 +2,10 @@ import type {RuleContext, RulesMeta} from '@eslint/core'
 import {Linter} from 'eslint'
 import {getPackageInstallCommand, tryInstall} from '../package-utils'
 
-// Whether to install the missing module(s) for the config
 let shouldFix = false
 
-;(function patch() {
+// Patches Linter.prototype.verify to detect when ESLint runs with --fix flag
+;(function patch(): void {
   // eslint-disable-next-line @typescript-eslint/unbound-method
   const {verify} = Linter.prototype
   Object.defineProperty(Linter.prototype, 'verify', {
@@ -35,19 +35,32 @@ export const meta: RulesMeta = {
   type: 'problem',
 }
 
-export function create(context: RuleContext) {
+function buildInstallMessage(module: string, filename: string, errorOutput?: string): string {
+  const command = getPackageInstallCommand(module, filename) ?? `npm i -D ${module}`
+  const suffix = errorOutput == null ? '' : `\n${errorOutput}`
+  return `Missing module for config: ${module}. Run: \`${command}\`${suffix}`
+}
+
+export function create(context: RuleContext): Record<string, never> {
   const [modules] = context.options as [string[]]
+
   for (const module of modules) {
-    let output = ''
     if (shouldFix) {
-      const result = tryInstall(module, context.filename) ?? ''
-      output = result ? `\n${result}` : ''
+      const result = tryInstall(module, context.filename)
+      if (result?.success === true) {
+        continue
+      }
+      const errorOutput = result?.success === false ? result.output : undefined
+      context.report({
+        loc: {column: 0, line: 1},
+        message: buildInstallMessage(module, context.filename, errorOutput),
+      })
+    } else {
+      context.report({
+        loc: {column: 0, line: 1},
+        message: buildInstallMessage(module, context.filename),
+      })
     }
-    const command = getPackageInstallCommand(module, context.filename) ?? ''
-    context.report({
-      loc: {column: 0, line: 1},
-      message: `Missing module for config: ${module}. Run: \`${command || `npm i -D ${module}`}\`${output}`,
-    })
   }
 
   return {}

--- a/packages/eslint-config/test/package-utils.test.ts
+++ b/packages/eslint-config/test/package-utils.test.ts
@@ -172,7 +172,7 @@ describe('package-utils', () => {
 
       const firstResult = tryInstall(moduleName, targetFile)
       expect(mockSpawnSync).toHaveBeenCalledTimes(1)
-      expect(firstResult).toBe('')
+      expect(firstResult).toEqual({success: true})
 
       mockSpawnSync.mockClear()
       const secondResult = tryInstall(moduleName, targetFile)
@@ -198,8 +198,12 @@ describe('package-utils', () => {
         signal: null,
       })
 
-      // First call should throw due to failed installation
-      expect(() => tryInstall(moduleName, targetFile)).toThrow()
+      // First call should return failure result
+      const firstResult = tryInstall(moduleName, targetFile)
+      expect(firstResult).toEqual({
+        success: false,
+        output: 'Package installation failed with status 1',
+      })
 
       // Clear the mock and call again; module should be cached and no new spawn occurs
       mockSpawnSync.mockClear()
@@ -215,7 +219,7 @@ describe('package-utils', () => {
       const targetFile = path.join(testProjectDir, 'eslint.config.ts')
       const result = tryInstall('eslint-plugin-test', targetFile)
 
-      expect(result).toBe('')
+      expect(result).toEqual({success: true})
       expect(mockSpawnSync).toHaveBeenCalledTimes(1)
       expect(mockSpawnSync).toHaveBeenCalledWith(
         'npm',
@@ -236,7 +240,7 @@ describe('package-utils', () => {
       const targetFile = path.join(testProjectDir, 'eslint.config.ts')
       const result = tryInstall('eslint-plugin-test@1.2.3', targetFile)
 
-      expect(result).toBe('')
+      expect(result).toEqual({success: true})
       expect(mockSpawnSync).toHaveBeenCalledTimes(1)
       expect(mockSpawnSync).toHaveBeenCalledWith(
         'npm',
@@ -256,7 +260,7 @@ describe('package-utils', () => {
       const targetFile = path.join(testProjectDir, 'eslint.config.ts')
       const result = tryInstall('@typescript-eslint/parser', targetFile)
 
-      expect(result).toBe('')
+      expect(result).toEqual({success: true})
       expect(mockSpawnSync).toHaveBeenCalledTimes(1)
       expect(mockSpawnSync).toHaveBeenCalledWith(
         'pnpm',
@@ -274,7 +278,7 @@ describe('package-utils', () => {
       const targetFile = path.join(testProjectDir, 'eslint.config.ts')
       const result = tryInstall('@typescript-eslint/parser@5.0.0', targetFile)
 
-      expect(result).toBe('')
+      expect(result).toEqual({success: true})
       expect(mockSpawnSync).toHaveBeenCalledTimes(1)
       expect(mockSpawnSync).toHaveBeenCalledWith(
         'yarn',
@@ -338,10 +342,10 @@ describe('package-utils', () => {
       const targetFile = path.join(testProjectDir, 'eslint.config.ts')
       const result = tryInstall('test-success', targetFile)
 
-      expect(result).toBe('')
+      expect(result).toEqual({success: true})
     })
 
-    it('throws error when installation fails with non-zero exit code', () => {
+    it('returns failure result when installation fails with non-zero exit code', () => {
       writeFileSync(path.join(testProjectDir, 'package.json'), JSON.stringify({name: 'test'}))
       writeFileSync(path.join(testProjectDir, 'package-lock.json'), '')
 
@@ -357,12 +361,14 @@ describe('package-utils', () => {
 
       const targetFile = path.join(testProjectDir, 'eslint.config.ts')
 
-      expect(() => tryInstall('test-fail', targetFile)).toThrow(
-        /Package installation failed with status 1/,
-      )
+      const result = tryInstall('test-fail', targetFile)
+      expect(result).toEqual({
+        success: false,
+        output: 'Package installation failed with status 1',
+      })
     })
 
-    it('throws error when spawn fails with error', () => {
+    it('returns failure result when spawn fails with error', () => {
       writeFileSync(path.join(testProjectDir, 'package.json'), JSON.stringify({name: 'test'}))
       writeFileSync(path.join(testProjectDir, 'package-lock.json'), '')
 
@@ -379,7 +385,11 @@ describe('package-utils', () => {
 
       const targetFile = path.join(testProjectDir, 'eslint.config.ts')
 
-      expect(() => tryInstall('test-error', targetFile)).toThrow(/ENOENT: command not found/)
+      const result = tryInstall('test-error', targetFile)
+      expect(result).toEqual({
+        success: false,
+        output: 'ENOENT: command not found',
+      })
     })
 
     it('respects packageManager field when installing', () => {


### PR DESCRIPTION
- Update tryInstall to return an InstallResult type instead of a string.
- Modify error handling to return success and output messages.
- Adjust tests to validate the new return structure of tryInstall.
- Refactor buildInstallMessage to include error output when applicable.