### PR TITLE
fix(eslint-config): support GFM alert syntax (`> [!NOTE] ...`)

### DIFF
--- a/.changeset/frank-hairs-march.md
+++ b/.changeset/frank-hairs-march.md
@@ -1,0 +1,8 @@
+---
+'@bfra.me/eslint-config': patch
+---
+
+> [!TIP]
+> Fix GFM admonition false positives in markdown linting
+
+Configure `markdown/no-missing-label-refs` rule to allow GitHub Flavored Markdown admonitions (`!NOTE`, `!TIP`, `!WARNING`, `!IMPORTANT`, `!CAUTION`) when using GFM language mode. This prevents false positive warnings for valid GFM alert syntax that uses bracket notation for callouts.

--- a/packages/eslint-config/src/configs/markdown.ts
+++ b/packages/eslint-config/src/configs/markdown.ts
@@ -263,7 +263,17 @@ export async function markdown(options: MarkdownOptions = {}): Promise<Config[]>
         'markdown/no-empty-links': 'error',
         'markdown/no-invalid-label-refs': 'error',
         'markdown/no-missing-atx-heading-space': 'error',
-        'markdown/no-missing-label-refs': 'error',
+        'markdown/no-missing-label-refs':
+          // Disable label warnings for admonitions if using GFM
+          language === 'gfm'
+            ? [
+                'error',
+                {
+                  // @keep-sorted
+                  allowLabels: ['!CAUTION', '!IMPORTANT', '!NOTE', '!TIP', '!WARNING'],
+                },
+              ]
+            : 'error',
         'markdown/no-missing-link-fragments': 'error',
         'markdown/no-multiple-h1': 'error',
         'markdown/no-reference-like-urls': 'error',

--- a/readme.md
+++ b/readme.md
@@ -137,13 +137,9 @@ const versionBadge = version('1.2.3')
 
 ## Development
 
-<!-- eslint-disable markdown/no-missing-label-refs -->
-
 > [!NOTE]
 >
 > This project requires Node.js 20+ and pnpm for optimal performance.
-
-<!-- eslint-enable markdown/no-missing-label-refs -->
 
 ### Setup
 


### PR DESCRIPTION
- Modify 'markdown/no-missing-label-refs' rule to allow specific labels when using GFM.