### PR TITLE
feat(es): update result types and utilities with improved documentation

### DIFF
--- a/.ai/plan/feature-es-package-1.md
+++ b/.ai/plan/feature-es-package-1.md
@@ -98,17 +98,17 @@ Create a shared `@bfra.me/es` package that provides high-quality reusable types 
 
 | Task | Description | Completed | Date |
 |------|-------------|-----------|------|
-| TASK-009 | Create `src/result/types.ts` with `Result<T, E>`, `Ok<T>`, `Err<E>` type definitions | | |
-| TASK-010 | Implement `ok<T>(value: T): Ok<T>` and `err<E>(error: E): Err<E>` factory functions in `src/result/factories.ts` | | |
-| TASK-011 | Implement type guards `isOk<T, E>(result: Result<T, E>): result is Ok<T>` and `isErr()` in `src/result/guards.ts` | | |
-| TASK-012 | Implement `unwrap<T, E>(result: Result<T, E>): T` throwing on Err, with custom error message support | | |
-| TASK-013 | Implement `unwrapOr<T, E>(result: Result<T, E>, defaultValue: T): T` for safe extraction | | |
-| TASK-014 | Implement `map<T, U, E>(result: Result<T, E>, fn: (value: T) => U): Result<U, E>` for transformation | | |
-| TASK-015 | Implement `flatMap<T, U, E>(result: Result<T, E>, fn: (value: T) => Result<U, E>): Result<U, E>` for chaining | | |
-| TASK-016 | Implement `mapErr<T, E, F>(result: Result<T, E>, fn: (error: E) => F): Result<T, F>` for error transformation | | |
-| TASK-017 | Implement `fromThrowable<T>(fn: () => T): Result<T, Error>` to wrap throwing functions | | |
-| TASK-018 | Implement `fromPromise<T>(promise: Promise<T>): Promise<Result<T, Error>>` for async operations | | |
-| TASK-019 | Create barrel export in `src/result/index.ts` with all Result utilities | | |
+| TASK-009 | Create `src/result/types.ts` with `Result<T, E>`, `Ok<T>`, `Err<E>` type definitions | ✅ | 2025-11-30 |
+| TASK-010 | Implement `ok<T>(value: T): Ok<T>` and `err<E>(error: E): Err<E>` factory functions in `src/result/factories.ts` | ✅ | 2025-11-30 |
+| TASK-011 | Implement type guards `isOk<T, E>(result: Result<T, E>): result is Ok<T>` and `isErr()` in `src/result/guards.ts` | ✅ | 2025-11-30 |
+| TASK-012 | Implement `unwrap<T, E>(result: Result<T, E>): T` throwing on Err, with custom error message support | ✅ | 2025-11-30 |
+| TASK-013 | Implement `unwrapOr<T, E>(result: Result<T, E>, defaultValue: T): T` for safe extraction | ✅ | 2025-11-30 |
+| TASK-014 | Implement `map<T, U, E>(result: Result<T, E>, fn: (value: T) => U): Result<U, E>` for transformation | ✅ | 2025-11-30 |
+| TASK-015 | Implement `flatMap<T, U, E>(result: Result<T, E>, fn: (value: T) => Result<U, E>): Result<U, E>` for chaining | ✅ | 2025-11-30 |
+| TASK-016 | Implement `mapErr<T, E, F>(result: Result<T, E>, fn: (error: E) => F): Result<T, F>` for error transformation | ✅ | 2025-11-30 |
+| TASK-017 | Implement `fromThrowable<T>(fn: () => T): Result<T, Error>` to wrap throwing functions | ✅ | 2025-11-30 |
+| TASK-018 | Implement `fromPromise<T>(promise: Promise<T>): Promise<Result<T, Error>>` for async operations | ✅ | 2025-11-30 |
+| TASK-019 | Create barrel export in `src/result/index.ts` with all Result utilities | ✅ | 2025-11-30 |
 
 ### Implementation Phase 3: Functional Utilities
 

--- a/packages/es/src/result/factories.ts
+++ b/packages/es/src/result/factories.ts
@@ -1,21 +1,11 @@
 import type {Err, Ok} from './types'
 
-/**
- * Creates a successful Result containing the given value.
- *
- * @param value - The value to wrap in an Ok result
- * @returns An Ok result containing the value
- */
+/** Creates a successful Result containing the given value. */
 export function ok<T>(value: T): Ok<T> {
   return {success: true, data: value}
 }
 
-/**
- * Creates a failed Result containing the given error.
- *
- * @param error - The error to wrap in an Err result
- * @returns An Err result containing the error
- */
+/** Creates a failed Result containing the given error. */
 export function err<E>(error: E): Err<E> {
   return {success: false, error}
 }

--- a/packages/es/src/result/guards.ts
+++ b/packages/es/src/result/guards.ts
@@ -1,21 +1,11 @@
 import type {Err, Ok, Result} from './types'
 
-/**
- * Type guard that checks if a Result is an Ok (success).
- *
- * @param result - The result to check
- * @returns True if the result is Ok, narrowing the type
- */
+/** Type guard that narrows a Result to Ok. */
 export function isOk<T, E>(result: Result<T, E>): result is Ok<T> {
-  return result.success === true
+  return result.success
 }
 
-/**
- * Type guard that checks if a Result is an Err (failure).
- *
- * @param result - The result to check
- * @returns True if the result is Err, narrowing the type
- */
+/** Type guard that narrows a Result to Err. */
 export function isErr<T, E>(result: Result<T, E>): result is Err<E> {
-  return result.success === false
+  return !result.success
 }

--- a/packages/es/src/result/operators.ts
+++ b/packages/es/src/result/operators.ts
@@ -3,12 +3,8 @@ import {err, ok} from './factories'
 import {isOk} from './guards'
 
 /**
- * Extracts the value from an Ok result, or throws an error for Err results.
- *
- * @param result - The result to unwrap
- * @param message - Optional custom error message for Err results
- * @returns The contained value if Ok
- * @throws Error if the result is Err
+ * Extracts the value from an Ok result, or throws for Err results.
+ * Use sparingly - prefer `unwrapOr` or pattern matching for safer extraction.
  */
 export function unwrap<T, E>(result: Result<T, E>, message?: string): T {
   if (isOk(result)) {
@@ -18,37 +14,17 @@ export function unwrap<T, E>(result: Result<T, E>, message?: string): T {
   throw new Error(errorMessage)
 }
 
-/**
- * Extracts the value from an Ok result, or returns the default value for Err results.
- *
- * @param result - The result to unwrap
- * @param defaultValue - The value to return if result is Err
- * @returns The contained value if Ok, otherwise the default value
- */
+/** Extracts the value from an Ok result, or returns the default value for Err. */
 export function unwrapOr<T, E>(result: Result<T, E>, defaultValue: T): T {
   return isOk(result) ? result.data : defaultValue
 }
 
-/**
- * Transforms the value inside an Ok result using the provided function.
- * Err results pass through unchanged.
- *
- * @param result - The result to transform
- * @param fn - The transformation function
- * @returns A new Result with the transformed value
- */
+/** Transforms the value inside an Ok result. Err results pass through unchanged. */
 export function map<T, U, E>(result: Result<T, E>, fn: (value: T) => U): Result<U, E> {
   return isOk(result) ? ok(fn(result.data)) : result
 }
 
-/**
- * Chains Result-returning functions, flattening the result.
- * Useful for composing operations that may fail.
- *
- * @param result - The result to chain
- * @param fn - A function that returns a Result
- * @returns The result of the function if Ok, otherwise the original Err
- */
+/** Chains Result-returning functions, flattening nested Results. */
 export function flatMap<T, U, E>(
   result: Result<T, E>,
   fn: (value: T) => Result<U, E>,
@@ -56,24 +32,12 @@ export function flatMap<T, U, E>(
   return isOk(result) ? fn(result.data) : result
 }
 
-/**
- * Transforms the error inside an Err result using the provided function.
- * Ok results pass through unchanged.
- *
- * @param result - The result to transform
- * @param fn - The error transformation function
- * @returns A new Result with the transformed error
- */
+/** Transforms the error inside an Err result. Ok results pass through unchanged. */
 export function mapErr<T, E, F>(result: Result<T, E>, fn: (error: E) => F): Result<T, F> {
   return isOk(result) ? result : err(fn(result.error))
 }
 
-/**
- * Wraps a potentially throwing function in a Result.
- *
- * @param fn - A function that may throw
- * @returns Ok with the return value, or Err with the caught error
- */
+/** Wraps a potentially throwing function in a Result. */
 export function fromThrowable<T>(fn: () => T): Result<T, Error> {
   try {
     return ok(fn())
@@ -82,12 +46,7 @@ export function fromThrowable<T>(fn: () => T): Result<T, Error> {
   }
 }
 
-/**
- * Converts a Promise to a Promise<Result>, catching rejections.
- *
- * @param promise - The promise to convert
- * @returns A Promise that resolves to Ok or Err
- */
+/** Converts a Promise to a Promise<Result>, catching rejections. */
 export async function fromPromise<T>(promise: Promise<T>): Promise<Result<T, Error>> {
   try {
     return ok(await promise)

--- a/packages/es/src/result/types.ts
+++ b/packages/es/src/result/types.ts
@@ -15,7 +15,14 @@ export interface Err<E> {
 }
 
 /**
- * A discriminated union representing either success (Ok) or failure (Err).
- * Use this pattern instead of throwing exceptions for expected errors.
+ * Discriminated union for error handling without exceptions.
+ * Prefer this pattern over throwing for expected/recoverable errors.
+ *
+ * @example
+ * ```ts
+ * function divide(a: number, b: number): Result<number, string> {
+ *   return b === 0 ? err('Division by zero') : ok(a / b)
+ * }
+ * ```
  */
 export type Result<T, E = Error> = Ok<T> | Err<E>


### PR DESCRIPTION
- Mark completed tasks in the feature plan for the @bfra.me/es package
- Simplify and enhance documentation comments in factories, guards, and operators
- Improve type definitions and examples in the Result type documentation

Closes #2281.