### PR TITLE
build(eslint-config): handle non-function config exports

### DIFF
--- a/packages/eslint-config/scripts/generate-types.ts
+++ b/packages/eslint-config/scripts/generate-types.ts
@@ -13,6 +13,9 @@ const configs = await composeConfig(
     },
   },
   ...Object.values(allConfigs).map(async f => {
+    if (typeof f !== 'function') {
+      return []
+    }
     if (f === allConfigs.typescript) {
       return (f as typeof allConfigs.typescript)({
         erasableSyntaxOnly: true,

--- a/packages/eslint-config/src/configs/stylistic.ts
+++ b/packages/eslint-config/src/configs/stylistic.ts
@@ -2,12 +2,12 @@ import type {Config} from '../config'
 import type {Flatten, OptionsOverrides, StylisticConfig} from '../options'
 import {interopDefault} from '../utils'
 
-const StylisticConfigDefaults: StylisticConfig = {
+export const StylisticConfigDefaults = {
   indent: 2,
   jsx: true,
   quotes: 'single',
   semi: false,
-}
+} as const
 
 /**
  * Configuration options for stylistic ESLint rules.


### PR DESCRIPTION
- Add a check to ensure only functions are processed in composeConfig.
- Export `StylisticConfigDefaults` from the `stylistic` config.