### PR TITLE
feat(es): add branded types for file paths and implement tests

### DIFF
--- a/.ai/plan/feature-es-package-1.md
+++ b/.ai/plan/feature-es-package-1.md
@@ -159,15 +159,15 @@ Create a shared `@bfra.me/es` package that provides high-quality reusable types 
 
 | Task | Description | Completed | Date |
 |------|-------------|-----------|------|
-| TASK-042 | Implement `Brand<T, B extends string>` and `Opaque<T, B extends string>` types in `src/types/brand.ts` | | |
-| TASK-043 | Implement `brand<T, B extends string>(value: T): Brand<T, B>` factory function | | |
-| TASK-044 | Implement `unbrand<T>(value: Brand<T, any>): T` extraction function | | |
-| TASK-045 | Create common branded types: `NonEmptyString`, `PositiveInteger`, `ValidPath`, `AbsolutePath` | | |
-| TASK-046 | Implement common type guards in `src/types/guards.ts`: `isString()`, `isNumber()`, `isObject()`, `isArray()`, `isFunction()` | | |
-| TASK-047 | Implement `hasProperty<K extends PropertyKey>(obj: unknown, key: K): obj is Record<K, unknown>` | | |
-| TASK-048 | Implement `isNonNullable<T>(value: T): value is NonNullable<T>` guard | | |
-| TASK-049 | Implement `assertType<T>(value: unknown, guard: (v: unknown) => v is T): asserts value is T` | | |
-| TASK-050 | Create barrel export in `src/types/index.ts` with all type utilities | | |
+| TASK-042 | Implement `Brand<T, B extends string>` and `Opaque<T, B extends string>` types in `src/types/brand.ts` | ✅ | 2025-11-30 |
+| TASK-043 | Implement `brand<T, B extends string>(value: T): Brand<T, B>` factory function | ✅ | 2025-11-30 |
+| TASK-044 | Implement `unbrand<T>(value: Brand<T, any>): T` extraction function | ✅ | 2025-11-30 |
+| TASK-045 | Create common branded types: `NonEmptyString`, `PositiveInteger`, `ValidPath`, `AbsolutePath` | ✅ | 2025-11-30 |
+| TASK-046 | Implement common type guards in `src/types/guards.ts`: `isString()`, `isNumber()`, `isObject()`, `isArray()`, `isFunction()` | ✅ | 2025-11-30 |
+| TASK-047 | Implement `hasProperty<K extends PropertyKey>(obj: unknown, key: K): obj is Record<K, unknown>` | ✅ | 2025-11-30 |
+| TASK-048 | Implement `isNonNullable<T>(value: T): value is NonNullable<T>` guard | ✅ | 2025-11-30 |
+| TASK-049 | Implement `assertType<T>(value: unknown, guard: (v: unknown) => v is T): asserts value is T` | ✅ | 2025-11-30 |
+| TASK-050 | Create barrel export in `src/types/index.ts` with all type utilities | ✅ | 2025-11-30 |
 
 ### Implementation Phase 7: Async Utilities
 

--- a/packages/es/src/types/assertions.ts
+++ b/packages/es/src/types/assertions.ts
@@ -1,9 +1,7 @@
 /**
- * Asserts that a value matches a type guard, throwing if it doesn't.
+ * Runtime assertion that throws for invalid types, enabling fail-fast error detection.
+ * Use at API boundaries where invalid input should halt execution immediately.
  *
- * @param value - The value to check
- * @param guard - The type guard function
- * @param message - Optional error message
  * @throws Error if the guard returns false
  */
 export function assertType<T>(

--- a/packages/es/src/types/brand.ts
+++ b/packages/es/src/types/brand.ts
@@ -1,43 +1,52 @@
 declare const BrandSymbol: unique symbol
 
 /**
- * A branded type that adds a compile-time tag to a base type.
- * Values of Brand<T, B> are assignable to T but not vice versa.
+ * Creates nominal typing in TypeScript's structural type system,
+ * preventing accidental assignment of structurally-compatible values.
  */
 export type Brand<T, B extends string> = T & {readonly [BrandSymbol]: B}
 
 /**
- * An opaque type that completely hides the underlying type.
- * More restrictive than Brand - the base type is not accessible.
+ * Like Brand but semantically indicates the underlying type should be treated as hidden.
+ * Use for values where the internal representation is an implementation detail.
  */
 export type Opaque<T, B extends string> = T & {readonly [BrandSymbol]: B}
 
 /**
- * A string that is guaranteed to be non-empty.
+ * Compile-time marker for strings validated as non-empty.
+ * Validation must be performed separately before branding.
  */
 export type NonEmptyString = Brand<string, 'NonEmptyString'>
 
 /**
- * A number that is guaranteed to be a positive integer.
+ * Compile-time marker for numbers validated as positive integers.
+ * Validation must be performed separately before branding.
  */
 export type PositiveInteger = Brand<number, 'PositiveInteger'>
 
 /**
- * Brands a value with the specified brand type.
- * This is a compile-time operation and does no runtime validation.
- *
- * @param value - The value to brand
- * @returns The branded value
+ * Compile-time marker for paths validated against null bytes and invalid characters.
+ * Validation must be performed separately before branding.
+ */
+export type ValidPath = Brand<string, 'ValidPath'>
+
+/**
+ * Compile-time marker for paths validated as absolute (Unix / or Windows drive letter).
+ * Validation must be performed separately before branding.
+ */
+export type AbsolutePath = Brand<string, 'AbsolutePath'>
+
+/**
+ * Zero-cost type cast that brands a value after external validation.
+ * This is purely a compile-time operation with no runtime overhead.
  */
 export function brand<T, B extends string>(value: T): Brand<T, B> {
   return value as Brand<T, B>
 }
 
 /**
- * Removes the brand from a branded value, returning the base type.
- *
- * @param value - The branded value
- * @returns The unbranded value
+ * Zero-cost type cast that removes branding when the raw value is needed.
+ * Useful for serialization or passing to external APIs that don't understand branded types.
  */
 export function unbrand<T>(value: Brand<T, string>): T {
   return value as T

--- a/packages/es/src/types/guards.ts
+++ b/packages/es/src/types/guards.ts
@@ -1,40 +1,40 @@
 /**
- * Type guard that checks if a value is a string.
+ * Narrows unknown values to string for safe string operations.
  */
 export function isString(value: unknown): value is string {
   return typeof value === 'string'
 }
 
 /**
- * Type guard that checks if a value is a number (and not NaN).
+ * Narrows unknown values to number, excluding NaN which often indicates invalid numeric operations.
  */
 export function isNumber(value: unknown): value is number {
   return typeof value === 'number' && !Number.isNaN(value)
 }
 
 /**
- * Type guard that checks if a value is a non-null object.
+ * Narrows to plain objects, excluding arrays and null to match typical "object" semantics in APIs.
  */
 export function isObject(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value)
 }
 
 /**
- * Type guard that checks if a value is an array.
+ * Narrows unknown values to arrays for safe iteration and array method access.
  */
 export function isArray(value: unknown): value is unknown[] {
   return Array.isArray(value)
 }
 
 /**
- * Type guard that checks if a value is a function.
+ * Narrows unknown values to callable functions for safe invocation.
  */
 export function isFunction(value: unknown): value is (...args: unknown[]) => unknown {
   return typeof value === 'function'
 }
 
 /**
- * Type guard that checks if an object has a specific property.
+ * Safely checks for property existence before access, preventing undefined property errors.
  */
 export function hasProperty<K extends PropertyKey>(
   obj: unknown,
@@ -44,7 +44,7 @@ export function hasProperty<K extends PropertyKey>(
 }
 
 /**
- * Type guard that checks if a value is not null or undefined.
+ * Filters out null and undefined, enabling safe property access on optional values.
  */
 export function isNonNullable<T>(value: T): value is NonNullable<T> {
   return value !== null && value !== undefined

--- a/packages/es/src/types/index.ts
+++ b/packages/es/src/types/index.ts
@@ -5,7 +5,7 @@
 // Assertion utilities
 export {assertType} from './assertions'
 // Branded types
-export type {Brand, NonEmptyString, Opaque, PositiveInteger} from './brand'
+export type {AbsolutePath, Brand, NonEmptyString, Opaque, PositiveInteger, ValidPath} from './brand'
 
 export {brand, unbrand} from './brand'
 

--- a/packages/es/test/types/assertions.test.ts
+++ b/packages/es/test/types/assertions.test.ts
@@ -1,0 +1,67 @@
+import {describe, expect, it} from 'vitest'
+
+import {assertType, isNumber, isString} from '../../src/types'
+
+describe('@bfra.me/es/types - assertions', () => {
+  describe('assertType()', () => {
+    it.concurrent('should not throw when guard returns true', () => {
+      const value: unknown = 'hello'
+      expect(() => assertType(value, isString)).not.toThrow()
+    })
+
+    it.concurrent('should throw when guard returns false', () => {
+      const value: unknown = 123
+      expect(() => assertType(value, isString)).toThrow('Type assertion failed')
+    })
+
+    it.concurrent('should throw with custom message', () => {
+      const value: unknown = 'not a number'
+      expect(() => assertType(value, isNumber, 'Expected a number')).toThrow('Expected a number')
+    })
+
+    it.concurrent('should narrow the type after successful assertion', () => {
+      const value: unknown = 'test'
+      assertType(value, isString)
+      const result: string = value.toUpperCase()
+      expect(result).toBe('TEST')
+    })
+
+    it.concurrent('should work with isNumber guard', () => {
+      const value: unknown = 42
+      assertType(value, isNumber)
+      const result: number = value * 2
+      expect(result).toBe(84)
+    })
+
+    it.concurrent('should work with custom type guards', () => {
+      interface User {
+        name: string
+        age: number
+      }
+
+      function isUser(value: unknown): value is User {
+        return (
+          typeof value === 'object' &&
+          value !== null &&
+          'name' in value &&
+          'age' in value &&
+          typeof (value as User).name === 'string' &&
+          typeof (value as User).age === 'number'
+        )
+      }
+
+      const value: unknown = {name: 'Alice', age: 30}
+      assertType(value, isUser)
+      expect(value.name).toBe('Alice')
+      expect(value.age).toBe(30)
+    })
+
+    it.concurrent('should throw for null when using isString', () => {
+      expect(() => assertType(null, isString)).toThrow('Type assertion failed')
+    })
+
+    it.concurrent('should throw for undefined when using isNumber', () => {
+      expect(() => assertType(undefined, isNumber)).toThrow('Type assertion failed')
+    })
+  })
+})

--- a/packages/es/test/types/brand.test.ts
+++ b/packages/es/test/types/brand.test.ts
@@ -1,0 +1,150 @@
+import type {
+  AbsolutePath,
+  Brand,
+  NonEmptyString,
+  Opaque,
+  PositiveInteger,
+  ValidPath,
+} from '../../src/types'
+
+import {describe, expect, it} from 'vitest'
+
+import {brand, unbrand} from '../../src/types'
+
+describe('@bfra.me/es/types - branded types', () => {
+  describe('brand()', () => {
+    it.concurrent('should brand a string value', () => {
+      const value = 'hello'
+      const branded = brand<string, 'TestBrand'>(value)
+      expect(branded).toBe('hello')
+    })
+
+    it.concurrent('should brand a number value', () => {
+      const value = 42
+      const branded = brand<number, 'TestNumber'>(value)
+      expect(branded).toBe(42)
+    })
+
+    it.concurrent('should brand an object value', () => {
+      const value = {foo: 'bar'}
+      const branded = brand<typeof value, 'TestObject'>(value)
+      expect(branded).toEqual({foo: 'bar'})
+    })
+
+    it.concurrent('should preserve reference identity for objects', () => {
+      const value = {foo: 'bar'}
+      const branded = brand<typeof value, 'TestObject'>(value)
+      expect(branded).toBe(value)
+    })
+  })
+
+  describe('unbrand()', () => {
+    it.concurrent('should unbrand a branded string', () => {
+      const branded = brand<string, 'TestBrand'>('hello')
+      const unbranded = unbrand(branded)
+      expect(unbranded).toBe('hello')
+    })
+
+    it.concurrent('should unbrand a branded number', () => {
+      const branded = brand<number, 'TestNumber'>(42)
+      const unbranded = unbrand(branded)
+      expect(unbranded).toBe(42)
+    })
+
+    it.concurrent('should unbrand a branded object', () => {
+      const original = {foo: 'bar'}
+      const branded = brand<typeof original, 'TestObject'>(original)
+      const unbranded = unbrand(branded)
+      expect(unbranded).toEqual({foo: 'bar'})
+      expect(unbranded).toBe(original)
+    })
+  })
+
+  describe('brand type', () => {
+    it.concurrent('should work with type assertions', () => {
+      type UserId = Brand<string, 'UserId'>
+      const userId = 'user-123' as UserId
+      expect(userId).toBe('user-123')
+    })
+
+    it.concurrent('should work with branded factory', () => {
+      type Email = Brand<string, 'Email'>
+      const email: Email = brand<string, 'Email'>('test@example.com')
+      expect(email).toBe('test@example.com')
+    })
+  })
+
+  describe('opaque type', () => {
+    it.concurrent('should work similar to Brand', () => {
+      type Token = Opaque<string, 'Token'>
+      const token = 'secret-token' as Token
+      expect(token).toBe('secret-token')
+    })
+  })
+
+  describe('nonEmptyString type', () => {
+    it.concurrent('should brand non-empty strings', () => {
+      const value: NonEmptyString = brand<string, 'NonEmptyString'>('hello')
+      expect(value).toBe('hello')
+    })
+
+    it.concurrent('should allow any string at runtime (validation is separate concern)', () => {
+      const value: NonEmptyString = brand<string, 'NonEmptyString'>('')
+      expect(value).toBe('')
+    })
+  })
+
+  describe('positiveInteger type', () => {
+    it.concurrent('should brand positive integers', () => {
+      const value: PositiveInteger = brand<number, 'PositiveInteger'>(42)
+      expect(value).toBe(42)
+    })
+
+    it.concurrent('should allow any number at runtime (validation is separate concern)', () => {
+      const value: PositiveInteger = brand<number, 'PositiveInteger'>(-5)
+      expect(value).toBe(-5)
+    })
+  })
+
+  describe('validPath type', () => {
+    it.concurrent('should brand valid paths', () => {
+      const value: ValidPath = brand<string, 'ValidPath'>('/home/user/file.txt')
+      expect(value).toBe('/home/user/file.txt')
+    })
+
+    it.concurrent('should brand relative paths', () => {
+      const value: ValidPath = brand<string, 'ValidPath'>('./relative/path')
+      expect(value).toBe('./relative/path')
+    })
+  })
+
+  describe('absolutePath type', () => {
+    it.concurrent('should brand absolute Unix paths', () => {
+      const value: AbsolutePath = brand<string, 'AbsolutePath'>('/usr/local/bin')
+      expect(value).toBe('/usr/local/bin')
+    })
+
+    it.concurrent('should brand absolute Windows paths', () => {
+      const value: AbsolutePath = brand<string, 'AbsolutePath'>(String.raw`C:\Users\Test`)
+      expect(value).toBe(String.raw`C:\Users\Test`)
+    })
+  })
+
+  describe('type safety (compile-time)', () => {
+    it.concurrent('branded values should be usable as base type', () => {
+      type UserId = Brand<string, 'UserId'>
+      const userId: UserId = brand<string, 'UserId'>('user-123')
+
+      const acceptsString = (s: string): string => s.toUpperCase()
+      expect(acceptsString(userId)).toBe('USER-123')
+    })
+
+    it.concurrent('branded numbers should support arithmetic', () => {
+      type Score = Brand<number, 'Score'>
+      const score: Score = brand<number, 'Score'>(100)
+
+      const doubled: number = score * 2
+      expect(doubled).toBe(200)
+    })
+  })
+})

--- a/packages/es/test/types/guards.test.ts
+++ b/packages/es/test/types/guards.test.ts
@@ -1,0 +1,233 @@
+import {describe, expect, it} from 'vitest'
+
+import {
+  hasProperty,
+  isArray,
+  isFunction,
+  isNonNullable,
+  isNumber,
+  isObject,
+  isString,
+} from '../../src/types'
+
+describe('@bfra.me/es/types - type guards', () => {
+  describe('isString()', () => {
+    it.concurrent('should return true for strings', () => {
+      expect(isString('hello')).toBe(true)
+      expect(isString('')).toBe(true)
+      expect(isString(String('test'))).toBe(true)
+    })
+
+    it.concurrent('should return false for non-strings', () => {
+      expect(isString(123)).toBe(false)
+      expect(isString(null)).toBe(false)
+      expect(isString(undefined)).toBe(false)
+      expect(isString({})).toBe(false)
+      expect(isString([])).toBe(false)
+      expect(isString(true)).toBe(false)
+    })
+  })
+
+  describe('isNumber()', () => {
+    it.concurrent('should return true for valid numbers', () => {
+      expect(isNumber(42)).toBe(true)
+      expect(isNumber(0)).toBe(true)
+      expect(isNumber(-1)).toBe(true)
+      expect(isNumber(3.14)).toBe(true)
+      expect(isNumber(Infinity)).toBe(true)
+      expect(isNumber(-Infinity)).toBe(true)
+    })
+
+    it.concurrent('should return false for NaN', () => {
+      expect(isNumber(Number.NaN)).toBe(false)
+    })
+
+    it.concurrent('should return false for non-numbers', () => {
+      expect(isNumber('42')).toBe(false)
+      expect(isNumber(null)).toBe(false)
+      expect(isNumber(undefined)).toBe(false)
+      expect(isNumber({})).toBe(false)
+    })
+  })
+
+  describe('isObject()', () => {
+    it.concurrent('should return true for plain objects', () => {
+      expect(isObject({})).toBe(true)
+      expect(isObject({foo: 'bar'})).toBe(true)
+      expect(isObject(Object.create(null))).toBe(true)
+    })
+
+    it.concurrent('should return false for null', () => {
+      expect(isObject(null)).toBe(false)
+    })
+
+    it.concurrent('should return false for arrays', () => {
+      expect(isObject([])).toBe(false)
+      expect(isObject([1, 2, 3])).toBe(false)
+    })
+
+    it.concurrent('should return false for primitives', () => {
+      expect(isObject('string')).toBe(false)
+      expect(isObject(123)).toBe(false)
+      expect(isObject(true)).toBe(false)
+      expect(isObject(undefined)).toBe(false)
+    })
+  })
+
+  describe('isArray()', () => {
+    it.concurrent('should return true for arrays', () => {
+      expect(isArray([])).toBe(true)
+      expect(isArray([1, 2, 3])).toBe(true)
+      expect(isArray(Array.from({length: 5}))).toBe(true)
+    })
+
+    it.concurrent('should return false for non-arrays', () => {
+      expect(isArray({})).toBe(false)
+      expect(isArray('string')).toBe(false)
+      expect(isArray(null)).toBe(false)
+      expect(isArray(undefined)).toBe(false)
+    })
+
+    it.concurrent('should return false for array-like objects', () => {
+      expect(isArray({length: 3})).toBe(false)
+    })
+  })
+
+  describe('isFunction()', () => {
+    it.concurrent('should return true for functions', () => {
+      expect(isFunction(() => {})).toBe(true)
+      const namedFn = (): void => {}
+      expect(isFunction(namedFn)).toBe(true)
+      expect(isFunction(async () => {})).toBe(true)
+    })
+
+    it.concurrent('should return true for generator functions', () => {
+      // eslint-disable-next-line unicorn/consistent-function-scoping -- Test requires inline definition
+      function* generatorFn(): Generator<number> {
+        yield 1
+      }
+      expect(isFunction(generatorFn)).toBe(true)
+    })
+
+    it.concurrent('should return true for class constructors', () => {
+      class MyClass {
+        value = 0
+      }
+      expect(isFunction(MyClass)).toBe(true)
+    })
+
+    it.concurrent('should return false for non-functions', () => {
+      expect(isFunction({})).toBe(false)
+      expect(isFunction('string')).toBe(false)
+      expect(isFunction(123)).toBe(false)
+      expect(isFunction(null)).toBe(false)
+    })
+  })
+
+  describe('hasProperty()', () => {
+    it.concurrent('should return true when object has property', () => {
+      const obj = {foo: 'bar', count: 42}
+      expect(hasProperty(obj, 'foo')).toBe(true)
+      expect(hasProperty(obj, 'count')).toBe(true)
+    })
+
+    it.concurrent('should return false when object lacks property', () => {
+      const obj = {foo: 'bar'}
+      expect(hasProperty(obj, 'missing')).toBe(false)
+    })
+
+    it.concurrent('should return true for inherited properties', () => {
+      const obj = Object.create({inherited: true}) as Record<string, unknown>
+      expect(hasProperty(obj, 'inherited')).toBe(true)
+    })
+
+    it.concurrent('should return false for non-objects', () => {
+      expect(hasProperty(null, 'foo')).toBe(false)
+      expect(hasProperty(undefined, 'foo')).toBe(false)
+      expect(hasProperty('string', 'length')).toBe(false)
+      expect(hasProperty([], 'length')).toBe(false)
+    })
+
+    it.concurrent('should work with symbol keys', () => {
+      const sym = Symbol('test')
+      const obj = {[sym]: 'value'}
+      expect(hasProperty(obj, sym)).toBe(true)
+    })
+
+    it.concurrent('should work with numeric keys', () => {
+      const obj = {0: 'zero', 1: 'one'}
+      expect(hasProperty(obj, 0)).toBe(true)
+      expect(hasProperty(obj, 2)).toBe(false)
+    })
+  })
+
+  describe('isNonNullable()', () => {
+    it.concurrent('should return true for defined values', () => {
+      expect(isNonNullable('string')).toBe(true)
+      expect(isNonNullable(0)).toBe(true)
+      expect(isNonNullable(false)).toBe(true)
+      expect(isNonNullable('')).toBe(true)
+      expect(isNonNullable({})).toBe(true)
+      expect(isNonNullable([])).toBe(true)
+    })
+
+    it.concurrent('should return false for null', () => {
+      expect(isNonNullable(null)).toBe(false)
+    })
+
+    it.concurrent('should return false for undefined', () => {
+      expect(isNonNullable(undefined)).toBe(false)
+    })
+
+    it.concurrent('should narrow types correctly', () => {
+      const value: string | null = 'hello'
+      expect(isNonNullable(value)).toBe(true)
+      const result: string = isNonNullable(value) ? value : ''
+      expect(result).toBe('hello')
+    })
+  })
+
+  describe('type narrowing', () => {
+    it.concurrent('isString should narrow to string', () => {
+      const value: unknown = 'test'
+      expect(isString(value)).toBe(true)
+      const result: string = isString(value) ? value.toUpperCase() : ''
+      expect(result).toBe('TEST')
+    })
+
+    it.concurrent('isNumber should narrow to number', () => {
+      const value: unknown = 42
+      expect(isNumber(value)).toBe(true)
+      const result: number = isNumber(value) ? value * 2 : 0
+      expect(result).toBe(84)
+    })
+
+    it.concurrent('isObject should narrow to Record<string, unknown>', () => {
+      const value: unknown = {foo: 'bar'}
+      expect(isObject(value)).toBe(true)
+      const result = isObject(value) ? value.foo : undefined
+      expect(result).toBe('bar')
+    })
+
+    it.concurrent('isArray should narrow to unknown[]', () => {
+      const value: unknown = [1, 2, 3]
+      expect(isArray(value)).toBe(true)
+      const result = isArray(value) ? value.length : 0
+      expect(result).toBe(3)
+    })
+
+    it.concurrent('isFunction should narrow to function type', () => {
+      const value: unknown = () => 'hello'
+      expect(isFunction(value)).toBe(true)
+      const result = isFunction(value) ? value() : ''
+      expect(result).toBe('hello')
+    })
+
+    it.concurrent('hasProperty should narrow object type', () => {
+      const value: unknown = {name: 'Alice', age: 30}
+      expect(hasProperty(value, 'name')).toBe(true)
+      const result = hasProperty(value, 'name') ? value.name : ''
+      expect(result).toBe('Alice')
+    })
+  })
+})


### PR DESCRIPTION
- Introduce AbsolutePath and ValidPath branded types for better type safety.
- Update index.ts to export new branded types.
- Create assertions.test.ts to validate type guards and assertions.
- Add brand.test.ts to test branding and unbranding functionality.
- Implement guards.test.ts to ensure type guards work as expected.

Closes #2285.