### PR TITLE
test(es): add type guard usage patterns and anti-pattern tests

### DIFF
--- a/.ai/plan/feature-es-package-1.md
+++ b/.ai/plan/feature-es-package-1.md
@@ -288,13 +288,13 @@ Create a shared `@bfra.me/es` package that provides high-quality reusable types 
 
 | Task | Description | Completed | Date |
 |------|-------------|-----------|------|
-| TASK-108 | Create fixture testing proper Result usage patterns | | |
-| TASK-109 | Create fixture testing improper Result usage (throwing from Result code paths) | | |
-| TASK-110 | Create fixture testing proper functional composition patterns | | |
-| TASK-111 | Create fixture testing pipe/compose misuse (side effects, mutation) | | |
-| TASK-112 | Create fixture testing proper type guard usage vs. type assertion | | |
-| TASK-113 | Write anti-pattern detection tests in `test/patterns/anti-pattern-detection.test.ts` | | |
-| TASK-114 | Write best practice validation tests in `test/patterns/best-practices.test.ts` | | |
+| TASK-108 | Create fixture testing proper Result usage patterns | ✅ | 2025-12-01 |
+| TASK-109 | Create fixture testing improper Result usage (throwing from Result code paths) | ✅ | 2025-12-01 |
+| TASK-110 | Create fixture testing proper functional composition patterns | ✅ | 2025-12-01 |
+| TASK-111 | Create fixture testing pipe/compose misuse (side effects, mutation) | ✅ | 2025-12-01 |
+| TASK-112 | Create fixture testing proper type guard usage vs. type assertion | ✅ | 2025-12-01 |
+| TASK-113 | Write anti-pattern detection tests in `test/patterns/anti-pattern-detection.test.ts` | ✅ | 2025-12-01 |
+| TASK-114 | Write best practice validation tests in `test/patterns/best-practices.test.ts` | ✅ | 2025-12-01 |
 
 ### Implementation Phase 16: Documentation
 

--- a/packages/es/test/fixtures/patterns/functional-improper-usage.ts
+++ b/packages/es/test/fixtures/patterns/functional-improper-usage.ts
@@ -1,0 +1,222 @@
+/**
+ * Improper functional composition patterns - demonstrates anti-patterns to detect and avoid.
+ * This file contains intentional anti-patterns for testing detection logic.
+ *
+ * WARNING: Do NOT copy these patterns - they demonstrate what NOT to do.
+ */
+
+import {compose, pipe} from '../../../src/functional'
+
+/**
+ * ANTI-PATTERN 1: Side effects in pipeline functions
+ * Functions in pipe/compose should be pure - no external state modification.
+ */
+let globalCounter = 0
+
+export const pipeWithSideEffect = pipe(
+  (x: number) => {
+    globalCounter++ // WRONG: Modifying external state
+    return x + 1
+  },
+  (x: number) => x * 2,
+)
+
+export {globalCounter}
+
+/**
+ * ANTI-PATTERN 2: Mutating the input argument
+ * Never mutate the input - always return a new value.
+ */
+interface MutableState {
+  count: number
+  items: string[]
+}
+
+export const mutatingPipeline = pipe(
+  (state: MutableState) => {
+    state.count++ // WRONG: Mutating input
+    return state
+  },
+  (state: MutableState) => {
+    state.items.push('new item') // WRONG: Mutating input array
+    return state
+  },
+)
+
+/**
+ * ANTI-PATTERN 3: Throwing inside pipeline functions
+ * Pipeline functions should be total (handle all inputs).
+ */
+export const throwingPipeline = pipe(
+  (x: number) => {
+    if (x < 0) {
+      throw new Error('Negative numbers not allowed') // WRONG: Should use Result
+    }
+    return x + 1
+  },
+  (x: number) => x * 2,
+)
+
+/**
+ * ANTI-PATTERN 4: Async functions in sync pipelines
+ * Mixing async and sync creates confusion and potential bugs.
+ */
+export const mixedAsyncPipeline = pipe(
+  (x: number) => x + 1,
+  async (x: number) => {
+    await Promise.resolve()
+    return x * 2 // WRONG: Async in sync pipeline - returns Promise, not number
+  },
+)
+
+/**
+ * ANTI-PATTERN 5: I/O operations inside pipelines
+ * I/O should be at boundaries, not inside pure transformations.
+ */
+export const ioInPipeline = pipe(
+  (filename: string) => filename.toUpperCase(),
+  (filename: string) => {
+    console.log(`Processing: ${filename}`) // WRONG: I/O side effect (console.log without tap)
+    return filename
+  },
+  (filename: string) => `processed_${filename}`,
+)
+
+/**
+ * ANTI-PATTERN 6: Depending on execution order for state
+ * Each function should be independent.
+ */
+const sharedState = {value: 0}
+
+export const orderDependentPipeline = pipe(
+  (x: number) => {
+    sharedState.value = x // WRONG: Setting shared state
+    return x + 1
+  },
+  (x: number) => {
+    return x + sharedState.value // WRONG: Reading shared state set by previous function
+  },
+)
+
+export {sharedState}
+
+/**
+ * ANTI-PATTERN 7: Non-deterministic functions in pipelines
+ * Pure functions should always return the same output for the same input.
+ */
+export const nonDeterministicPipeline = pipe(
+  (x: number) => x + Math.random(), // WRONG: Non-deterministic
+  (x: number) => x * 2,
+)
+
+/**
+ * ANTI-PATTERN 8: Direct external system manipulation in pipelines
+ * Side effects to external systems should be at boundaries.
+ */
+export const externalManipulationPipeline = pipe(
+  (text: string) => text.toUpperCase(),
+  (text: string) => {
+    // WRONG: External system manipulation inside pipeline
+    // Example: modifying environment, file system, or other external state
+    process.env.LAST_PROCESSED = text
+    return text
+  },
+)
+
+/**
+ * ANTI-PATTERN 9: Using closures that capture mutable state
+ * Closures should only capture immutable values.
+ */
+function createBadPipeline() {
+  let cache: number | null = null
+
+  return pipe(
+    (x: number) => {
+      if (cache !== null) {
+        return cache // WRONG: Returning cached value, not processing input
+      }
+      return x + 1
+    },
+    (x: number) => {
+      cache = x // WRONG: Caching in mutable closure
+      return x * 2
+    },
+  )
+}
+
+export const badCachingPipeline = createBadPipeline()
+
+/**
+ * ANTI-PATTERN 10: Breaking the pipeline with early returns
+ * All paths should return a value of the expected type.
+ */
+export const earlyReturnPipeline = pipe(
+  (x: number) => {
+    if (x === 0) {
+      return 0 // This is fine, but the next function might expect non-zero
+    }
+    return x + 1
+  },
+  (x: number) => {
+    // This might fail or give unexpected results if x is 0
+    return 10 / x // WRONG: Division by zero possible due to early return above
+  },
+)
+
+/**
+ * ANTI-PATTERN 11: Overly long pipelines without decomposition
+ * Long pipelines should be broken into named, composable units.
+ */
+export const tooLongPipeline = pipe(
+  (x: number) => x + 1,
+  (x: number) => x * 2,
+  (x: number) => x - 3,
+  (x: number) => x / 4,
+  (x: number) => x + 5,
+  (x: number) => x * 6,
+  (x: number) => x - 7,
+  (x: number) => x / 8,
+  (x: number) => x + 9,
+  (x: number) => x * 10,
+)
+
+/**
+ * ANTI-PATTERN 12: Using compose/pipe for single function
+ * Unnecessary wrapping adds complexity without benefit.
+ */
+export const unnecessaryPipe = pipe((x: number) => x + 1) // WRONG: Just use the function directly
+
+/**
+ * ANTI-PATTERN 13: Tight coupling to external services
+ * External service calls should be dependency-injected or at boundaries.
+ */
+export const externalServicePipeline = pipe(
+  (userId: string) => userId.trim(),
+  async (userId: string) => {
+    // WRONG: Direct HTTP call inside pipeline
+    const response = await fetch(`https://api.example.com/users/${userId}`)
+    return response.json()
+  },
+)
+
+/**
+ * ANTI-PATTERN 14: Type assertions to bypass type safety
+ * If types don't align, fix the functions, don't assert.
+ */
+export const typeAssertionPipeline = pipe(
+  (x: unknown) => x as number, // WRONG: Unsafe type assertion
+  (x: number) => x * 2,
+)
+
+/**
+ * ANTI-PATTERN 15: Compose/pipe that doesn't compose well
+ * Functions should have compatible signatures for composition.
+ */
+const badlyDesigned1 = (x: number): {result: number} => ({result: x + 1})
+const badlyDesigned2 = (x: number): number => x * 2 // Expects number, not object
+
+export const incompatiblePipeline = compose(
+  badlyDesigned2,
+  // @ts-expect-error - Intentionally showing type mismatch anti-pattern
+  badlyDesigned1,
+)

--- a/packages/es/test/fixtures/patterns/functional-proper-usage.ts
+++ b/packages/es/test/fixtures/patterns/functional-proper-usage.ts
@@ -1,0 +1,150 @@
+/**
+ * Proper functional composition patterns - demonstrates correct usage of pipe/compose.
+ * This file serves as a reference for detecting anti-patterns by comparison.
+ */
+
+import {compose, constant, curry, identity, pipe, tap} from '../../../src/functional'
+
+/**
+ * PATTERN 1: Pure functions in pipe/compose
+ * All functions in a pipeline should be pure (no side effects).
+ */
+export const processNumber = pipe(
+  (x: number) => x + 1,
+  (x: number) => x * 2,
+  (x: number) => x.toString(),
+)
+
+/**
+ * PATTERN 2: Type transformations through pipeline
+ * Each function receives output of previous and returns new value.
+ */
+interface User {
+  id: number
+  name: string
+  email: string
+}
+
+interface UserDTO {
+  userId: number
+  displayName: string
+  contactEmail: string
+}
+
+export const toUserDTO = pipe(
+  (user: User) => ({
+    ...user,
+    displayName: user.name.toUpperCase(),
+  }),
+  (user: User & {displayName: string}): UserDTO => ({
+    userId: user.id,
+    displayName: user.displayName,
+    contactEmail: user.email,
+  }),
+)
+
+/**
+ * PATTERN 3: Use compose for right-to-left composition
+ * Compose is useful when thinking mathematically (f ∘ g means "f after g").
+ */
+export const formatPrice = compose(
+  (s: string) => `$${s}`,
+  (n: number) => n.toFixed(2),
+)
+
+/**
+ * PATTERN 4: Curried functions in pipelines
+ * Curry allows partial application for pipeline compatibility.
+ */
+const multiply = curry((a: number, b: number) => a * b)
+const add = curry((a: number, b: number) => a + b)
+
+export const calculateTotal = pipe(add(10), multiply(2), (x: number) => x - 5)
+
+/**
+ * PATTERN 5: Identity function for conditional pipelines
+ * Use identity as a pass-through when no transformation needed.
+ */
+export function conditionalProcess(value: number, shouldDouble: boolean): number {
+  const processor = pipe((x: number) => x + 1, shouldDouble ? (x: number) => x * 2 : identity)
+
+  return processor(value)
+}
+
+/**
+ * PATTERN 6: Use tap for debugging without breaking the chain
+ * Tap allows side effects (like logging) while maintaining data flow.
+ */
+const debugPipeline = pipe(
+  (x: number) => x + 1,
+  tap((x: number) => console.log('After add:', x)),
+  (x: number) => x * 2,
+  tap((x: number) => console.log('After multiply:', x)),
+)
+
+export {debugPipeline}
+
+/**
+ * PATTERN 7: Constant function for default values
+ * Use constant for functions that always return the same value.
+ */
+export const getDefaultValue = constant(42)
+export const getEmptyArray = constant<string[]>([])
+
+/**
+ * PATTERN 8: Composing with Result-returning functions
+ * Handle errors at pipeline boundaries, not inside.
+ */
+import {isErr, map, ok} from '../../../src/result'
+import type {Result} from '../../../src/result'
+
+function parseNumber(s: string): Result<number, string> {
+  const n = parseInt(s, 10)
+  return isNaN(n) ? {success: false, error: 'Not a number'} : ok(n)
+}
+
+function validatePositive(n: number): Result<number, string> {
+  return n > 0 ? ok(n) : {success: false, error: 'Must be positive'}
+}
+
+export function processStringToNumber(input: string): Result<number, string> {
+  const parsed = parseNumber(input)
+  if (isErr(parsed)) return parsed
+
+  const validated = validatePositive(parsed.data)
+  if (isErr(validated)) return validated
+
+  return map(validated, x => x * 2)
+}
+
+/**
+ * PATTERN 9: Small, focused functions for composition
+ * Each function should do one thing well.
+ */
+const trim = (s: string) => s.trim()
+const toLowerCase = (s: string) => s.toLowerCase()
+const removeSpaces = (s: string) => s.replace(/\s+/g, '-')
+const addPrefix = (prefix: string) => (s: string) => `${prefix}${s}`
+
+export const createSlug = pipe(trim, toLowerCase, removeSpaces, addPrefix('/'))
+
+/**
+ * PATTERN 10: Maintaining immutability in pipelines
+ * Never mutate input - always return new values.
+ */
+interface State {
+  count: number
+  items: string[]
+}
+
+const incrementCount = (state: State): State => ({
+  ...state,
+  count: state.count + 1,
+})
+
+const addItem = (item: string) => (state: State): State => ({
+  ...state,
+  items: [...state.items, item],
+})
+
+export const updateState = (item: string) => pipe(incrementCount, addItem(item))

--- a/packages/es/test/fixtures/patterns/result-improper-usage.ts
+++ b/packages/es/test/fixtures/patterns/result-improper-usage.ts
@@ -1,0 +1,172 @@
+/**
+ * Improper Result usage patterns - demonstrates anti-patterns to detect and avoid.
+ * This file contains intentional anti-patterns for testing detection logic.
+ *
+ * WARNING: Do NOT copy these patterns - they demonstrate what NOT to do.
+ */
+
+import {err, isErr, isOk, ok, unwrap} from '../../../src/result'
+import type {Result} from '../../../src/result'
+
+/**
+ * ANTI-PATTERN 1: Throwing inside Result-returning functions
+ * Functions returning Result should never throw for expected errors.
+ */
+export function divideNumbersBad(a: number, b: number): Result<number, string> {
+  if (b === 0) {
+    throw new Error('Division by zero') // WRONG: Should return err()
+  }
+  return ok(a / b)
+}
+
+/**
+ * ANTI-PATTERN 2: Mixing throw and Result in the same code path
+ * This creates inconsistent error handling.
+ */
+export function processDataBad(data: unknown): Result<string, string> {
+  if (data === null) {
+    throw new Error('Data cannot be null') // WRONG: Should return err()
+  }
+  if (typeof data !== 'string') {
+    return err('Data must be a string') // Correct usage
+  }
+  return ok(data.toUpperCase())
+}
+
+/**
+ * ANTI-PATTERN 3: Using try/catch inside Result-returning functions for expected errors
+ * Expected errors should be handled with Result, not exceptions.
+ */
+export function parseConfigBad(config: string): Result<object, string> {
+  try {
+    const parsed = JSON.parse(config)
+    return ok(parsed)
+  } catch {
+    throw new Error('Invalid JSON') // WRONG: Should return err()
+  }
+}
+
+/**
+ * ANTI-PATTERN 4: Ignoring Err results silently
+ * Errors should be explicitly handled or propagated.
+ */
+export function processIgnoringErrors(result: Result<number, string>): number {
+  if (isOk(result)) {
+    return result.data * 2
+  }
+  // WRONG: Error is silently ignored, returning magic value
+  return 0
+}
+
+/**
+ * ANTI-PATTERN 5: Using unwrap without proper error handling
+ * Unwrap should only be used when you're certain the Result is Ok.
+ */
+export function unsafeUnwrap(result: Result<string, Error>): string {
+  // WRONG: This will throw if result is Err - defeats the purpose of Result
+  return unwrap(result)
+}
+
+/**
+ * ANTI-PATTERN 6: Direct property access without type guards
+ * Should use isOk/isErr guards for proper type narrowing.
+ */
+export function directPropertyAccess(result: Result<number, string>): number | string {
+  // WRONG: Accessing .success directly without type guard
+  if ((result as {success: boolean}).success) {
+    return (result as {data: number}).data
+  }
+  return (result as {error: string}).error
+}
+
+/**
+ * ANTI-PATTERN 7: Converting Result back to throw
+ * This pattern negates the benefits of using Result.
+ */
+export function convertToThrow(result: Result<string, Error>): string {
+  if (isErr(result)) {
+    throw result.error // WRONG: Should propagate Result, not convert to throw
+  }
+  return result.data
+}
+
+/**
+ * ANTI-PATTERN 8: Catching and throwing different error
+ * This loses error context and makes debugging harder.
+ */
+export async function loseErrorContext(): Promise<Result<string, Error>> {
+  try {
+    const response = await fetch('https://example.com')
+    return ok(await response.text())
+  } catch {
+    throw new Error('Something went wrong') // WRONG: Original error context lost
+  }
+}
+
+/**
+ * ANTI-PATTERN 9: Using Result but still relying on exception flow
+ * Mixing paradigms creates confusion and bugs.
+ */
+export function mixedParadigms(values: number[]): Result<number, string> {
+  if (values.length === 0) {
+    return err('Array is empty')
+  }
+
+  // WRONG: Using exception for control flow within Result-based code
+  const sum = values.reduce((acc, val) => {
+    if (val < 0) {
+      throw new Error('Negative values not allowed')
+    }
+    return acc + val
+  }, 0)
+
+  return ok(sum)
+}
+
+/**
+ * ANTI-PATTERN 10: Not handling async Result rejections properly
+ * Async Result functions should catch rejections and return err().
+ */
+export async function asyncNoErrorHandling(url: string): Promise<Result<unknown, string>> {
+  // WRONG: fetch can reject, but we're not catching it
+  const response = await fetch(url)
+  if (!response.ok) {
+    return err(`HTTP ${response.status}`)
+  }
+  return ok(await response.json())
+}
+
+/**
+ * ANTI-PATTERN 11: Throwing inside map/flatMap callbacks
+ * These callbacks should be pure and not throw.
+ */
+export function throwInCallback(result: Result<string, Error>): Result<number, Error> {
+  if (isOk(result)) {
+    const parsed = parseInt(result.data, 10)
+    if (isNaN(parsed)) {
+      throw new Error('Invalid number') // WRONG: Should use flatMap and return err()
+    }
+    return ok(parsed)
+  }
+  return result
+}
+
+/**
+ * ANTI-PATTERN 12: Nested try/catch instead of flatMap chains
+ * This creates deeply nested, hard to read code.
+ */
+export function nestedTryCatch(input: string): Result<{value: number}, string> {
+  try {
+    const obj = JSON.parse(input)
+    try {
+      if (typeof obj.value !== 'number') {
+        throw new Error('Invalid value type')
+      }
+      return ok({value: obj.value})
+    } catch {
+      return err('Value validation failed')
+    }
+  } catch {
+    return err('JSON parse failed')
+  }
+}

--- a/packages/es/test/fixtures/patterns/result-proper-usage.ts
+++ b/packages/es/test/fixtures/patterns/result-proper-usage.ts
@@ -1,0 +1,150 @@
+/**
+ * Proper Result usage patterns - demonstrates correct error handling with discriminated unions.
+ * This file serves as a reference for detecting anti-patterns by comparison.
+ */
+
+import {err, flatMap, fromPromise, fromThrowable, isErr, isOk, map, ok, unwrapOr} from '../../../src/result'
+import type {Result} from '../../../src/result'
+
+/**
+ * PATTERN 1: Return Result instead of throwing for expected errors
+ * Expected errors (validation, not found, etc.) should return Err variants.
+ */
+export function divideNumbers(a: number, b: number): Result<number, string> {
+  if (b === 0) {
+    return err('Division by zero')
+  }
+  return ok(a / b)
+}
+
+/**
+ * PATTERN 2: Use type guards for discriminated union narrowing
+ * Always use isOk/isErr guards instead of direct property access.
+ */
+export function processResult<T, E>(result: Result<T, E>): {value: T | null; error: E | null} {
+  if (isOk(result)) {
+    return {value: result.data, error: null}
+  }
+  return {value: null, error: result.error}
+}
+
+/**
+ * PATTERN 3: Chain operations with map/flatMap instead of imperative checks
+ * Use functional composition for cleaner Result transformations.
+ */
+export function processUserData(userId: string): Result<{id: string; displayName: string}, string> {
+  const validateId = (id: string): Result<string, string> => {
+    if (id.length === 0) {
+      return err('User ID cannot be empty')
+    }
+    return ok(id)
+  }
+
+  const fetchUser = (id: string): Result<{id: string; name: string}, string> => {
+    if (id === 'invalid') {
+      return err('User not found')
+    }
+    return ok({id, name: 'Test User'})
+  }
+
+  const formatDisplay = (user: {id: string; name: string}): {id: string; displayName: string} => ({
+    id: user.id,
+    displayName: `User: ${user.name}`,
+  })
+
+  return map(flatMap(validateId(userId), fetchUser), formatDisplay)
+}
+
+/**
+ * PATTERN 4: Use unwrapOr for safe default values
+ * Prefer unwrapOr over unwrap for safer value extraction.
+ */
+export function getConfigValue(config: Result<{value: number}, Error>): number {
+  return unwrapOr(map(config, (c: {value: number}) => c.value), 0)
+}
+
+/**
+ * PATTERN 5: Wrap external throwing functions with fromThrowable
+ * Third-party code that throws should be wrapped at the boundary.
+ */
+export function parseJsonSafely(json: string): Result<unknown, Error> {
+  return fromThrowable(() => JSON.parse(json))
+}
+
+/**
+ * PATTERN 6: Wrap async operations with fromPromise
+ * Promise rejections should be converted to Result at the boundary.
+ */
+export async function fetchDataSafely(url: string): Promise<Result<unknown, Error>> {
+  return fromPromise(
+    fetch(url).then(response => {
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}`)
+      }
+      return response.json()
+    }),
+  )
+}
+
+/**
+ * PATTERN 7: Exhaustive error handling with Result
+ * Handle both success and error cases explicitly.
+ */
+export function handleResult<T, E>(
+  result: Result<T, E>,
+  handlers: {onOk: (data: T) => void; onErr: (error: E) => void},
+): void {
+  if (isOk(result)) {
+    handlers.onOk(result.data)
+  } else {
+    handlers.onErr(result.error)
+  }
+}
+
+/**
+ * PATTERN 8: Use mapErr for error transformation
+ * Transform errors at appropriate boundaries rather than catching and rethrowing.
+ */
+export function enrichError(result: Result<number, string>): Result<number, {code: string; message: string}> {
+  if (isErr(result)) {
+    return err({code: 'E001', message: result.error})
+  }
+  return result
+}
+
+/**
+ * PATTERN 9: Combine multiple Results properly
+ * Use flatMap chains or specialized combinators for multiple operations.
+ */
+export function combineResults<A, B, E>(
+  resultA: Result<A, E>,
+  resultB: Result<B, E>,
+): Result<[A, B], E> {
+  if (isErr(resultA)) return resultA
+  if (isErr(resultB)) return resultB
+  return ok([resultA.data, resultB.data])
+}
+
+/**
+ * PATTERN 10: Early return pattern with Result
+ * Return early on errors to maintain flat code structure.
+ */
+export function processMultiStep(input: string): Result<string, string> {
+  const step1 = validateInput(input)
+  if (isErr(step1)) return step1
+
+  const step2 = transformInput(step1.data)
+  if (isErr(step2)) return step2
+
+  return ok(`Processed: ${step2.data}`)
+}
+
+function validateInput(input: string): Result<string, string> {
+  if (input.length === 0) return err('Input cannot be empty')
+  return ok(input)
+}
+
+function transformInput(input: string): Result<string, string> {
+  if (input.includes('invalid')) return err('Invalid content detected')
+  return ok(input.toUpperCase())
+}

--- a/packages/es/test/fixtures/patterns/typeguard-improper-usage.ts
+++ b/packages/es/test/fixtures/patterns/typeguard-improper-usage.ts
@@ -1,0 +1,209 @@
+/**
+ * Improper type guard usage patterns - demonstrates anti-patterns to detect and avoid.
+ * This file contains intentional anti-patterns for testing detection logic.
+ *
+ * WARNING: Do NOT copy these patterns - they demonstrate what NOT to do.
+ */
+
+/**
+ * ANTI-PATTERN 1: Using type assertions instead of type guards
+ * Type assertions bypass runtime checks and can cause runtime errors.
+ */
+export function processApiResponseBad(data: unknown): string {
+  // WRONG: Asserting type without validation
+  const response = data as {name: string}
+  return response.name // Will throw if data doesn't have 'name' property
+}
+
+/**
+ * ANTI-PATTERN 2: Using 'any' to bypass type checking
+ * 'any' defeats the purpose of TypeScript's type safety.
+ */
+export function processWithAny(data: unknown): string {
+  // WRONG: Casting to 'any' bypasses all type checking
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const unsafeData = data as any
+  return unsafeData.name.toUpperCase() // No type safety
+}
+
+/**
+ * ANTI-PATTERN 3: Non-exhaustive type checking
+ * Missing cases in union type handling.
+ */
+type Status = 'pending' | 'active' | 'completed' | 'cancelled'
+
+export function handleStatusBad(status: Status): string {
+  if (status === 'pending') return 'Waiting'
+  if (status === 'active') return 'In Progress'
+  // WRONG: Missing 'cancelled' case - not exhaustive
+  return 'Done'
+}
+
+/**
+ * ANTI-PATTERN 4: Truthiness checks instead of proper guards
+ * Truthiness doesn't guarantee the expected type.
+ */
+export function processTruthyBad(value: unknown): number {
+  if (value) {
+    // WRONG: Truthy doesn't mean it's a number
+    return (value as number) * 2
+  }
+  return 0
+}
+
+/**
+ * ANTI-PATTERN 5: typeof checks that don't narrow properly
+ * Some typeof checks don't provide useful narrowing.
+ */
+export function processObjectBad(data: unknown): object {
+  if (typeof data === 'object') {
+    // WRONG: typeof 'object' includes null
+    return data as object // Will return null if data is null
+  }
+  return {}
+}
+
+/**
+ * ANTI-PATTERN 6: Instanceof checks for plain objects
+ * instanceof doesn't work for object literals from external sources.
+ */
+class User {
+  constructor(
+    public id: number,
+    public name: string,
+  ) {}
+}
+
+export function processUserBad(data: unknown): User {
+  if (data instanceof User) {
+    return data
+  }
+  // WRONG: External data won't be instance of User class
+  // even if it has the same shape
+  throw new Error('Invalid user')
+}
+
+/**
+ * ANTI-PATTERN 7: Double assertion (assertion to unknown then to target)
+ * This is a code smell indicating type system bypass.
+ */
+export function doubleAssertionBad(value: string): number {
+  // WRONG: Double assertion bypasses type checking
+  return value as unknown as number
+}
+
+/**
+ * ANTI-PATTERN 8: Non-null assertion operator (!) without validation
+ * The ! operator asserts non-null without runtime check.
+ */
+interface MaybeData {
+  value?: string
+}
+
+export function processOptionalBad(data: MaybeData): string {
+  // WRONG: Using ! without checking if value exists
+  return data.value!.toUpperCase()
+}
+
+/**
+ * ANTI-PATTERN 9: Relying on array index access without bounds checking
+ * Array access can return undefined even if typed otherwise.
+ */
+export function getFirstItemBad(items: string[]): string {
+  // WRONG: No check if array is empty
+  return items[0]!.toUpperCase()
+}
+
+/**
+ * ANTI-PATTERN 10: Type guards that don't properly narrow
+ * A type guard must return 'value is T' to narrow types.
+ */
+function isStringLoose(value: unknown): boolean {
+  // WRONG: Returns boolean, not 'value is string'
+  // This doesn't narrow the type
+  return typeof value === 'string'
+}
+
+export function processWithLooseGuard(value: unknown): string {
+  if (isStringLoose(value)) {
+    // WRONG: value is still 'unknown' because guard doesn't narrow
+    return (value as string).toUpperCase()
+  }
+  return ''
+}
+
+/**
+ * ANTI-PATTERN 11: Partial type checking
+ * Only checking some properties when all should be validated.
+ */
+interface FullConfig {
+  host: string
+  port: number
+  timeout: number
+}
+
+export function parseConfigBad(data: unknown): FullConfig {
+  if (typeof data === 'object' && data !== null) {
+    // WRONG: Only checking host, not port and timeout
+    if ('host' in data) {
+      return data as FullConfig // Unsafe - port and timeout not validated
+    }
+  }
+  throw new Error('Invalid config')
+}
+
+/**
+ * ANTI-PATTERN 12: Using 'in' operator without proper object check
+ * 'in' operator should only be used after validating object type.
+ */
+export function checkPropertyBad(value: unknown): string {
+  // WRONG: 'in' on primitives will throw
+  if ('name' in (value as object)) {
+    return (value as {name: string}).name
+  }
+  return ''
+}
+
+/**
+ * ANTI-PATTERN 13: Ignoring undefined in optional chaining
+ * Optional chaining returns undefined, which may not be handled.
+ */
+interface NestedData {
+  outer?: {
+    inner?: {
+      value?: string
+    }
+  }
+}
+
+export function getNestedValueBad(data: NestedData): string {
+  // WRONG: Returns undefined as string type
+  return data.outer?.inner?.value as string
+}
+
+/**
+ * ANTI-PATTERN 14: Type predicate that always returns true
+ * A type guard must actually validate the condition.
+ */
+function isNumberAlwaysTrue(_value: unknown): _value is number {
+  // WRONG: This always returns true regardless of actual type
+  return true
+}
+
+export function processWithBadGuard(value: unknown): number {
+  if (isNumberAlwaysTrue(value)) {
+    // TypeScript thinks this is safe, but it's not
+    return value * 2 // Will fail if value isn't actually a number
+  }
+  return 0
+}
+
+/**
+ * ANTI-PATTERN 15: Casting array types without element validation
+ * Array type assertions don't validate element types.
+ */
+export function sumArrayBad(data: unknown): number {
+  // WRONG: Casting entire array without validating elements
+  const numbers = data as number[]
+  return numbers.reduce((a, b) => a + b, 0) // Fails if elements aren't numbers
+}

--- a/packages/es/test/fixtures/patterns/typeguard-proper-usage.ts
+++ b/packages/es/test/fixtures/patterns/typeguard-proper-usage.ts
@@ -1,0 +1,201 @@
+/**
+ * Proper type guard usage patterns - demonstrates correct type narrowing.
+ * This file serves as a reference for detecting anti-patterns by comparison.
+ */
+
+import {
+  assertType,
+  hasProperty,
+  isArray,
+  isFunction,
+  isNonNullable,
+  isNumber,
+  isObject,
+  isString,
+} from '../../../src/types'
+
+/**
+ * PATTERN 1: Use type guards for unknown values from external sources
+ * API responses, user input, and parsed data should always be validated.
+ */
+export function processApiResponse(data: unknown): string {
+  if (!isObject(data)) {
+    throw new Error('Expected object response')
+  }
+
+  if (!hasProperty(data, 'name') || !isString(data.name)) {
+    throw new Error('Expected name property of type string')
+  }
+
+  return data.name
+}
+
+/**
+ * PATTERN 2: Type guards for discriminated union narrowing
+ * Use specific guards instead of direct property access.
+ */
+import {isOk} from '../../../src/result'
+import type {Result} from '../../../src/result'
+
+export function processResult<T, E>(result: Result<T, E>): T | null {
+  if (isOk(result)) {
+    return result.data
+  }
+  return null
+}
+
+/**
+ * PATTERN 3: Custom type guard functions for domain types
+ * Create reusable guards for your domain objects.
+ */
+interface User {
+  id: number
+  name: string
+  email: string
+}
+
+function isUser(value: unknown): value is User {
+  return (
+    isObject(value) &&
+    hasProperty(value, 'id') &&
+    isNumber(value.id) &&
+    hasProperty(value, 'name') &&
+    isString(value.name) &&
+    hasProperty(value, 'email') &&
+    isString(value.email)
+  )
+}
+
+export function validateUser(data: unknown): User {
+  if (!isUser(data)) {
+    throw new Error('Invalid user data')
+  }
+  return data
+}
+
+/**
+ * PATTERN 4: Narrowing arrays with type guards
+ * Use isArray followed by element validation.
+ */
+export function sumNumbers(data: unknown): number {
+  if (!isArray(data)) {
+    throw new Error('Expected array')
+  }
+
+  return data.reduce<number>((sum, item) => {
+    if (!isNumber(item)) {
+      throw new Error('Expected array of numbers')
+    }
+    return sum + item
+  }, 0)
+}
+
+/**
+ * PATTERN 5: Using isNonNullable for optional chains
+ * Filter out null/undefined safely before processing.
+ */
+export function processOptionalValues(values: (string | null | undefined)[]): string[] {
+  return values.filter(isNonNullable)
+}
+
+/**
+ * PATTERN 6: Combining guards for complex types
+ * Build up validation through composition.
+ */
+interface Config {
+  port: number
+  host: string
+  options?: {
+    timeout: number
+  }
+}
+
+function isConfig(value: unknown): value is Config {
+  if (!isObject(value)) return false
+  if (!hasProperty(value, 'port') || !isNumber(value.port)) return false
+  if (!hasProperty(value, 'host') || !isString(value.host)) return false
+
+  if (hasProperty(value, 'options')) {
+    if (!isObject(value.options)) return false
+    if (!hasProperty(value.options, 'timeout') || !isNumber(value.options.timeout)) {
+      return false
+    }
+  }
+
+  return true
+}
+
+export {isConfig}
+
+/**
+ * PATTERN 7: Using assertType for guaranteed narrowing
+ * Assert type when you want to throw on failure.
+ */
+export function processStringInput(value: unknown): string {
+  assertType(value, isString)
+  return value.toUpperCase()
+}
+
+/**
+ * PATTERN 8: Type guards with function parameters
+ * Validate callbacks before invoking.
+ */
+export function safeInvoke(fn: unknown, arg: number): number | null {
+  if (!isFunction(fn)) {
+    return null
+  }
+  return fn(arg) as number
+}
+
+/**
+ * PATTERN 9: Early return pattern with guards
+ * Return early when validation fails for cleaner code.
+ */
+export function parseUserFromJson(json: unknown): User | null {
+  if (!isObject(json)) return null
+  if (!hasProperty(json, 'id') || !isNumber(json.id)) return null
+  if (!hasProperty(json, 'name') || !isString(json.name)) return null
+  if (!hasProperty(json, 'email') || !isString(json.email)) return null
+
+  return {
+    id: json.id,
+    name: json.name,
+    email: json.email,
+  }
+}
+
+/**
+ * PATTERN 10: Type narrowing in array methods
+ * Use guards in filter/find for type-safe results.
+ */
+interface Item {
+  type: 'product' | 'service'
+  name: string
+  price: number
+}
+
+interface Product extends Item {
+  type: 'product'
+  sku: string
+}
+
+interface Service extends Item {
+  type: 'service'
+  duration: number
+}
+
+function isProduct(item: Item): item is Product {
+  return item.type === 'product' && hasProperty(item, 'sku')
+}
+
+function isService(item: Item): item is Service {
+  return item.type === 'service' && hasProperty(item, 'duration')
+}
+
+export function filterProducts(items: Item[]): Product[] {
+  return items.filter(isProduct)
+}
+
+export function filterServices(items: Item[]): Service[] {
+  return items.filter(isService)
+}

--- a/packages/es/test/patterns/anti-pattern-detection.test.ts
+++ b/packages/es/test/patterns/anti-pattern-detection.test.ts
@@ -1,0 +1,458 @@
+/**
+ * Anti-pattern detection tests - validates detection of common anti-patterns.
+ *
+ * These tests verify that anti-patterns can be detected at runtime through
+ * behavioral testing, demonstrating how improper usage leads to failures
+ * while proper usage succeeds.
+ *
+ * Related requirements:
+ * - TEST-038: Validates Result usage patterns (no throwing from Result code paths)
+ * - TEST-039: Validates pipe/compose usage (no side effects, no mutation)
+ * - TEST-040: Validates type guard usage over type assertions
+ */
+
+import type {Result} from '../../src/result'
+
+import {beforeEach, describe, expect, it} from 'vitest'
+
+import {compose, pipe} from '../../src/functional'
+import {err, isErr, isOk, map, ok, unwrapOr} from '../../src/result'
+import {hasProperty, isNumber, isObject, isString} from '../../src/types'
+
+function divideProper(a: number, b: number): Result<number, string> {
+  if (b === 0) {
+    return err('Division by zero')
+  }
+  return ok(a / b)
+}
+
+function divideBad(a: number, b: number): Result<number, string> {
+  if (b === 0) {
+    throw new Error('Division by zero')
+  }
+  return ok(a / b)
+}
+
+function processBad(data: unknown): Result<string, string> {
+  if (data === null) {
+    throw new Error('Null not allowed')
+  }
+  if (typeof data !== 'string') {
+    return err('Must be string')
+  }
+  return ok(data.toUpperCase())
+}
+
+function processApiResponse(data: unknown): string {
+  if (!isObject(data)) {
+    return 'Invalid: not an object'
+  }
+  if (!hasProperty(data, 'name') || !isString(data.name)) {
+    return 'Invalid: missing or invalid name'
+  }
+  return data.name.toUpperCase()
+}
+
+function processApiResponseBad(data: unknown): string {
+  const response = data as {name: string}
+  return response.name.toUpperCase()
+}
+
+function processValue(value: unknown): number {
+  if (value === null || value === undefined) {
+    return 0
+  }
+  if (!isNumber(value)) {
+    return 0
+  }
+  return value * 2
+}
+
+function processValueBad(value: unknown): number | string {
+  if (typeof value === 'number' || typeof value === 'string') {
+    return (value as number) * 2
+  }
+  return 0
+}
+
+interface UserClass {
+  id: number
+  name: string
+}
+
+class User implements UserClass {
+  id: number
+  name: string
+
+  constructor(id: number, name: string) {
+    this.id = id
+    this.name = name
+  }
+}
+
+function isUserLike(value: unknown): value is {id: number; name: string} {
+  return (
+    isObject(value) &&
+    hasProperty(value, 'id') &&
+    isNumber(value.id) &&
+    hasProperty(value, 'name') &&
+    isString(value.name)
+  )
+}
+
+function sumNumbers(data: unknown): Result<number, string> {
+  if (!Array.isArray(data)) {
+    return err('Expected array')
+  }
+
+  if (!data.every(isNumber)) {
+    return err('All elements must be numbers')
+  }
+
+  return ok(data.reduce((sum: number, n: number) => sum + n, 0))
+}
+
+function sumNumbersBad(data: unknown): number | string {
+  const numbers = data as number[]
+  return numbers.reduce((sum: number, n: number) => sum + n, 0)
+}
+
+describe('@bfra.me/es/patterns - Anti-Pattern Detection', () => {
+  describe('result usage patterns (TEST-038)', () => {
+    describe('throwing inside Result-returning functions (ANTI-PATTERN)', () => {
+      it.concurrent('should demonstrate proper Result usage does not throw', () => {
+        const result = divideProper(10, 0)
+
+        expect(isErr(result)).toBe(true)
+        expect(() => divideProper(10, 0)).not.toThrow()
+      })
+
+      it.concurrent('should detect throwing inside Result functions as anti-pattern', () => {
+        expect(() => divideBad(10, 0)).toThrow('Division by zero')
+      })
+
+      it.concurrent('should detect mixed throw/Result patterns', () => {
+        expect(() => processBad(null)).toThrow()
+        expect(isErr(processBad(123))).toBe(true)
+      })
+    })
+
+    describe('proper Result error handling', () => {
+      it.concurrent('should handle errors with type guards', () => {
+        const success: Result<number, string> = ok(42)
+        const failure: Result<number, string> = err('failed')
+
+        expect(isOk(success) && success.data).toBe(42)
+        expect(isErr(failure) && failure.error).toBe('failed')
+      })
+
+      it.concurrent('should chain operations with map/flatMap', () => {
+        const result = ok(5)
+        const doubled = map(result, x => x * 2)
+
+        expect(isOk(doubled) && doubled.data).toBe(10)
+      })
+
+      it.concurrent('should use unwrapOr for safe extraction', () => {
+        const success: Result<number, string> = ok(42)
+        const failure: Result<number, string> = err('failed')
+
+        expect(unwrapOr(success, 0)).toBe(42)
+        expect(unwrapOr(failure, 0)).toBe(0)
+      })
+    })
+
+    describe('detecting improper unwrap usage', () => {
+      it.concurrent('should show unwrap throws on Err', () => {
+        const failure: Result<number, string> = err('failed')
+
+        expect(isErr(failure)).toBe(true)
+        expect(() => {
+          throw new Error(failure.error)
+        }).toThrow()
+      })
+    })
+  })
+
+  describe('pipe/compose usage patterns (TEST-039)', () => {
+    describe('side effects in pipelines (ANTI-PATTERN)', () => {
+      let sideEffectCounter: number
+
+      beforeEach(() => {
+        sideEffectCounter = 0
+      })
+
+      it.concurrent('should demonstrate pure pipeline has no side effects', () => {
+        const purePipeline = pipe(
+          (x: number) => x + 1,
+          (x: number) => x * 2,
+        )
+
+        const result1 = purePipeline(5)
+        const result2 = purePipeline(5)
+
+        expect(result1).toBe(12)
+        expect(result2).toBe(12)
+        expect(result1).toBe(result2)
+      })
+
+      it('should detect side effects in pipeline', () => {
+        const impurePipeline = pipe(
+          (x: number) => {
+            sideEffectCounter++
+            return x + 1
+          },
+          (x: number) => x * 2,
+        )
+
+        expect(sideEffectCounter).toBe(0)
+        impurePipeline(5)
+        expect(sideEffectCounter).toBe(1)
+        impurePipeline(5)
+        expect(sideEffectCounter).toBe(2)
+      })
+    })
+
+    describe('mutation in pipelines (ANTI-PATTERN)', () => {
+      it.concurrent('should demonstrate immutable pipeline', () => {
+        interface State {
+          count: number
+          items: string[]
+        }
+
+        const immutablePipeline = pipe(
+          (state: State): State => ({...state, count: state.count + 1}),
+          (state: State): State => ({...state, items: [...state.items, 'new']}),
+        )
+
+        const initial: State = {count: 0, items: []}
+        const result = immutablePipeline(initial)
+
+        expect(initial.count).toBe(0)
+        expect(initial.items).toEqual([])
+        expect(result.count).toBe(1)
+        expect(result.items).toEqual(['new'])
+      })
+
+      it.concurrent('should detect mutation anti-pattern', () => {
+        interface MutableState {
+          count: number
+          items: string[]
+        }
+
+        const mutatingPipeline = pipe(
+          (state: MutableState) => {
+            state.count++
+            return state
+          },
+          (state: MutableState) => {
+            state.items.push('mutated')
+            return state
+          },
+        )
+
+        const initial: MutableState = {count: 0, items: []}
+        mutatingPipeline(initial)
+
+        expect(initial.count).toBe(1)
+        expect(initial.items).toEqual(['mutated'])
+      })
+    })
+
+    describe('non-deterministic functions in pipelines (ANTI-PATTERN)', () => {
+      it.concurrent('should demonstrate deterministic pipeline', () => {
+        const deterministicPipeline = pipe(
+          (x: number) => x + 1,
+          (x: number) => x * 2,
+        )
+
+        const results = Array.from({length: 10}, () => deterministicPipeline(5))
+
+        expect(results.every(r => r === 12)).toBe(true)
+      })
+
+      it.concurrent('should detect non-deterministic pipeline', () => {
+        const nonDeterministicPipeline = pipe(
+          (x: number) => x + Math.random(),
+          (x: number) => x * 2,
+        )
+
+        const results = new Set(Array.from({length: 10}, () => nonDeterministicPipeline(5)))
+
+        expect(results.size).toBeGreaterThan(1)
+      })
+    })
+
+    describe('throwing in pipelines (ANTI-PATTERN)', () => {
+      it.concurrent('should demonstrate safe pipeline with Result', () => {
+        const safePipeline = pipe(
+          (x: number): Result<number, string> => (x < 0 ? err('Negative') : ok(x + 1)),
+          (result: Result<number, string>) => map(result, x => x * 2),
+        )
+
+        const success = safePipeline(5)
+        const failure = safePipeline(-1)
+
+        expect(isOk(success) && success.data).toBe(12)
+        expect(isErr(failure) && failure.error).toBe('Negative')
+        expect(() => safePipeline(-1)).not.toThrow()
+      })
+
+      it.concurrent('should detect throwing pipeline', () => {
+        const throwingPipeline = pipe(
+          (x: number) => {
+            if (x < 0) throw new Error('Negative')
+            return x + 1
+          },
+          (x: number) => x * 2,
+        )
+
+        expect(throwingPipeline(5)).toBe(12)
+        expect(() => throwingPipeline(-1)).toThrow('Negative')
+      })
+    })
+
+    describe('compose vs pipe direction', () => {
+      it.concurrent('should apply pipe left-to-right', () => {
+        const addOne = (x: number) => x + 1
+        const double = (x: number) => x * 2
+        const stringify = (x: number) => `Result: ${x}`
+
+        const piped = pipe(addOne, double, stringify)
+
+        expect(piped(5)).toBe('Result: 12')
+      })
+
+      it.concurrent('should apply compose right-to-left', () => {
+        const addOne = (x: number) => x + 1
+        const double = (x: number) => x * 2
+        const asNumber = (x: string) => Number.parseInt(x, 10)
+
+        const composed = compose(addOne, double, asNumber)
+
+        expect(composed('5')).toBe(11)
+      })
+    })
+  })
+
+  describe('type guard usage patterns (TEST-040)', () => {
+    describe('type assertions vs type guards (ANTI-PATTERN)', () => {
+      it.concurrent('should demonstrate safe type guard usage', () => {
+        expect(processApiResponse({name: 'test'})).toBe('TEST')
+        expect(processApiResponse({name: 123})).toBe('Invalid: missing or invalid name')
+        expect(processApiResponse(null)).toBe('Invalid: not an object')
+        expect(processApiResponse('string')).toBe('Invalid: not an object')
+      })
+
+      it.concurrent('should show type assertion failures at runtime', () => {
+        expect(processApiResponseBad({name: 'test'})).toBe('TEST')
+        expect(() => processApiResponseBad(null)).toThrow()
+        expect(() => processApiResponseBad({noName: true})).toThrow()
+      })
+    })
+
+    describe('using proper type predicates', () => {
+      interface UserData {
+        id: number
+        name: string
+        email: string
+      }
+
+      function isUserData(value: unknown): value is UserData {
+        return (
+          isObject(value) &&
+          hasProperty(value, 'id') &&
+          isNumber(value.id) &&
+          hasProperty(value, 'name') &&
+          isString(value.name) &&
+          hasProperty(value, 'email') &&
+          isString(value.email)
+        )
+      }
+
+      it.concurrent('should narrow types correctly with proper guard', () => {
+        const validUser = {id: 1, name: 'Test', email: 'test@example.com'}
+        const invalidUser = {id: 'not-a-number', name: 'Test'}
+
+        expect(isUserData(validUser)).toBe(true)
+        expect(isUserData(invalidUser)).toBe(false)
+
+        const narrowedUser = isUserData(validUser) ? validUser : null
+        expect(narrowedUser?.id).toBe(1)
+        expect(narrowedUser?.name.toUpperCase()).toBe('TEST')
+      })
+
+      it.concurrent('should demonstrate filter with type guards', () => {
+        const mixedData: unknown[] = [
+          {id: 1, name: 'User1', email: 'user1@test.com'},
+          {id: 'bad', name: 'Invalid'},
+          null,
+          {id: 2, name: 'User2', email: 'user2@test.com'},
+          'string',
+        ]
+
+        const users = mixedData.filter(isUserData)
+
+        expect(users).toHaveLength(2)
+        expect(users.at(0)?.name).toBe('User1')
+        expect(users.at(1)?.name).toBe('User2')
+      })
+    })
+
+    describe('truthy checks vs proper validation (ANTI-PATTERN)', () => {
+      it.concurrent('should demonstrate proper null check', () => {
+        expect(processValue(5)).toBe(10)
+        expect(processValue(null)).toBe(0)
+        expect(processValue(0)).toBe(0)
+        expect(processValue('')).toBe(0)
+      })
+
+      it.concurrent('should show truthy check failures', () => {
+        // ANTI-PATTERN: Using type assertion (as number) causes unexpected coercion
+        // '5' * 2 coerces string to number, returning 10 instead of proper string handling
+        expect(processValueBad(5)).toBe(10)
+        expect(processValueBad(0)).toBe(0)
+        expect(processValueBad('5')).toBe(10) // String '5' coerced to number by * operator
+        expect(processValueBad(null)).toBe(0)
+      })
+    })
+
+    describe('instanceof limitations', () => {
+      it.concurrent('should show instanceof works with class instances', () => {
+        const user = new User(1, 'Test')
+
+        expect(user instanceof User).toBe(true)
+      })
+
+      it.concurrent('should demonstrate instanceof fails with plain objects', () => {
+        const plainObject = {id: 1, name: 'Test'}
+
+        expect(plainObject instanceof User).toBe(false)
+      })
+
+      it.concurrent('should use type guards for plain objects', () => {
+        const plainObject = {id: 1, name: 'Test'}
+
+        expect(isUserLike(plainObject)).toBe(true)
+      })
+    })
+
+    describe('array validation patterns', () => {
+      it.concurrent('should validate array elements', () => {
+        const validResult = sumNumbers([1, 2, 3])
+        const invalidElements = sumNumbers([1, '2', 3])
+        const notArray = sumNumbers('not array')
+
+        expect(isOk(validResult) && validResult.data).toBe(6)
+        expect(isErr(invalidElements) && invalidElements.error).toBe('All elements must be numbers')
+        expect(isErr(notArray) && notArray.error).toBe('Expected array')
+      })
+
+      it.concurrent('should show array assertion failures', () => {
+        expect(sumNumbersBad([1, 2, 3])).toBe(6)
+        // Demonstrates unexpected string concatenation when types aren't validated
+        expect(sumNumbersBad([1, '2', 3])).toBe('123')
+      })
+    })
+  })
+})

--- a/packages/es/test/patterns/best-practices.test.ts
+++ b/packages/es/test/patterns/best-practices.test.ts
@@ -1,0 +1,521 @@
+/**
+ * Best practice validation tests - verifies architectural patterns are correctly implemented.
+ *
+ * These tests validate that the @bfra.me/es package follows established best practices
+ * for Result types, functional composition, and type safety.
+ *
+ * Related requirements:
+ * - GUD-001: TypeScript patterns (explicit exports, no export *)
+ * - GUD-003: Use discriminated union result pattern instead of throwing
+ * - PAT-003: Discriminated unions for result types
+ * - PAT-004: Pure function architecture with no side effects
+ */
+
+import type {Result} from '../../src/result'
+
+import {describe, expect, it} from 'vitest'
+
+import {
+  compose,
+  constant,
+  curry,
+  flip,
+  identity,
+  memoize,
+  noop,
+  noopAsync,
+  partial,
+  pipe,
+  tap,
+} from '../../src/functional'
+import {
+  err,
+  flatMap,
+  fromPromise,
+  fromThrowable,
+  isErr,
+  isOk,
+  map,
+  mapErr,
+  ok,
+  unwrap,
+  unwrapOr,
+} from '../../src/result'
+import {
+  assertType,
+  brand,
+  hasProperty,
+  isArray,
+  isFunction,
+  isNonNullable,
+  isNumber,
+  isObject,
+  isString,
+  unbrand,
+} from '../../src/types'
+
+describe('@bfra.me/es/patterns - Best Practices Validation', () => {
+  describe('result type best practices', () => {
+    describe('discriminated union structure', () => {
+      it.concurrent('should have correct Ok structure with success: true', () => {
+        const result = ok(42)
+
+        expect(result.success).toBe(true)
+        expect(result.data).toBe(42)
+      })
+
+      it.concurrent('should have correct Err structure with success: false', () => {
+        const result = err('error message')
+
+        expect(result.success).toBe(false)
+        expect(result.error).toBe('error message')
+      })
+
+      it.concurrent('should be distinguishable by success property', () => {
+        const success: Result<number, string> = ok(42)
+        const failure: Result<number, string> = err('failed')
+
+        expect('data' in success && success.success === true).toBe(true)
+        expect('error' in failure && failure.success === false).toBe(true)
+      })
+    })
+
+    describe('type guard usage patterns', () => {
+      it.concurrent('should narrow Ok type with isOk', () => {
+        const result: Result<number, string> = ok(42)
+
+        expect(isOk(result)).toBe(true)
+        expect(isOk(result) && result.data).toBe(42)
+      })
+
+      it.concurrent('should narrow Err type with isErr', () => {
+        const result: Result<number, string> = err('failed')
+
+        expect(isErr(result)).toBe(true)
+        expect(isErr(result) && result.error).toBe('failed')
+      })
+
+      it.concurrent('should support exhaustive handling', () => {
+        const handleResult = (result: Result<number, string>): string => {
+          if (isOk(result)) {
+            return `Success: ${result.data}`
+          }
+          return `Error: ${result.error}`
+        }
+
+        expect(handleResult(ok(42))).toBe('Success: 42')
+        expect(handleResult(err('failed'))).toBe('Error: failed')
+      })
+    })
+
+    describe('safe value extraction patterns', () => {
+      it.concurrent('should extract value with unwrapOr fallback', () => {
+        const success: Result<number, string> = ok(42)
+        const failure: Result<number, string> = err('failed')
+
+        expect(unwrapOr(success, 0)).toBe(42)
+        expect(unwrapOr(failure, 0)).toBe(0)
+      })
+
+      it.concurrent('should throw with unwrap on Err (use sparingly)', () => {
+        const success: Result<number, string> = ok(42)
+        const failure: Result<number, string> = err('failed')
+
+        expect(unwrap(success)).toBe(42)
+        expect(() => unwrap(failure)).toThrow()
+      })
+    })
+
+    describe('transformation patterns', () => {
+      it.concurrent('should transform Ok values with map', () => {
+        const result = ok(5)
+        const doubled = map(result, x => x * 2)
+
+        expect(isOk(doubled) && doubled.data).toBe(10)
+      })
+
+      it.concurrent('should pass through Err with map', () => {
+        const result: Result<number, string> = err('failed')
+        const doubled = map(result, x => x * 2)
+
+        expect(isErr(doubled) && doubled.error).toBe('failed')
+      })
+
+      it.concurrent('should chain Results with flatMap', () => {
+        function validatePositive(n: number): Result<number, string> {
+          return n > 0 ? ok(n) : err('Must be positive')
+        }
+
+        const success = flatMap(ok(5), validatePositive)
+        const failure = flatMap(ok(-1), validatePositive)
+
+        expect(isOk(success) && success.data).toBe(5)
+        expect(isErr(failure) && failure.error).toBe('Must be positive')
+      })
+
+      it.concurrent('should transform errors with mapErr', () => {
+        const result: Result<number, string> = err('original')
+        const enriched = mapErr(result, e => ({code: 'E001', message: e}))
+
+        expect(isErr(enriched) && enriched.error).toEqual({code: 'E001', message: 'original'})
+      })
+    })
+
+    describe('wrapping throwing code patterns', () => {
+      it.concurrent('should wrap sync throwing functions with fromThrowable', () => {
+        const safeParseJson = (json: string) => fromThrowable(() => JSON.parse(json))
+
+        const valid = safeParseJson('{"key": "value"}')
+        const invalid = safeParseJson('not json')
+
+        expect(isOk(valid) && valid.data).toEqual({key: 'value'})
+        expect(isErr(invalid)).toBe(true)
+      })
+
+      it.concurrent('should wrap async functions with fromPromise', async () => {
+        const resolving = fromPromise(Promise.resolve(42))
+        const rejecting = fromPromise(Promise.reject(new Error('failed')))
+
+        const resolved = await resolving
+        const rejected = await rejecting
+
+        expect(isOk(resolved) && resolved.data).toBe(42)
+        expect(isErr(rejected)).toBe(true)
+      })
+    })
+  })
+
+  describe('functional composition best practices', () => {
+    describe('pipe composition patterns', () => {
+      it.concurrent('should compose functions left-to-right', () => {
+        const addOne = (x: number) => x + 1
+        const double = (x: number) => x * 2
+        const toString = (x: number) => String(x)
+
+        const pipeline = pipe(addOne, double, toString)
+
+        expect(pipeline(5)).toBe('12')
+      })
+
+      it.concurrent('should support type transformations', () => {
+        interface User {
+          name: string
+        }
+
+        const getName = (user: User) => user.name
+        const toUpperCase = (s: string) => s.toUpperCase()
+        const getLength = (s: string) => s.length
+
+        const pipeline = pipe(getName, toUpperCase, getLength)
+
+        expect(pipeline({name: 'test'})).toBe(4)
+      })
+
+      it.concurrent('should compose up to 10 functions', () => {
+        const addOne = (x: number) => x + 1
+
+        const pipeline = pipe(
+          addOne,
+          addOne,
+          addOne,
+          addOne,
+          addOne,
+          addOne,
+          addOne,
+          addOne,
+          addOne,
+          addOne,
+        )
+
+        expect(pipeline(0)).toBe(10)
+      })
+    })
+
+    describe('compose patterns', () => {
+      it.concurrent('should compose functions right-to-left', () => {
+        const addOne = (x: number) => x + 1
+        const double = (x: number) => x * 2
+
+        const composed = compose(addOne, double)
+
+        expect(composed(5)).toBe(11)
+      })
+    })
+
+    describe('curry patterns', () => {
+      it.concurrent('should curry binary functions', () => {
+        const add = curry((a: number, b: number) => a + b)
+
+        expect(add(1)(2)).toBe(3)
+        expect(add(1, 2)).toBe(3)
+      })
+
+      it.concurrent('should curry ternary functions', () => {
+        const sum3 = curry((a: number, b: number, c: number) => a + b + c)
+
+        expect(sum3(1)(2)(3)).toBe(6)
+        expect(sum3(1, 2)(3)).toBe(6)
+        expect(sum3(1)(2, 3)).toBe(6)
+        expect(sum3(1, 2, 3)).toBe(6)
+      })
+    })
+
+    describe('partial application patterns', () => {
+      it.concurrent('should partially apply arguments', () => {
+        const greet = (greeting: string, name: string) => `${greeting}, ${name}!`
+        const sayHello = partial(greet, 'Hello')
+
+        expect(sayHello('World')).toBe('Hello, World!')
+      })
+    })
+
+    describe('utility function patterns', () => {
+      it.concurrent('should use identity for pass-through', () => {
+        expect(identity(42)).toBe(42)
+        expect(identity('test')).toBe('test')
+
+        const obj = {key: 'value'}
+        expect(identity(obj)).toBe(obj)
+      })
+
+      it.concurrent('should use constant for fixed values', () => {
+        const always42 = constant(42)
+
+        expect(always42()).toBe(42)
+        expect(always42()).toBe(42)
+      })
+
+      it.concurrent('should use tap for side effects in pipeline', () => {
+        const values: number[] = []
+        const capture = tap((x: number) => values.push(x))
+
+        const result = pipe(
+          (x: number) => x + 1,
+          capture,
+          (x: number) => x * 2,
+        )(5)
+
+        expect(result).toBe(12)
+        expect(values).toEqual([6])
+      })
+
+      it.concurrent('should use flip to reverse argument order', () => {
+        const subtract = (a: number, b: number) => a - b
+        const flipped = flip(subtract)
+
+        expect(subtract(10, 3)).toBe(7)
+        expect(flipped(10, 3)).toBe(-7)
+      })
+
+      it.concurrent('should use noop for no-op callbacks', () => {
+        expect(noop()).toBeUndefined()
+      })
+
+      it.concurrent('should use noopAsync for async no-op callbacks', async () => {
+        const result = await noopAsync()
+        expect(result).toBeUndefined()
+      })
+    })
+
+    describe('memoization patterns', () => {
+      it.concurrent('should memoize pure functions', () => {
+        let callCount = 0
+        const expensive = (n: number) => {
+          callCount++
+          return n * 2
+        }
+
+        const memoized = memoize(expensive)
+
+        expect(memoized(5)).toBe(10)
+        expect(memoized(5)).toBe(10)
+        expect(memoized(5)).toBe(10)
+        expect(callCount).toBe(1)
+
+        expect(memoized(10)).toBe(20)
+        expect(callCount).toBe(2)
+      })
+    })
+  })
+
+  describe('type safety best practices', () => {
+    describe('type guard patterns', () => {
+      it.concurrent('should use isString for string validation', () => {
+        expect(isString('test')).toBe(true)
+        expect(isString('')).toBe(true)
+        expect(isString(123)).toBe(false)
+        expect(isString(null)).toBe(false)
+      })
+
+      it.concurrent('should use isNumber for number validation (excluding NaN)', () => {
+        expect(isNumber(42)).toBe(true)
+        expect(isNumber(0)).toBe(true)
+        expect(isNumber(-1.5)).toBe(true)
+        expect(isNumber(Number.NaN)).toBe(false)
+        expect(isNumber('42')).toBe(false)
+      })
+
+      it.concurrent('should use isObject for plain object validation', () => {
+        expect(isObject({})).toBe(true)
+        expect(isObject({key: 'value'})).toBe(true)
+        expect(isObject(null)).toBe(false)
+        expect(isObject([])).toBe(false)
+      })
+
+      it.concurrent('should use isArray for array validation', () => {
+        expect(isArray([])).toBe(true)
+        expect(isArray([1, 2, 3])).toBe(true)
+        expect(isArray({})).toBe(false)
+      })
+
+      it.concurrent('should use isFunction for function validation', () => {
+        expect(isFunction(() => {})).toBe(true)
+        expect(isFunction(Math.max)).toBe(true)
+        expect(isFunction('not a function')).toBe(false)
+      })
+
+      it.concurrent('should use hasProperty for safe property access', () => {
+        const obj: unknown = {name: 'test', age: 25}
+
+        expect(hasProperty(obj, 'name')).toBe(true)
+        expect(hasProperty(obj, 'missing')).toBe(false)
+      })
+
+      it.concurrent('should use isNonNullable for null filtering', () => {
+        const values: (string | null | undefined)[] = ['a', null, 'b', undefined, 'c']
+        const filtered = values.filter(isNonNullable)
+
+        expect(filtered).toEqual(['a', 'b', 'c'])
+      })
+    })
+
+    describe('assertion patterns', () => {
+      it.concurrent('should use assertType for guaranteed narrowing', () => {
+        const value: unknown = 'test'
+
+        assertType(value, isString)
+        expect(value.toUpperCase()).toBe('TEST')
+      })
+
+      it.concurrent('should throw on failed assertion', () => {
+        const value: unknown = 42
+
+        expect(() => assertType(value, isString)).toThrow()
+      })
+    })
+
+    describe('branded type patterns', () => {
+      it.concurrent('should create branded values', () => {
+        const userId = brand<number, 'UserId'>(123)
+
+        expect(unbrand(userId)).toBe(123)
+      })
+
+      it.concurrent('should maintain type safety with brands', () => {
+        type UserId = ReturnType<typeof brand<number, 'UserId'>>
+        type OrderId = ReturnType<typeof brand<number, 'OrderId'>>
+
+        const userId: UserId = brand<number, 'UserId'>(1)
+        const orderId: OrderId = brand<number, 'OrderId'>(1)
+
+        expect(unbrand(userId)).toBe(unbrand(orderId))
+        expect(unbrand(userId)).toBe(1)
+      })
+    })
+  })
+
+  describe('immutability best practices', () => {
+    describe('state transformations', () => {
+      it.concurrent('should never mutate input in pipelines', () => {
+        interface State {
+          count: number
+          items: string[]
+        }
+
+        const incrementCount = (state: State): State => ({
+          ...state,
+          count: state.count + 1,
+        })
+
+        const addItem =
+          (item: string) =>
+          (state: State): State => ({
+            ...state,
+            items: [...state.items, item],
+          })
+
+        const initial: State = {count: 0, items: []}
+        const updated = pipe(incrementCount, addItem('test'))(initial)
+
+        expect(initial).toEqual({count: 0, items: []})
+        expect(updated).toEqual({count: 1, items: ['test']})
+      })
+
+      it.concurrent('should return new arrays, not mutated ones', () => {
+        const addToArray = <T>(arr: T[], item: T): T[] => [...arr, item]
+
+        const original = [1, 2, 3]
+        const updated = addToArray(original, 4)
+
+        expect(original).toEqual([1, 2, 3])
+        expect(updated).toEqual([1, 2, 3, 4])
+        expect(original).not.toBe(updated)
+      })
+
+      it.concurrent('should return new objects, not mutated ones', () => {
+        interface Config {
+          value: number
+          enabled: boolean
+        }
+
+        const updateValue = (config: Config, value: number): Config => ({
+          ...config,
+          value,
+        })
+
+        const original: Config = {value: 10, enabled: true}
+        const updated = updateValue(original, 20)
+
+        expect(original).toEqual({value: 10, enabled: true})
+        expect(updated).toEqual({value: 20, enabled: true})
+        expect(original).not.toBe(updated)
+      })
+    })
+  })
+
+  describe('error handling best practices', () => {
+    describe('boundary wrapping patterns', () => {
+      it.concurrent('should wrap external APIs at boundaries', () => {
+        const safeJsonParse = (json: string): Result<unknown, Error> => {
+          return fromThrowable(() => JSON.parse(json))
+        }
+
+        const valid = safeJsonParse('{"key": "value"}')
+        const invalid = safeJsonParse('invalid')
+
+        expect(isOk(valid)).toBe(true)
+        expect(isErr(invalid)).toBe(true)
+      })
+
+      it.concurrent('should propagate errors through Result chains', () => {
+        const step1 = (x: number): Result<number, string> => {
+          return x > 0 ? ok(x * 2) : err('Step 1: must be positive')
+        }
+
+        const step2 = (x: number): Result<number, string> => {
+          return x < 100 ? ok(x + 1) : err('Step 2: must be less than 100')
+        }
+
+        const pipeline = (x: number) => flatMap(step1(x), step2)
+
+        expect(isOk(pipeline(5)) && pipeline(5)).toMatchObject({data: 11})
+        expect(isErr(pipeline(-1)) && pipeline(-1)).toMatchObject({
+          error: 'Step 1: must be positive',
+        })
+        expect(isErr(pipeline(60)) && pipeline(60)).toMatchObject({
+          error: 'Step 2: must be less than 100',
+        })
+      })
+    })
+  })
+})


### PR DESCRIPTION
- Introduce type guard anti-patterns in `typeguard-improper-usage.ts`.
- Implement proper type guard usage examples in `typeguard-proper-usage.ts`.
- Create tests for detecting anti-patterns in `anti-pattern-detection.test.ts`.
- Add best practices validation tests in `best-practices.test.ts`.
- Ensure comprehensive coverage of Result type patterns and functional composition.

Closes #2294.