### PR TITLE
feat(eslint-config): add support for custom global ignore patterns

### DIFF
--- a/.changeset/curvy-peaches-tan.md
+++ b/.changeset/curvy-peaches-tan.md
@@ -1,0 +1,23 @@
+---
+'@bfra.me/eslint-config': minor
+---
+
+Add support for custom global ignore patterns with function transforms
+
+Introduces new `ignores` option to `defineConfig()` that allows users to extend or transform global ESLint ignore patterns. The option accepts either:
+- An array of glob patterns to append to the default exclusions
+- A function that receives the original exclusions and returns a transformed array
+
+This provides flexibility to customize which files are ignored by ESLint while maintaining the default exclusions.
+
+Example usage:
+```typescript
+// Append additional patterns
+defineConfig({
+  ignores: ['dist/**', 'coverage/**']
+})
+
+// Transform the defaults
+defineConfig({
+  ignores: (originals) => originals.filter((p) => !p.includes('node_modules'))
+})

--- a/packages/eslint-config/src/configs/ignores.ts
+++ b/packages/eslint-config/src/configs/ignores.ts
@@ -3,11 +3,44 @@ import type {Config} from '../config'
 import {GLOB_EXCLUDE} from '../globs'
 import {interopDefault} from '../utils'
 
-export async function ignores(ignores: string[] = []): Promise<Config[]> {
+/**
+ * Generates an ESLint configuration section that merges built-in glob exclusions
+ * with user-provided ignore patterns.
+ *
+ * Accepts either:
+ * - An array of glob patterns to append to the default exclusions.
+ * - A function that receives the original exclusions and returns a transformed array.
+ *
+ * The result is a single configuration entry named `@bfra.me/ignores` containing the
+ * computed ignore list.
+ *
+ * @param userIgnores - An array of glob patterns to add to the defaults, or a
+ * function that maps the original exclusions to a new set. Defaults to an empty array.
+ * @returns A promise resolving to an array with one `Config` object that includes the merged ignores.
+ *
+ * @example
+ * // Append additional patterns
+ * await ignores(['dist/**', 'coverage/**'])
+ *
+ * @example
+ * // Transform the defaults
+ * await ignores((originals) => originals.filter((p) => !p.includes('node_modules')))
+ */
+export async function ignores(
+  userIgnores: string[] | ((originals: string[]) => string[]) = [],
+): Promise<Config[]> {
+  let ignores = [...GLOB_EXCLUDE]
+
+  if (typeof userIgnores === 'function') {
+    ignores = userIgnores(ignores)
+  } else {
+    ignores.push(...userIgnores)
+  }
+
   return [
     {
       name: '@bfra.me/ignores',
-      ignores: [...GLOB_EXCLUDE, ...ignores],
+      ignores,
     },
   ]
 }

--- a/packages/eslint-config/src/define-config.ts
+++ b/packages/eslint-config/src/define-config.ts
@@ -66,6 +66,7 @@ export async function defineConfig<C extends Config = Config, CN extends ConfigN
   const {
     astro: enableAstro = false,
     gitignore: enableGitignore = true,
+    ignores: userIgnores = [],
     imports: enableImports = true,
     jsx: enableJsx = true,
     nextjs: enableNextjs = false,
@@ -108,7 +109,7 @@ export async function defineConfig<C extends Config = Config, CN extends ConfigN
   }
 
   configs.push(
-    ignores(options.ignores),
+    ignores(userIgnores),
     javascript({isInEditor, overrides: getOverrides(options, 'javascript')}),
     eslintComments(),
     node(),

--- a/packages/eslint-config/src/options.ts
+++ b/packages/eslint-config/src/options.ts
@@ -208,6 +208,16 @@ export type Options = Flatten<
     gitignore?: boolean | FlatGitignoreOptions
 
     /**
+     * Extend the global ignores.
+     *
+     * Passing an array to extends the ignores.
+     * Passing a function to modify the default ignores.
+     *
+     * @default []
+     */
+    ignores?: string[] | ((originals: string[]) => string[])
+
+    /**
      * Options to override the behavior of import-related rules.
      *
      * @default true


### PR DESCRIPTION
- Introduce new `ignores` option to `defineConfig()` for extending or transforming global ESLint ignore patterns.
- Allow users to pass an array of glob patterns or a function to modify the default exclusions.
- Update `ignores` function to handle user-provided ignore patterns.