### PR TITLE
feat(badge-config): add GitHub Actions badge generator

### DIFF
--- a/.changeset/full-monkeys-argue.md
+++ b/.changeset/full-monkeys-argue.md
@@ -1,0 +1,11 @@
+---
+"@bfra.me/badge-config": minor
+---
+
+Add `githubActions` preset generator for GitHub Actions workflow status badges
+
+- New `githubActions()` function generates dynamic Shields.io badge URLs for GitHub Actions workflows
+- Supports custom workflow names (with automatic URL encoding for spaces/special characters)
+- Configurable options: `repository`, `workflow`, `branch`, `event`, `label`, `style`, `logo`, `logoColor`, `cacheSeconds`
+- Defaults to the `githubactions` logo
+- Exports `GitHubActionsOptions` and `GitHubActionsResult` types

--- a/packages/badge-config/src/generators/github-actions.ts
+++ b/packages/badge-config/src/generators/github-actions.ts
@@ -1,0 +1,139 @@
+/**
+ * @module
+ * This module provides a preset generator for creating GitHub Actions workflow status badges.
+ * It generates dynamic badges that display the current status of a GitHub Actions workflow.
+ */
+
+import type {BadgeColor, BadgeStyle} from '../types'
+
+/**
+ * Configuration options for creating a GitHub Actions status badge.
+ */
+export interface GitHubActionsOptions {
+  /**
+   * The repository in "owner/repo" format.
+   * @example 'bfra-me/works'
+   */
+  repository: string
+  /**
+   * The workflow file name or workflow name.
+   * Can be a filename (e.g., 'ci.yaml') or a workflow name (e.g., 'Build and Test').
+   * @example 'ci.yaml'
+   * @example 'Build and Test'
+   */
+  workflow: string
+  /**
+   * The branch to show status for. If omitted, shows status for the default branch.
+   * @example 'main'
+   */
+  branch?: string
+  /**
+   * The event type to filter by (e.g., 'push', 'pull_request').
+   */
+  event?: string
+  /**
+   * The text for the left side of the badge (custom label override).
+   */
+  label?: string
+  /** The visual style of the badge. */
+  style?: BadgeStyle
+  /** A logo to embed in the badge. @default 'githubactions' */
+  logo?: string
+  /** The color of the embedded logo. */
+  logoColor?: BadgeColor
+  /** The number of seconds to cache the badge URL. */
+  cacheSeconds?: number
+}
+
+/**
+ * Result of a GitHub Actions badge generation.
+ */
+export interface GitHubActionsResult {
+  /** The complete shields.io URL for the GitHub Actions badge. */
+  url: string
+}
+
+/**
+ * Generates a GitHub Actions workflow status badge URL.
+ *
+ * This creates a dynamic badge that queries GitHub Actions for the current
+ * workflow status. The badge color is determined automatically based on
+ * the workflow's latest run status (green for success, red for failure, etc.).
+ *
+ * @param options - The GitHub Actions badge configuration.
+ * @returns An object containing the generated badge URL.
+ *
+ * @example
+ * ```typescript
+ * import { githubActions } from '@bfra.me/badge-config';
+ *
+ * // Generate a badge for a workflow file
+ * const result = githubActions({
+ *   repository: 'bfra-me/works',
+ *   workflow: 'ci.yaml'
+ * });
+ * console.log(result.url);
+ * // => https://img.shields.io/github/actions/workflow/status/bfra-me/works/ci.yaml?logo=githubactions
+ *
+ * // Generate a badge for a specific branch with custom label
+ * const mainBadge = githubActions({
+ *   repository: 'bfra-me/works',
+ *   workflow: 'Build and Test',
+ *   branch: 'main',
+ *   label: 'build'
+ * });
+ * ```
+ */
+export function githubActions(options: GitHubActionsOptions): GitHubActionsResult {
+  const {
+    repository,
+    workflow,
+    branch,
+    event,
+    label,
+    style,
+    logo = 'githubactions',
+    logoColor,
+    cacheSeconds,
+  } = options
+
+  const encodedWorkflow = encodeURIComponent(workflow)
+
+  // Shields.io endpoint format: /github/actions/workflow/status/:user/:repo/:workflow
+  const baseUrl = `https://img.shields.io/github/actions/workflow/status/${repository}/${encodedWorkflow}`
+
+  const searchParams = new URLSearchParams()
+
+  if (branch !== undefined && branch !== '') {
+    searchParams.set('branch', branch)
+  }
+
+  if (event !== undefined && event !== '') {
+    searchParams.set('event', event)
+  }
+
+  if (label !== undefined && label !== '') {
+    searchParams.set('label', label)
+  }
+
+  if (style !== undefined) {
+    searchParams.set('style', style)
+  }
+
+  if (logo !== undefined && logo !== '') {
+    searchParams.set('logo', logo)
+  }
+
+  if (logoColor !== undefined) {
+    searchParams.set('logoColor', logoColor)
+  }
+
+  if (cacheSeconds !== undefined) {
+    searchParams.set('cacheSeconds', cacheSeconds.toString())
+  }
+
+  const queryString = searchParams.toString()
+  const url = queryString ? `${baseUrl}?${queryString}` : baseUrl
+
+  return {url}
+}

--- a/packages/badge-config/src/generators/index.ts
+++ b/packages/badge-config/src/generators/index.ts
@@ -26,6 +26,10 @@ export type {BuildStatus, BuildStatusOptions} from './build-status'
 export {coverage} from './coverage'
 export type {CoverageOptions, CoverageThresholds} from './coverage'
 
+// GitHub Actions generator
+export {githubActions} from './github-actions'
+export type {GitHubActionsOptions, GitHubActionsResult} from './github-actions'
+
 // License generator
 export {license} from './license'
 export type {LicenseCategory, LicenseOptions} from './license'

--- a/packages/badge-config/src/index.ts
+++ b/packages/badge-config/src/index.ts
@@ -6,12 +6,14 @@
 export {createBadge, createBadgeUrl} from './create-badge'
 
 // Preset generators
-export {buildStatus, coverage, license, social, version} from './generators'
+export {buildStatus, coverage, githubActions, license, social, version} from './generators'
 export type {
   BuildStatus,
   BuildStatusOptions,
   CoverageOptions,
   CoverageThresholds,
+  GitHubActionsOptions,
+  GitHubActionsResult,
   LicenseCategory,
   LicenseOptions,
   SocialBadgeOptions,

--- a/packages/badge-config/test/fixtures/input/preset-configs.json
+++ b/packages/badge-config/test/fixtures/input/preset-configs.json
@@ -99,5 +99,50 @@
       "type": "followers",
       "user": "marcusrbrown"
     }
+  },
+  "githubActions": {
+    "simple": {
+      "repository": "bfra-me/works",
+      "workflow": "ci.yaml"
+    },
+    "withBranch": {
+      "repository": "bfra-me/works",
+      "workflow": "ci.yaml",
+      "branch": "main"
+    },
+    "withWorkflowName": {
+      "repository": "bfra-me/works",
+      "workflow": "Build and Test"
+    },
+    "withCustomLabel": {
+      "repository": "bfra-me/works",
+      "workflow": "ci.yaml",
+      "label": "build"
+    },
+    "withEvent": {
+      "repository": "bfra-me/works",
+      "workflow": "ci.yaml",
+      "branch": "main",
+      "event": "push"
+    },
+    "withStyle": {
+      "repository": "bfra-me/works",
+      "workflow": "ci.yaml",
+      "style": "flat-square"
+    },
+    "withNoLogo": {
+      "repository": "bfra-me/works",
+      "workflow": "ci.yaml",
+      "logo": ""
+    },
+    "fullConfig": {
+      "repository": "bfra-me/works",
+      "workflow": "release.yaml",
+      "branch": "main",
+      "label": "release",
+      "style": "for-the-badge",
+      "logoColor": "white",
+      "cacheSeconds": 300
+    }
   }
 }

--- a/packages/badge-config/test/fixtures/output/preset-urls.json
+++ b/packages/badge-config/test/fixtures/output/preset-urls.json
@@ -23,5 +23,15 @@
     "githubStars": "https://img.shields.io/badge/stars-0-yellow?logo=github",
     "githubForks": "https://img.shields.io/badge/forks-0-blue?logo=github",
     "npmDownloads": "https://img.shields.io/badge/downloads-0-green"
+  },
+  "githubActions": {
+    "simple": "https://img.shields.io/github/actions/workflow/status/bfra-me/works/ci.yaml?logo=githubactions",
+    "withBranch": "https://img.shields.io/github/actions/workflow/status/bfra-me/works/ci.yaml?branch=main&logo=githubactions",
+    "withWorkflowName": "https://img.shields.io/github/actions/workflow/status/bfra-me/works/Build%20and%20Test?logo=githubactions",
+    "withCustomLabel": "https://img.shields.io/github/actions/workflow/status/bfra-me/works/ci.yaml?label=build&logo=githubactions",
+    "withEvent": "https://img.shields.io/github/actions/workflow/status/bfra-me/works/ci.yaml?branch=main&event=push&logo=githubactions",
+    "withStyle": "https://img.shields.io/github/actions/workflow/status/bfra-me/works/ci.yaml?style=flat-square&logo=githubactions",
+    "withNoLogo": "https://img.shields.io/github/actions/workflow/status/bfra-me/works/ci.yaml",
+    "fullConfig": "https://img.shields.io/github/actions/workflow/status/bfra-me/works/release.yaml?branch=main&label=release&style=for-the-badge&logo=githubactions&logoColor=white&cacheSeconds=300"
   }
 }


### PR DESCRIPTION
- New `githubActions()` function generates dynamic Shields.io badge URLs for GitHub Actions workflows
- Supports custom workflow names (with automatic URL encoding for spaces/special characters)
- Configurable options: `repository`, `workflow`, `branch`, `event`, `label`, `style`, `logo`, `logoColor`, `cacheSeconds`
- Defaults to the `githubactions` logo
- Exports `GitHubActionsOptions` and `GitHubActionsResult` types