### PR TITLE
feat(eslint-config): refine type generation script

### DIFF
--- a/.changeset/mighty-melons-lick.md
+++ b/.changeset/mighty-melons-lick.md
@@ -1,0 +1,10 @@
+---
+"@bfra.me/eslint-config": patch
+---
+
+Refine type generation script for accurate DTS output
+
+- Update `scripts/generate-types.ts` to correctly compose all configs and include ESLint builtin rules via `Object.fromEntries(builtinRules)`.
+- Ensure JSX (`jsx({ a11y: true })`) and TypeScript (`typescript({ erasableSyntaxOnly: true, tsconfigPath: 'tsconfig.json' })`) configurations are represented during generation.
+
+Tooling-only change; no runtime behavior affected.

--- a/packages/eslint-config/src/rules.d.ts
+++ b/packages/eslint-config/src/rules.d.ts
@@ -2723,6 +2723,204 @@ export interface Rules {
    */
   'jsonc/vue-custom-block/no-parsing-error'?: Linter.RuleEntry<[]>
   /**
+   * Enforce emojis are wrapped in `<span>` and provide screen reader access.
+   * @see https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/tree/HEAD/docs/rules/accessible-emoji.md
+   * @deprecated
+   */
+  'jsx-a11y/accessible-emoji'?: Linter.RuleEntry<JsxA11YAccessibleEmoji>
+  /**
+   * Enforce all elements that require alternative text have meaningful information to relay back to end user.
+   * @see https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/tree/HEAD/docs/rules/alt-text.md
+   */
+  'jsx-a11y/alt-text'?: Linter.RuleEntry<JsxA11YAltText>
+  /**
+   * Enforce `<a>` text to not exactly match "click here", "here", "link", or "a link".
+   * @see https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/tree/HEAD/docs/rules/anchor-ambiguous-text.md
+   */
+  'jsx-a11y/anchor-ambiguous-text'?: Linter.RuleEntry<JsxA11YAnchorAmbiguousText>
+  /**
+   * Enforce all anchors to contain accessible content.
+   * @see https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/tree/HEAD/docs/rules/anchor-has-content.md
+   */
+  'jsx-a11y/anchor-has-content'?: Linter.RuleEntry<JsxA11YAnchorHasContent>
+  /**
+   * Enforce all anchors are valid, navigable elements.
+   * @see https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/tree/HEAD/docs/rules/anchor-is-valid.md
+   */
+  'jsx-a11y/anchor-is-valid'?: Linter.RuleEntry<JsxA11YAnchorIsValid>
+  /**
+   * Enforce elements with aria-activedescendant are tabbable.
+   * @see https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/tree/HEAD/docs/rules/aria-activedescendant-has-tabindex.md
+   */
+  'jsx-a11y/aria-activedescendant-has-tabindex'?: Linter.RuleEntry<JsxA11YAriaActivedescendantHasTabindex>
+  /**
+   * Enforce all `aria-*` props are valid.
+   * @see https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/tree/HEAD/docs/rules/aria-props.md
+   */
+  'jsx-a11y/aria-props'?: Linter.RuleEntry<JsxA11YAriaProps>
+  /**
+   * Enforce ARIA state and property values are valid.
+   * @see https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/tree/HEAD/docs/rules/aria-proptypes.md
+   */
+  'jsx-a11y/aria-proptypes'?: Linter.RuleEntry<JsxA11YAriaProptypes>
+  /**
+   * Enforce that elements with ARIA roles must use a valid, non-abstract ARIA role.
+   * @see https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/tree/HEAD/docs/rules/aria-role.md
+   */
+  'jsx-a11y/aria-role'?: Linter.RuleEntry<JsxA11YAriaRole>
+  /**
+   * Enforce that elements that do not support ARIA roles, states, and properties do not have those attributes.
+   * @see https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/tree/HEAD/docs/rules/aria-unsupported-elements.md
+   */
+  'jsx-a11y/aria-unsupported-elements'?: Linter.RuleEntry<JsxA11YAriaUnsupportedElements>
+  /**
+   * Enforce that autocomplete attributes are used correctly.
+   * @see https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/tree/HEAD/docs/rules/autocomplete-valid.md
+   */
+  'jsx-a11y/autocomplete-valid'?: Linter.RuleEntry<JsxA11YAutocompleteValid>
+  /**
+   * Enforce a clickable non-interactive element has at least one keyboard event listener.
+   * @see https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/tree/HEAD/docs/rules/click-events-have-key-events.md
+   */
+  'jsx-a11y/click-events-have-key-events'?: Linter.RuleEntry<JsxA11YClickEventsHaveKeyEvents>
+  /**
+   * Enforce that a control (an interactive element) has a text label.
+   * @see https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/control-has-associated-label.md
+   */
+  'jsx-a11y/control-has-associated-label'?: Linter.RuleEntry<JsxA11YControlHasAssociatedLabel>
+  /**
+   * Enforce heading (`h1`, `h2`, etc) elements contain accessible content.
+   * @see https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/tree/HEAD/docs/rules/heading-has-content.md
+   */
+  'jsx-a11y/heading-has-content'?: Linter.RuleEntry<JsxA11YHeadingHasContent>
+  /**
+   * Enforce `<html>` element has `lang` prop.
+   * @see https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/tree/HEAD/docs/rules/html-has-lang.md
+   */
+  'jsx-a11y/html-has-lang'?: Linter.RuleEntry<JsxA11YHtmlHasLang>
+  /**
+   * Enforce iframe elements have a title attribute.
+   * @see https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/tree/HEAD/docs/rules/iframe-has-title.md
+   */
+  'jsx-a11y/iframe-has-title'?: Linter.RuleEntry<JsxA11YIframeHasTitle>
+  /**
+   * Enforce `<img>` alt prop does not contain the word "image", "picture", or "photo".
+   * @see https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/tree/HEAD/docs/rules/img-redundant-alt.md
+   */
+  'jsx-a11y/img-redundant-alt'?: Linter.RuleEntry<JsxA11YImgRedundantAlt>
+  /**
+   * Enforce that elements with interactive handlers like `onClick` must be focusable.
+   * @see https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/tree/HEAD/docs/rules/interactive-supports-focus.md
+   */
+  'jsx-a11y/interactive-supports-focus'?: Linter.RuleEntry<JsxA11YInteractiveSupportsFocus>
+  /**
+   * Enforce that a `label` tag has a text label and an associated control.
+   * @see https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/label-has-associated-control.md
+   */
+  'jsx-a11y/label-has-associated-control'?: Linter.RuleEntry<JsxA11YLabelHasAssociatedControl>
+  /**
+   * Enforce that `<label>` elements have the `htmlFor` prop.
+   * @see https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/tree/HEAD/docs/rules/label-has-for.md
+   * @deprecated
+   */
+  'jsx-a11y/label-has-for'?: Linter.RuleEntry<JsxA11YLabelHasFor>
+  /**
+   * Enforce lang attribute has a valid value.
+   * @see https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/tree/HEAD/docs/rules/lang.md
+   */
+  'jsx-a11y/lang'?: Linter.RuleEntry<JsxA11YLang>
+  /**
+   * Enforces that `<audio>` and `<video>` elements must have a `<track>` for captions.
+   * @see https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/tree/HEAD/docs/rules/media-has-caption.md
+   */
+  'jsx-a11y/media-has-caption'?: Linter.RuleEntry<JsxA11YMediaHasCaption>
+  /**
+   * Enforce that `onMouseOver`/`onMouseOut` are accompanied by `onFocus`/`onBlur` for keyboard-only users.
+   * @see https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/tree/HEAD/docs/rules/mouse-events-have-key-events.md
+   */
+  'jsx-a11y/mouse-events-have-key-events'?: Linter.RuleEntry<JsxA11YMouseEventsHaveKeyEvents>
+  /**
+   * Enforce that the `accessKey` prop is not used on any element to avoid complications with keyboard commands used by a screen reader.
+   * @see https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/tree/HEAD/docs/rules/no-access-key.md
+   */
+  'jsx-a11y/no-access-key'?: Linter.RuleEntry<JsxA11YNoAccessKey>
+  /**
+   * Disallow `aria-hidden="true"` from being set on focusable elements.
+   * @see https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/tree/HEAD/docs/rules/no-aria-hidden-on-focusable.md
+   */
+  'jsx-a11y/no-aria-hidden-on-focusable'?: Linter.RuleEntry<JsxA11YNoAriaHiddenOnFocusable>
+  /**
+   * Enforce autoFocus prop is not used.
+   * @see https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/tree/HEAD/docs/rules/no-autofocus.md
+   */
+  'jsx-a11y/no-autofocus'?: Linter.RuleEntry<JsxA11YNoAutofocus>
+  /**
+   * Enforce distracting elements are not used.
+   * @see https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/tree/HEAD/docs/rules/no-distracting-elements.md
+   */
+  'jsx-a11y/no-distracting-elements'?: Linter.RuleEntry<JsxA11YNoDistractingElements>
+  /**
+   * Interactive elements should not be assigned non-interactive roles.
+   * @see https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/tree/HEAD/docs/rules/no-interactive-element-to-noninteractive-role.md
+   */
+  'jsx-a11y/no-interactive-element-to-noninteractive-role'?: Linter.RuleEntry<JsxA11YNoInteractiveElementToNoninteractiveRole>
+  /**
+   * Non-interactive elements should not be assigned mouse or keyboard event listeners.
+   * @see https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/tree/HEAD/docs/rules/no-noninteractive-element-interactions.md
+   */
+  'jsx-a11y/no-noninteractive-element-interactions'?: Linter.RuleEntry<JsxA11YNoNoninteractiveElementInteractions>
+  /**
+   * Non-interactive elements should not be assigned interactive roles.
+   * @see https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/tree/HEAD/docs/rules/no-noninteractive-element-to-interactive-role.md
+   */
+  'jsx-a11y/no-noninteractive-element-to-interactive-role'?: Linter.RuleEntry<JsxA11YNoNoninteractiveElementToInteractiveRole>
+  /**
+   * `tabIndex` should only be declared on interactive elements.
+   * @see https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/tree/HEAD/docs/rules/no-noninteractive-tabindex.md
+   */
+  'jsx-a11y/no-noninteractive-tabindex'?: Linter.RuleEntry<JsxA11YNoNoninteractiveTabindex>
+  /**
+   * Enforce usage of `onBlur` over `onChange` on select menus for accessibility.
+   * @see https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/tree/HEAD/docs/rules/no-onchange.md
+   * @deprecated
+   */
+  'jsx-a11y/no-onchange'?: Linter.RuleEntry<JsxA11YNoOnchange>
+  /**
+   * Enforce explicit role property is not the same as implicit/default role property on element.
+   * @see https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/tree/HEAD/docs/rules/no-redundant-roles.md
+   */
+  'jsx-a11y/no-redundant-roles'?: Linter.RuleEntry<JsxA11YNoRedundantRoles>
+  /**
+   * Enforce that non-interactive, visible elements (such as `<div>`) that have click handlers use the role attribute.
+   * @see https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/tree/HEAD/docs/rules/no-static-element-interactions.md
+   */
+  'jsx-a11y/no-static-element-interactions'?: Linter.RuleEntry<JsxA11YNoStaticElementInteractions>
+  /**
+   * Enforces using semantic DOM elements over the ARIA `role` property.
+   * @see https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/tree/HEAD/docs/rules/prefer-tag-over-role.md
+   */
+  'jsx-a11y/prefer-tag-over-role'?: Linter.RuleEntry<JsxA11YPreferTagOverRole>
+  /**
+   * Enforce that elements with ARIA roles must have all required attributes for that role.
+   * @see https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/tree/HEAD/docs/rules/role-has-required-aria-props.md
+   */
+  'jsx-a11y/role-has-required-aria-props'?: Linter.RuleEntry<JsxA11YRoleHasRequiredAriaProps>
+  /**
+   * Enforce that elements with explicit or implicit roles defined contain only `aria-*` properties supported by that `role`.
+   * @see https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/tree/HEAD/docs/rules/role-supports-aria-props.md
+   */
+  'jsx-a11y/role-supports-aria-props'?: Linter.RuleEntry<JsxA11YRoleSupportsAriaProps>
+  /**
+   * Enforce `scope` prop is only used on `<th>` elements.
+   * @see https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/tree/HEAD/docs/rules/scope.md
+   */
+  'jsx-a11y/scope'?: Linter.RuleEntry<JsxA11YScope>
+  /**
+   * Enforce `tabIndex` value is not greater than zero.
+   * @see https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/tree/HEAD/docs/rules/tabindex-no-positive.md
+   */
+  'jsx-a11y/tabindex-no-positive'?: Linter.RuleEntry<JsxA11YTabindexNoPositive>
+  /**
    * Enforce the consistent use of either double or single quotes in JSX attributes
    * @see https://eslint.org/docs/latest/rules/jsx-quotes
    * @deprecated
@@ -11133,6 +11331,221 @@ type JsoncSpaceUnaryOps = []|[{
   overrides?: {
     [k: string]: boolean | undefined
   }
+}]
+// ----- jsx-a11y/accessible-emoji -----
+type JsxA11YAccessibleEmoji = []|[{
+  [k: string]: unknown | undefined
+}]
+// ----- jsx-a11y/alt-text -----
+type JsxA11YAltText = []|[{
+  elements?: string[]
+  img?: string[]
+  object?: string[]
+  area?: string[]
+  "input[type=\"image\"]"?: string[]
+  [k: string]: unknown | undefined
+}]
+// ----- jsx-a11y/anchor-ambiguous-text -----
+type JsxA11YAnchorAmbiguousText = []|[{
+  words?: string[]
+  [k: string]: unknown | undefined
+}]
+// ----- jsx-a11y/anchor-has-content -----
+type JsxA11YAnchorHasContent = []|[{
+  components?: string[]
+  [k: string]: unknown | undefined
+}]
+// ----- jsx-a11y/anchor-is-valid -----
+type JsxA11YAnchorIsValid = []|[{
+  components?: string[]
+  specialLink?: string[]
+  
+  aspects?: [("noHref" | "invalidHref" | "preferButton"), ...(("noHref" | "invalidHref" | "preferButton"))[]]
+  [k: string]: unknown | undefined
+}]
+// ----- jsx-a11y/aria-activedescendant-has-tabindex -----
+type JsxA11YAriaActivedescendantHasTabindex = []|[{
+  [k: string]: unknown | undefined
+}]
+// ----- jsx-a11y/aria-props -----
+type JsxA11YAriaProps = []|[{
+  [k: string]: unknown | undefined
+}]
+// ----- jsx-a11y/aria-proptypes -----
+type JsxA11YAriaProptypes = []|[{
+  [k: string]: unknown | undefined
+}]
+// ----- jsx-a11y/aria-role -----
+type JsxA11YAriaRole = []|[{
+  allowedInvalidRoles?: string[]
+  ignoreNonDOM?: boolean
+  [k: string]: unknown | undefined
+}]
+// ----- jsx-a11y/aria-unsupported-elements -----
+type JsxA11YAriaUnsupportedElements = []|[{
+  [k: string]: unknown | undefined
+}]
+// ----- jsx-a11y/autocomplete-valid -----
+type JsxA11YAutocompleteValid = []|[{
+  inputComponents?: string[]
+  [k: string]: unknown | undefined
+}]
+// ----- jsx-a11y/click-events-have-key-events -----
+type JsxA11YClickEventsHaveKeyEvents = []|[{
+  [k: string]: unknown | undefined
+}]
+// ----- jsx-a11y/control-has-associated-label -----
+type JsxA11YControlHasAssociatedLabel = []|[{
+  labelAttributes?: string[]
+  controlComponents?: string[]
+  ignoreElements?: string[]
+  ignoreRoles?: string[]
+  
+  depth?: number
+  [k: string]: unknown | undefined
+}]
+// ----- jsx-a11y/heading-has-content -----
+type JsxA11YHeadingHasContent = []|[{
+  components?: string[]
+  [k: string]: unknown | undefined
+}]
+// ----- jsx-a11y/html-has-lang -----
+type JsxA11YHtmlHasLang = []|[{
+  [k: string]: unknown | undefined
+}]
+// ----- jsx-a11y/iframe-has-title -----
+type JsxA11YIframeHasTitle = []|[{
+  [k: string]: unknown | undefined
+}]
+// ----- jsx-a11y/img-redundant-alt -----
+type JsxA11YImgRedundantAlt = []|[{
+  components?: string[]
+  words?: string[]
+  [k: string]: unknown | undefined
+}]
+// ----- jsx-a11y/interactive-supports-focus -----
+type JsxA11YInteractiveSupportsFocus = []|[{
+  
+  tabbable?: ("button" | "checkbox" | "columnheader" | "combobox" | "grid" | "gridcell" | "link" | "listbox" | "menu" | "menubar" | "menuitem" | "menuitemcheckbox" | "menuitemradio" | "option" | "progressbar" | "radio" | "radiogroup" | "row" | "rowheader" | "scrollbar" | "searchbox" | "slider" | "spinbutton" | "switch" | "tab" | "tablist" | "textbox" | "tree" | "treegrid" | "treeitem" | "doc-backlink" | "doc-biblioref" | "doc-glossref" | "doc-noteref")[]
+  [k: string]: unknown | undefined
+}]
+// ----- jsx-a11y/label-has-associated-control -----
+type JsxA11YLabelHasAssociatedControl = []|[{
+  labelComponents?: string[]
+  labelAttributes?: string[]
+  controlComponents?: string[]
+  
+  assert?: ("htmlFor" | "nesting" | "both" | "either")
+  
+  depth?: number
+  [k: string]: unknown | undefined
+}]
+// ----- jsx-a11y/label-has-for -----
+type JsxA11YLabelHasFor = []|[{
+  components?: string[]
+  required?: (("nesting" | "id") | {
+    
+    some: ("nesting" | "id")[]
+    [k: string]: unknown | undefined
+  } | {
+    
+    every: ("nesting" | "id")[]
+    [k: string]: unknown | undefined
+  })
+  allowChildren?: boolean
+  [k: string]: unknown | undefined
+}]
+// ----- jsx-a11y/lang -----
+type JsxA11YLang = []|[{
+  [k: string]: unknown | undefined
+}]
+// ----- jsx-a11y/media-has-caption -----
+type JsxA11YMediaHasCaption = []|[{
+  audio?: string[]
+  video?: string[]
+  track?: string[]
+  [k: string]: unknown | undefined
+}]
+// ----- jsx-a11y/mouse-events-have-key-events -----
+type JsxA11YMouseEventsHaveKeyEvents = []|[{
+  
+  hoverInHandlers?: string[]
+  
+  hoverOutHandlers?: string[]
+  [k: string]: unknown | undefined
+}]
+// ----- jsx-a11y/no-access-key -----
+type JsxA11YNoAccessKey = []|[{
+  [k: string]: unknown | undefined
+}]
+// ----- jsx-a11y/no-aria-hidden-on-focusable -----
+type JsxA11YNoAriaHiddenOnFocusable = []|[{
+  [k: string]: unknown | undefined
+}]
+// ----- jsx-a11y/no-autofocus -----
+type JsxA11YNoAutofocus = []|[{
+  ignoreNonDOM?: boolean
+  [k: string]: unknown | undefined
+}]
+// ----- jsx-a11y/no-distracting-elements -----
+type JsxA11YNoDistractingElements = []|[{
+  
+  elements?: ("marquee" | "blink")[]
+  [k: string]: unknown | undefined
+}]
+// ----- jsx-a11y/no-interactive-element-to-noninteractive-role -----
+type JsxA11YNoInteractiveElementToNoninteractiveRole = []|[{
+  [k: string]: string[] | undefined
+}]
+// ----- jsx-a11y/no-noninteractive-element-interactions -----
+type JsxA11YNoNoninteractiveElementInteractions = []|[{
+  handlers?: string[]
+  [k: string]: unknown | undefined
+}]
+// ----- jsx-a11y/no-noninteractive-element-to-interactive-role -----
+type JsxA11YNoNoninteractiveElementToInteractiveRole = []|[{
+  [k: string]: string[] | undefined
+}]
+// ----- jsx-a11y/no-noninteractive-tabindex -----
+type JsxA11YNoNoninteractiveTabindex = []|[{
+  
+  roles?: string[]
+  
+  tags?: string[]
+  [k: string]: unknown | undefined
+}]
+// ----- jsx-a11y/no-onchange -----
+type JsxA11YNoOnchange = []|[{
+  [k: string]: unknown | undefined
+}]
+// ----- jsx-a11y/no-redundant-roles -----
+type JsxA11YNoRedundantRoles = []|[{
+  [k: string]: string[] | undefined
+}]
+// ----- jsx-a11y/no-static-element-interactions -----
+type JsxA11YNoStaticElementInteractions = []|[{
+  handlers?: string[]
+  [k: string]: unknown | undefined
+}]
+// ----- jsx-a11y/prefer-tag-over-role -----
+type JsxA11YPreferTagOverRole = []|[{
+  [k: string]: unknown | undefined
+}]
+// ----- jsx-a11y/role-has-required-aria-props -----
+type JsxA11YRoleHasRequiredAriaProps = []|[{
+  [k: string]: unknown | undefined
+}]
+// ----- jsx-a11y/role-supports-aria-props -----
+type JsxA11YRoleSupportsAriaProps = []|[{
+  [k: string]: unknown | undefined
+}]
+// ----- jsx-a11y/scope -----
+type JsxA11YScope = []|[{
+  [k: string]: unknown | undefined
+}]
+// ----- jsx-a11y/tabindex-no-positive -----
+type JsxA11YTabindexNoPositive = []|[{
+  [k: string]: unknown | undefined
 }]
 // ----- jsx-quotes -----
 type JsxQuotes = []|[("prefer-single" | "prefer-double")]


### PR DESCRIPTION
- Update `scripts/generate-types.ts` to correctly compose all configs and include ESLint builtin rules via `Object.fromEntries(builtinRules)`.
- Ensure JSX (`jsx({ a11y: true })`) and TypeScript (`typescript({ erasableSyntaxOnly: true, tsconfigPath: 'tsconfig.json' })`) configurations are represented during generation.