### PR TITLE
docs(ai): update implementation plans to utilize @bfra.me/es package

### DIFF
--- a/.ai/plan/feature-doc-sync-engine-1.md
+++ b/.ai/plan/feature-doc-sync-engine-1.md
@@ -62,7 +62,7 @@ Build an intelligent documentation synchronization engine that continuously moni
 | TASK-004 | Set up `eslint.config.ts` using `defineConfig()` with TypeScript and Vitest support | | |
 | TASK-005 | Create `tsup.config.ts` for ES module build with proper entry points | | |
 | TASK-006 | Initialize `vitest.config.ts` with coverage and test configuration | | |
-| TASK-007 | Create core types in `src/types.ts` for PackageInfo, DocConfig, ParseResult, SyncResult | | |
+| TASK-007 | Create core types in `src/types.ts` for PackageInfo, DocConfig, ParseResult, SyncResult extending `Result<T, E>` from `@bfra.me/es/result` | | |
 
 ### Implementation Phase 2: Source Code Parsing Engine
 
@@ -98,9 +98,9 @@ Build an intelligent documentation synchronization engine that continuously moni
 
 | Task | Description | Completed | Date |
 |------|-------------|-----------|------|
-| TASK-022 | Create `src/watcher/file-watcher.ts` using chokidar for file system monitoring | | |
-| TASK-023 | Implement `src/watcher/change-detector.ts` for incremental change detection with hash comparison | | |
-| TASK-024 | Create `src/watcher/debouncer.ts` for batching rapid file changes | | |
+| TASK-022 | Create `src/watcher/file-watcher.ts` using `createFileWatcher()` from `@bfra.me/es/watcher` for file system monitoring | | |
+| TASK-023 | Implement `src/watcher/change-detector.ts` using `createChangeDetector()` from `@bfra.me/es/watcher` with hash comparison | | |
+| TASK-024 | Create `src/watcher/debouncer.ts` using `createDebouncer()` from `@bfra.me/es/watcher` for batching file changes | | |
 | TASK-025 | Implement `src/orchestrator/sync-orchestrator.ts` for coordinating parse → generate → write flow | | |
 | TASK-026 | Create `src/orchestrator/package-scanner.ts` for discovering packages and their documentation needs | | |
 | TASK-027 | Build `src/orchestrator/validation-pipeline.ts` for pre-write MDX validation | | |
@@ -172,15 +172,16 @@ Build an intelligent documentation synchronization engine that continuously moni
 
 ## 4. Dependencies
 
-- **DEP-001**: `ts-morph` - TypeScript Compiler API wrapper for source code analysis and JSDoc extraction
-- **DEP-002**: `chokidar` - Cross-platform file system watcher for change detection
-- **DEP-003**: `fast-glob` - Fast file globbing for package discovery
-- **DEP-004**: `unified` + `remark-parse` + `remark-mdx` - Markdown/MDX parsing and generation
-- **DEP-005**: `@commander-js/extra-typings` - Type-safe CLI argument parsing
-- **DEP-006**: `consola` - Console logging with levels and formatting (already in workspace)
-- **DEP-007**: `memfs` - In-memory file system for testing (dev dependency)
-- **DEP-008**: `@astrojs/starlight` - Peer dependency for type references (already in docs/)
-- **DEP-009**: `zod` - Runtime validation for configuration schemas (already in workspace)
+- **DEP-001**: `@bfra.me/es` (workspace:*) — Provides `Result<T, E>` type from `/result` and file watcher utilities (`createFileWatcher()`, `createChangeDetector()`, `createDebouncer()`) from `/watcher`
+- **DEP-002**: `ts-morph` — TypeScript Compiler API wrapper for source code analysis and JSDoc extraction
+- **DEP-003**: `chokidar` — Cross-platform file system watcher for change detection (peer dependency of @bfra.me/es)
+- **DEP-004**: `fast-glob` — Fast file globbing for package discovery
+- **DEP-005**: `unified` + `remark-parse` + `remark-mdx` — Markdown/MDX parsing and generation
+- **DEP-006**: `@commander-js/extra-typings` — Type-safe CLI argument parsing
+- **DEP-007**: `consola` — Console logging with levels and formatting (already in workspace)
+- **DEP-008**: `memfs` — In-memory file system for testing (dev dependency)
+- **DEP-009**: `@astrojs/starlight` — Peer dependency for type references (already in docs/)
+- **DEP-010**: `zod` — Runtime validation for configuration schemas (already in workspace)
 
 ## 5. Files
 

--- a/.ai/plan/feature-es-package-1.md
+++ b/.ai/plan/feature-es-package-1.md
@@ -315,13 +315,13 @@ Create a shared `@bfra.me/es` package that provides high-quality reusable types 
 
 | Task | Description | Completed | Date |
 |------|-------------|-----------|------|
-| TASK-121 | Update `refactor-create-package-1.md` TASK-002 to import `Result<T, E>` from `@bfra.me/es/result` | | |
-| TASK-122 | Update `refactor-create-package-1.md` TASK-005 to import `pipe()`, `compose()`, `curry()` from `@bfra.me/es/functional` | | |
-| TASK-123 | Update `feature-workspace-analyzer-1.md` TASK-008 to import `Result<T>` from `@bfra.me/es/result` | | |
-| TASK-124 | Update `feature-doc-sync-engine-1.md` TASK-007 types to extend/import from `@bfra.me/es/result` | | |
-| TASK-125 | Update `feature-doc-sync-engine-1.md` TASK-022-024 to use `createFileWatcher()` from `@bfra.me/es/watcher` | | |
-| TASK-126 | Update `feature-workspace-analyzer-1.md` TASK-057-058 to use file hasher from `@bfra.me/es/watcher` | | |
-| TASK-127 | Add `@bfra.me/es` as DEP-001 in all three dependent implementation plans | | |
+| TASK-121 | Update `refactor-create-package-1.md` TASK-002 to import `Result<T, E>` from `@bfra.me/es/result` | ✅ | 2025-12-01 |
+| TASK-122 | Update `refactor-create-package-1.md` TASK-005 to import `pipe()`, `compose()`, `curry()` from `@bfra.me/es/functional` | ✅ | 2025-12-01 |
+| TASK-123 | Update `feature-workspace-analyzer-1.md` TASK-008 to import `Result<T>` from `@bfra.me/es/result` | ✅ | 2025-12-01 |
+| TASK-124 | Update `feature-doc-sync-engine-1.md` TASK-007 types to extend/import from `@bfra.me/es/result` | ✅ | 2025-12-01 |
+| TASK-125 | Update `feature-doc-sync-engine-1.md` TASK-022-024 to use `createFileWatcher()` from `@bfra.me/es/watcher` | ✅ | 2025-12-01 |
+| TASK-126 | Update `feature-workspace-analyzer-1.md` TASK-057-058 to use file hasher from `@bfra.me/es/watcher` | ✅ | 2025-12-01 |
+| TASK-127 | Add `@bfra.me/es` as DEP-001 in all three dependent implementation plans | ✅ | 2025-12-01 |
 
 ### Implementation Phase 18: ESLint-Config Migration
 

--- a/.ai/plan/feature-workspace-analyzer-1.md
+++ b/.ai/plan/feature-workspace-analyzer-1.md
@@ -79,7 +79,7 @@ Create a new `@bfra.me/workspace-analyzer` package in the bfra.me/works monorepo
 | TASK-005 | Create `tsup.config.ts` for ES module build with entry points `['src/index.ts', 'src/cli.ts']` | | |
 | TASK-006 | Create `vitest.config.ts` with coverage thresholds (80% statements, 75% branches) | | |
 | TASK-007 | Implement core types in `src/types/index.ts` (AnalysisResult, AnalyzerConfig, Issue, Severity) | | |
-| TASK-008 | Implement Result<T> discriminated union type in `src/types/result.ts` | | |
+| TASK-008 | Import `Result<T, E>` discriminated union type from `@bfra.me/es/result` in `src/types/result.ts` | | |
 | TASK-009 | Create workspace scanner in `src/scanner/workspace-scanner.ts` for file discovery using fast-glob | | |
 | TASK-010 | Implement AST parser wrapper in `src/parser/typescript-parser.ts` using TypeScript Compiler API | | |
 | TASK-011 | Create main export barrel in `src/index.ts` with explicit named exports | | |
@@ -171,7 +171,7 @@ Create a new `@bfra.me/workspace-analyzer` package in the bfra.me/works monorepo
 | Task | Description | Completed | Date |
 |------|-------------|-----------|------|
 | TASK-057 | Design cache schema in `src/cache/cache-schema.ts` | | |
-| TASK-058 | Implement file hash calculator for change detection in `src/cache/file-hasher.ts` | | |
+| TASK-058 | Use `createFileHasher()` from `@bfra.me/es/watcher` for change detection in `src/cache/file-hasher.ts` | | |
 | TASK-059 | Create cache manager in `src/cache/cache-manager.ts` with file-based storage | | |
 | TASK-060 | Implement incremental analysis orchestrator in `src/core/incremental-analyzer.ts` | | |
 | TASK-061 | Add cache invalidation for configuration file changes | | |
@@ -298,22 +298,23 @@ Create a new `@bfra.me/workspace-analyzer` package in the bfra.me/works monorepo
 
 ### Runtime Dependencies
 
-- **DEP-001**: `typescript` (^5.4.0) — TypeScript Compiler API for AST parsing
-- **DEP-002**: `fast-glob` (^3.3.0) — Efficient file discovery with gitignore support
-- **DEP-003**: `picomatch` (^3.0.0) — Glob pattern matching for rule configuration
-- **DEP-004**: `picocolors` (^1.0.0) — Terminal color output for console reporter
-- **DEP-005**: `json5` (^2.2.0) — JSON5 parsing for tsconfig.json with comments
+- **DEP-001**: `@bfra.me/es` (workspace:*) — Provides `Result<T, E>` type from `/result` and `createFileHasher()` from `/watcher` for change detection
+- **DEP-002**: `typescript` (^5.4.0) — TypeScript Compiler API for AST parsing
+- **DEP-003**: `fast-glob` (^3.3.0) — Efficient file discovery with gitignore support
+- **DEP-004**: `picomatch` (^3.0.0) — Glob pattern matching for rule configuration
+- **DEP-005**: `picocolors` (^1.0.0) — Terminal color output for console reporter
+- **DEP-006**: `json5` (^2.2.0) — JSON5 parsing for tsconfig.json with comments
 
 ### Development Dependencies
 
-- **DEP-006**: `@bfra.me/works` (workspace:*) — Root workspace dev dependency aggregator
-- **DEP-007**: `@bfra.me/tsconfig` (workspace:*) — Shared TypeScript configuration
-- **DEP-008**: `vitest` — Testing framework (via workspace root)
-- **DEP-009**: `tsup` — Build tool (via workspace root)
+- **DEP-007**: `@bfra.me/works` (workspace:*) — Root workspace dev dependency aggregator
+- **DEP-008**: `@bfra.me/tsconfig` (workspace:*) — Shared TypeScript configuration
+- **DEP-009**: `vitest` — Testing framework (via workspace root)
+- **DEP-010**: `tsup` — Build tool (via workspace root)
 
 ### Peer Dependencies
 
-- **DEP-010**: `typescript` (>=5.0.0) — Consumer provides TypeScript version
+- **DEP-011**: `typescript` (>=5.0.0) — Consumer provides TypeScript version
 
 ## 5. Files
 

--- a/.ai/plan/refactor-create-package-1.md
+++ b/.ai/plan/refactor-create-package-1.md
@@ -40,10 +40,10 @@ This implementation plan addresses critical architectural issues in the `@bfra.m
 | Task | Description | Completed | Date |
 |------|-------------|-----------|------|
 | TASK-001 | Create branded types for `TemplateSource`, `ProjectPath`, and `PackageName` with compile-time validation | |  |
-| TASK-002 | Implement strict `Result<T, E>` discriminated union type replacing mixed return patterns | |  |
+| TASK-002 | Import strict `Result<T, E>` discriminated union type from `@bfra.me/es/result` replacing mixed return patterns | |  |
 | TASK-003 | Create comprehensive type guards for runtime validation of all input types | |  |
 | TASK-004 | Establish unified error handling system with `createError()` factory and error codes | |  |
-| TASK-005 | Implement functional utilities module with `pipe()`, `compose()`, and `curry()` helpers | |  |
+| TASK-005 | Import functional utilities (`pipe()`, `compose()`, `curry()`) from `@bfra.me/es/functional` | |  |
 | TASK-006 | Create validation factory functions replacing scattered validation logic | |  |
 | TASK-007 | Establish logging/telemetry factory with consistent progress indicators and error reporting | |  |
 
@@ -127,8 +127,9 @@ This implementation plan addresses critical architectural issues in the `@bfra.m
 
 ## 4. Dependencies
 
-- **DEP-001**: Enhanced TypeScript configuration supporting latest language features and strict type checking
-- **DEP-002**: Vitest testing framework with comprehensive mocking and snapshot capabilities
+- **DEP-001**: `@bfra.me/es` (workspace:*) — Provides `Result<T, E>` type from `/result`, functional utilities (`pipe()`, `compose()`, `curry()`) from `/functional`, and type guards from `/types`
+- **DEP-002**: Enhanced TypeScript configuration supporting latest language features and strict type checking
+- **DEP-003**: Vitest testing framework with comprehensive mocking and snapshot capabilities
 - **DEP-003**: Updated @clack/prompts for consistent CLI interactions
 - **DEP-004**: Maintained compatibility with existing AI provider SDKs (OpenAI, Anthropic)
 - **DEP-005**: Giget for template fetching with enhanced caching mechanisms


### PR DESCRIPTION
- Update types in `feature-doc-sync-engine-1.md` to extend from `@bfra.me/es/result`.
- Modify file watcher tasks in `feature-doc-sync-engine-1.md` to use `createFileWatcher()` from `@bfra.me/es/watcher`.
- Revise tasks in `feature-es-package-1.md` to import types and utilities from `@bfra.me/es`.
- Adjust tasks in `feature-workspace-analyzer-1.md` to import `Result<T, E>` and file hasher from `@bfra.me/es`.
- Refactor `refactor-create-package-1.md` to import types and utilities from `@bfra.me/es`.

Closes #2296.