### PR TITLE
feat(es): implement package scope checking and enhance utilities

### DIFF
--- a/.ai/plan/feature-es-package-1.md
+++ b/.ai/plan/feature-es-package-1.md
@@ -133,12 +133,12 @@ Create a shared `@bfra.me/es` package that provides high-quality reusable types 
 
 | Task | Description | Completed | Date |
 |------|-------------|-----------|------|
-| TASK-030 | Extract `interopDefault<T>(m: Awaitable<T>): Promise<T>` from `@bfra.me/eslint-config/src/utils.ts` to `src/module/interop.ts` | | |
-| TASK-031 | Implement `isPackageInScope(name: string, scopeUrl?: string): boolean` generalized from eslint-config | | |
-| TASK-032 | Implement `resolveModule<T>(specifier: string): Promise<Result<T, Error>>` with Result return type | | |
-| TASK-033 | Implement `dynamicImport<T>(path: string): Promise<Result<T, Error>>` with error handling | | |
-| TASK-034 | Implement `isESModule(module: unknown): boolean` type guard for module detection | | |
-| TASK-035 | Create barrel export in `src/module/index.ts` with all module utilities | | |
+| TASK-030 | Extract `interopDefault<T>(m: Awaitable<T>): Promise<T>` from `@bfra.me/eslint-config/src/utils.ts` to `src/module/interop.ts` | ✅ | 2025-11-30 |
+| TASK-031 | Implement `isPackageInScope(name: string, scopeUrl?: string): boolean` generalized from eslint-config | ✅ | 2025-11-30 |
+| TASK-032 | Implement `resolveModule<T>(specifier: string): Promise<Result<T, Error>>` with Result return type | ✅ | 2025-11-30 |
+| TASK-033 | Implement `dynamicImport<T>(path: string): Promise<Result<T, Error>>` with error handling | ✅ | 2025-11-30 |
+| TASK-034 | Implement `isESModule(module: unknown): boolean` type guard for module detection | ✅ | 2025-11-30 |
+| TASK-035 | Create barrel export in `src/module/index.ts` with all module utilities | ✅ | 2025-11-30 |
 
 ### Implementation Phase 5: Environment Detection
 

--- a/packages/es/src/index.ts
+++ b/packages/es/src/index.ts
@@ -46,6 +46,8 @@ export {
 export {compose} from './functional/compose'
 export {constant} from './functional/constant'
 export {curry} from './functional/curry'
+export type {Curried} from './functional/curry'
+export {flip} from './functional/flip'
 export {identity} from './functional/identity'
 export {noop, noopAsync} from './functional/noop'
 export {partial} from './functional/partial'
@@ -53,8 +55,14 @@ export {pipe} from './functional/pipe'
 export {tap} from './functional/tap'
 
 // Module utilities
-export {dynamicImport, interopDefault, isESModule, resolveModule} from './module/interop'
-export type {Awaitable} from './module/interop'
+export {
+  dynamicImport,
+  interopDefault,
+  isESModule,
+  isPackageInScope,
+  resolveModule,
+} from './module/interop'
+export type {Awaitable, IsPackageInScopeOptions} from './module/interop'
 
 // Result types and utilities
 export {err, ok} from './result/factories'

--- a/packages/es/src/module/index.ts
+++ b/packages/es/src/module/index.ts
@@ -2,4 +2,5 @@
  * @bfra.me/es/module - Module interoperability utilities
  */
 
-export {dynamicImport, interopDefault, isESModule, resolveModule} from './interop'
+export type {Awaitable, IsPackageInScopeOptions} from './interop'
+export {dynamicImport, interopDefault, isESModule, isPackageInScope, resolveModule} from './interop'

--- a/packages/es/test/module/interop.test.ts
+++ b/packages/es/test/module/interop.test.ts
@@ -1,0 +1,175 @@
+import {describe, expect, it} from 'vitest'
+import {
+  dynamicImport,
+  interopDefault,
+  isESModule,
+  isPackageInScope,
+  resolveModule,
+} from '../../src/module'
+import {isErr, isOk} from '../../src/result'
+
+describe('@bfra.me/es/module', () => {
+  describe('interopDefault', () => {
+    it.concurrent('should return value as-is when no default export', async () => {
+      const plainObject = {foo: 'bar'}
+      const result = await interopDefault(plainObject)
+      expect(result).toEqual({foo: 'bar'})
+    })
+
+    it.concurrent('should unwrap default export from ES module', async () => {
+      const esModule = {default: {foo: 'bar'}}
+      const result = await interopDefault(esModule)
+      expect(result).toEqual({foo: 'bar'})
+    })
+
+    it.concurrent('should handle nested default exports', async () => {
+      const nestedModule = {default: {default: 'inner'}}
+      const result = await interopDefault(nestedModule)
+      expect(result).toBe('inner')
+    })
+
+    it.concurrent('should handle Promise-wrapped modules', async () => {
+      const promiseModule = Promise.resolve({default: 'resolved'})
+      const result = await interopDefault(promiseModule)
+      expect(result).toBe('resolved')
+    })
+
+    it.concurrent('should handle primitive values', async () => {
+      const stringValue = 'primitive'
+      const result = await interopDefault(stringValue)
+      expect(result).toBe('primitive')
+    })
+
+    it.concurrent('should handle null value', async () => {
+      const result = await interopDefault(null)
+      expect(result).toBeNull()
+    })
+
+    it.concurrent('should handle array values', async () => {
+      const arrayValue = [1, 2, 3]
+      const result = await interopDefault(arrayValue)
+      expect(result).toEqual([1, 2, 3])
+    })
+  })
+
+  describe('isESModule', () => {
+    it.concurrent('should return true for object with __esModule flag', () => {
+      const esModule = {__esModule: true, foo: 'bar'}
+      expect(isESModule(esModule)).toBe(true)
+    })
+
+    it.concurrent('should return true for Module object with Symbol.toStringTag', () => {
+      const moduleObject = {[Symbol.toStringTag]: 'Module', foo: 'bar'}
+      expect(isESModule(moduleObject)).toBe(true)
+    })
+
+    it.concurrent('should return false for plain object', () => {
+      const plainObject = {foo: 'bar'}
+      expect(isESModule(plainObject)).toBe(false)
+    })
+
+    it.concurrent('should return false for null', () => {
+      expect(isESModule(null)).toBe(false)
+    })
+
+    it.concurrent('should return false for undefined', () => {
+      expect(isESModule(undefined)).toBe(false)
+    })
+
+    it.concurrent('should return false for primitive values', () => {
+      expect(isESModule('string')).toBe(false)
+      expect(isESModule(123)).toBe(false)
+      expect(isESModule(true)).toBe(false)
+    })
+
+    it.concurrent('should return false for array', () => {
+      expect(isESModule([1, 2, 3])).toBe(false)
+    })
+
+    it.concurrent('should return false for function', () => {
+      expect(isESModule(() => {})).toBe(false)
+    })
+  })
+
+  describe('resolveModule', () => {
+    it.concurrent('should resolve built-in Node.js modules', async () => {
+      const result = await resolveModule<typeof import('node:path')>('node:path')
+      expect(isOk(result)).toBe(true)
+      expect(result.success).toBe(true)
+      expect(result.success && typeof result.data.join).toBe('function')
+    })
+
+    it.concurrent('should return Err for non-existent module', async () => {
+      const result = await resolveModule('non-existent-module-xyz-123')
+      expect(isErr(result)).toBe(true)
+      expect(result.success).toBe(false)
+      expect(!result.success && result.error).toBeInstanceOf(Error)
+    })
+
+    it.concurrent('should resolve workspace packages', async () => {
+      const result = await resolveModule('vitest')
+      expect(isOk(result)).toBe(true)
+    })
+  })
+
+  describe('dynamicImport', () => {
+    it.concurrent('should import built-in modules', async () => {
+      const result = await dynamicImport<typeof import('node:fs')>('node:fs')
+      expect(isOk(result)).toBe(true)
+      expect(result.success).toBe(true)
+      expect(result.success && typeof result.data.readFileSync).toBe('function')
+    })
+
+    it.concurrent('should return Err for invalid module path', async () => {
+      const result = await dynamicImport('/non/existent/path.js')
+      expect(isErr(result)).toBe(true)
+    })
+
+    it.concurrent('should have same behavior as resolveModule', async () => {
+      const resolveResult = await resolveModule('node:url')
+      const dynamicResult = await dynamicImport('node:url')
+      expect(isOk(resolveResult)).toBe(isOk(dynamicResult))
+    })
+  })
+
+  describe('isPackageInScope', () => {
+    it.concurrent('should return true for installed packages', () => {
+      expect(isPackageInScope('vitest')).toBe(true)
+    })
+
+    it.concurrent('should return true for Node.js built-in modules', () => {
+      expect(isPackageInScope('node:fs')).toBe(true)
+      expect(isPackageInScope('node:path')).toBe(true)
+    })
+
+    it.concurrent('should return false for non-existent packages', () => {
+      expect(isPackageInScope('non-existent-package-xyz-abc-123')).toBe(false)
+    })
+
+    it.concurrent('should return false for empty string', () => {
+      expect(isPackageInScope('')).toBe(false)
+    })
+
+    it.concurrent('should return false for whitespace-only string', () => {
+      expect(isPackageInScope('   ')).toBe(false)
+    })
+
+    it.concurrent('should work with scopeUrl option as string', () => {
+      const scopeUrl = new URL('.', import.meta.url).href
+      expect(isPackageInScope('vitest', {scopeUrl})).toBe(true)
+    })
+
+    it.concurrent('should work with scopeUrl option as URL object', () => {
+      const scopeUrl = new URL('.', import.meta.url)
+      expect(isPackageInScope('vitest', {scopeUrl})).toBe(true)
+    })
+
+    it.concurrent('should work with regular file path as scopeUrl', () => {
+      expect(isPackageInScope('vitest', {scopeUrl: process.cwd()})).toBe(true)
+    })
+
+    it.concurrent('should return false for package not in specified scope', () => {
+      expect(isPackageInScope('non-existent-xyz', {scopeUrl: '/tmp'})).toBe(false)
+    })
+  })
+})


### PR DESCRIPTION
- Add `isPackageInScope` function to check if a package exists within a specific scope.
- Update `interop.ts` to include new interface and function for package scope checking.
- Modify `index.ts` to export new types for better utility access.
- Create comprehensive tests for `isPackageInScope`, `interopDefault`, and other utilities.

Closes #2283.