### PR TITLE
feat: add parsers for JSDoc, README, TypeScript, and package info

### DIFF
--- a/packages/doc-sync/package.json
+++ b/packages/doc-sync/package.json
@@ -30,6 +30,11 @@
       "source": "./src/index.ts",
       "import": "./lib/index.js"
     },
+    "./parsers": {
+      "types": "./lib/parsers/index.d.ts",
+      "source": "./src/parsers/index.ts",
+      "import": "./lib/parsers/index.js"
+    },
     "./types": {
       "types": "./lib/types.d.ts",
       "source": "./src/types.ts",

--- a/packages/doc-sync/src/parsers/export-analyzer.ts
+++ b/packages/doc-sync/src/parsers/export-analyzer.ts
@@ -1,0 +1,335 @@
+/**
+ * @bfra.me/doc-sync/parsers/export-analyzer - Public API surface analyzer for package exports
+ */
+
+import type {Project, SourceFile} from 'ts-morph'
+
+import type {PackageAPI, ParseResult, ReExport} from '../types'
+
+import {ok} from '@bfra.me/es/result'
+
+import {createProject, extractPackageAPI, parseSourceFile} from './typescript-parser'
+
+/**
+ * Options for analyzing package exports
+ */
+export interface ExportAnalyzerOptions {
+  readonly tsConfigPath?: string
+  readonly followReExports?: boolean
+  readonly maxDepth?: number
+}
+
+/**
+ * Resolved export information including the original source
+ */
+export interface ResolvedExport {
+  readonly name: string
+  readonly kind: 'function' | 'type' | 'interface' | 'enum' | 'class' | 're-export'
+  readonly source: string
+  readonly isDefault: boolean
+}
+
+/**
+ * Complete analysis of a package's public API
+ */
+export interface PublicAPIAnalysis {
+  readonly packagePath: string
+  readonly entryPoint: string
+  readonly api: PackageAPI
+  readonly resolvedExports: readonly ResolvedExport[]
+}
+
+/**
+ * Analyzes the public API surface of a package from its entry point
+ */
+export function analyzePublicAPI(
+  entryPointPath: string,
+  options?: ExportAnalyzerOptions,
+): ParseResult<PublicAPIAnalysis> {
+  const project = createProject({tsConfigPath: options?.tsConfigPath})
+  const sourceFileResult = parseSourceFile(project, entryPointPath)
+
+  if (!sourceFileResult.success) {
+    return sourceFileResult
+  }
+
+  const sourceFile = sourceFileResult.data
+  const api = extractPackageAPI(sourceFile)
+  const resolvedExports = resolveAllExports(sourceFile, api, project, options)
+
+  return ok({
+    packagePath: sourceFile.getDirectoryPath(),
+    entryPoint: entryPointPath,
+    api,
+    resolvedExports,
+  })
+}
+
+function resolveAllExports(
+  sourceFile: SourceFile,
+  api: PackageAPI,
+  project: Project,
+  options?: ExportAnalyzerOptions,
+): readonly ResolvedExport[] {
+  const exports: ResolvedExport[] = []
+  const filePath = sourceFile.getFilePath()
+
+  // Add direct function exports
+  for (const func of api.functions) {
+    exports.push({
+      name: func.name,
+      kind: 'function',
+      source: filePath,
+      isDefault: func.isDefault,
+    })
+  }
+
+  // Add direct type exports
+  for (const type of api.types) {
+    exports.push({
+      name: type.name,
+      kind: type.kind,
+      source: filePath,
+      isDefault: type.isDefault,
+    })
+  }
+
+  // Handle re-exports if enabled
+  if (options?.followReExports !== false) {
+    const maxDepth = options?.maxDepth ?? 5
+    const reExportedItems = resolveReExports(
+      sourceFile,
+      api.reExports,
+      project,
+      maxDepth,
+      new Set(),
+    )
+    exports.push(...reExportedItems)
+  }
+
+  return exports
+}
+
+function resolveReExports(
+  sourceFile: SourceFile,
+  reExports: readonly ReExport[],
+  project: Project,
+  remainingDepth: number,
+  visited: Set<string>,
+): readonly ResolvedExport[] {
+  if (remainingDepth <= 0 || reExports.length === 0) {
+    return []
+  }
+
+  const exports: ResolvedExport[] = []
+
+  for (const reExport of reExports) {
+    const resolvedPath = resolveModulePath(sourceFile, reExport.from)
+    if (resolvedPath === undefined || visited.has(resolvedPath)) {
+      // Add as unresolved re-export
+      if (reExport.exports === '*') {
+        exports.push({
+          name: reExport.alias ?? '*',
+          kind: 're-export',
+          source: reExport.from,
+          isDefault: false,
+        })
+      } else {
+        for (const name of reExport.exports) {
+          exports.push({
+            name,
+            kind: 're-export',
+            source: reExport.from,
+            isDefault: false,
+          })
+        }
+      }
+      continue
+    }
+
+    visited.add(resolvedPath)
+
+    try {
+      const reExportedFile = getOrAddSourceFile(project, resolvedPath)
+      if (reExportedFile === undefined) continue
+
+      const reExportedAPI = extractPackageAPI(reExportedFile)
+
+      if (reExport.exports === '*') {
+        // Namespace export - include all exports from the module
+        for (const func of reExportedAPI.functions) {
+          exports.push({
+            name: func.name,
+            kind: 'function',
+            source: resolvedPath,
+            isDefault: func.isDefault,
+          })
+        }
+
+        for (const type of reExportedAPI.types) {
+          exports.push({
+            name: type.name,
+            kind: type.kind,
+            source: resolvedPath,
+            isDefault: type.isDefault,
+          })
+        }
+
+        // Recurse into nested re-exports
+        const nestedExports = resolveReExports(
+          reExportedFile,
+          reExportedAPI.reExports,
+          project,
+          remainingDepth - 1,
+          visited,
+        )
+        exports.push(...nestedExports)
+      } else {
+        // Named exports - only include specified exports
+        for (const exportName of reExport.exports) {
+          // Parse potential alias: "original as alias"
+          const [originalName, alias] = parseExportName(exportName)
+
+          // Check if this is a function export
+          const func = reExportedAPI.functions.find(f => f.name === originalName)
+          if (func !== undefined) {
+            exports.push({
+              name: alias ?? originalName,
+              kind: 'function',
+              source: resolvedPath,
+              isDefault: func.isDefault,
+            })
+            continue
+          }
+
+          // Check if this is a type export
+          const type = reExportedAPI.types.find(t => t.name === originalName)
+          if (type !== undefined) {
+            exports.push({
+              name: alias ?? originalName,
+              kind: type.kind,
+              source: resolvedPath,
+              isDefault: type.isDefault,
+            })
+          }
+        }
+      }
+    } catch {
+      // Failed to resolve re-export, skip
+    }
+  }
+
+  return exports
+}
+
+function parseExportName(exportName: string): [string, string | undefined] {
+  const asIndex = exportName.indexOf(' as ')
+  if (asIndex > 0) {
+    return [exportName.slice(0, asIndex), exportName.slice(asIndex + 4)]
+  }
+  return [exportName, undefined]
+}
+
+function resolveModulePath(sourceFile: SourceFile, modulePath: string): string | undefined {
+  if (!modulePath.startsWith('.')) {
+    // External module, cannot resolve
+    return undefined
+  }
+
+  try {
+    const directory = sourceFile.getDirectory()
+    const extensions = ['.ts', '.tsx', '/index.ts', '/index.tsx', '.js', '.jsx']
+
+    for (const ext of extensions) {
+      const candidate = directory.getSourceFile(modulePath + ext)
+      if (candidate !== undefined) {
+        return candidate.getFilePath()
+      }
+    }
+
+    // Try without extension
+    const direct = directory.getSourceFile(modulePath)
+    return direct?.getFilePath()
+  } catch {
+    return undefined
+  }
+}
+
+function getOrAddSourceFile(project: Project, filePath: string): SourceFile | undefined {
+  try {
+    return project.getSourceFile(filePath) ?? project.addSourceFileAtPath(filePath)
+  } catch {
+    return undefined
+  }
+}
+
+/**
+ * Finds all exported symbols from a package entry point
+ */
+export function findExportedSymbols(
+  entryPointPath: string,
+  options?: ExportAnalyzerOptions,
+): ParseResult<readonly string[]> {
+  const analysisResult = analyzePublicAPI(entryPointPath, options)
+
+  if (!analysisResult.success) {
+    return analysisResult
+  }
+
+  const symbols = analysisResult.data.resolvedExports.map(exp => exp.name)
+  return ok([...new Set(symbols)])
+}
+
+/**
+ * Checks if a symbol is exported from a package
+ */
+export function isSymbolExported(
+  entryPointPath: string,
+  symbolName: string,
+  options?: ExportAnalyzerOptions,
+): ParseResult<boolean> {
+  const analysisResult = analyzePublicAPI(entryPointPath, options)
+
+  if (!analysisResult.success) {
+    return analysisResult
+  }
+
+  const isExported = analysisResult.data.resolvedExports.some(exp => exp.name === symbolName)
+  return ok(isExported)
+}
+
+/**
+ * Gets detailed information about a specific exported symbol
+ */
+export function getExportedSymbolInfo(
+  entryPointPath: string,
+  symbolName: string,
+  options?: ExportAnalyzerOptions,
+): ParseResult<ResolvedExport | undefined> {
+  const analysisResult = analyzePublicAPI(entryPointPath, options)
+
+  if (!analysisResult.success) {
+    return analysisResult
+  }
+
+  const exported = analysisResult.data.resolvedExports.find(exp => exp.name === symbolName)
+  return ok(exported)
+}
+
+/**
+ * Filters exports by kind
+ */
+export function getExportsByKind(
+  entryPointPath: string,
+  kind: ResolvedExport['kind'],
+  options?: ExportAnalyzerOptions,
+): ParseResult<readonly ResolvedExport[]> {
+  const analysisResult = analyzePublicAPI(entryPointPath, options)
+
+  if (!analysisResult.success) {
+    return analysisResult
+  }
+
+  const filtered = analysisResult.data.resolvedExports.filter(exp => exp.kind === kind)
+  return ok(filtered)
+}

--- a/packages/doc-sync/src/parsers/guards.ts
+++ b/packages/doc-sync/src/parsers/guards.ts
@@ -1,0 +1,350 @@
+/**
+ * @bfra.me/doc-sync/parsers/guards - Type guards and validation for parser types
+ */
+
+import type {
+  DocConfigSource,
+  ExportedFunction,
+  ExportedType,
+  JSDocInfo,
+  JSDocParam,
+  JSDocTag,
+  MDXFrontmatter,
+  PackageAPI,
+  PackageInfo,
+  ParseError,
+  ReadmeContent,
+  ReadmeSection,
+  ReExport,
+  SyncError,
+} from '../types'
+
+export function isParseError(value: unknown): value is ParseError {
+  if (typeof value !== 'object' || value === null) {
+    return false
+  }
+
+  const obj = value as Record<string, unknown>
+
+  return (
+    typeof obj.code === 'string' &&
+    typeof obj.message === 'string' &&
+    [
+      'INVALID_SYNTAX',
+      'FILE_NOT_FOUND',
+      'READ_ERROR',
+      'MALFORMED_JSON',
+      'UNSUPPORTED_FORMAT',
+    ].includes(obj.code)
+  )
+}
+
+/**
+ * Type guard for SyncError
+ */
+export function isSyncError(value: unknown): value is SyncError {
+  if (typeof value !== 'object' || value === null) {
+    return false
+  }
+
+  const obj = value as Record<string, unknown>
+
+  return (
+    typeof obj.code === 'string' &&
+    typeof obj.message === 'string' &&
+    [
+      'WRITE_ERROR',
+      'VALIDATION_ERROR',
+      'GENERATION_ERROR',
+      'PACKAGE_NOT_FOUND',
+      'CONFIG_ERROR',
+    ].includes(obj.code)
+  )
+}
+
+export function isJSDocParam(value: unknown): value is JSDocParam {
+  if (typeof value !== 'object' || value === null) {
+    return false
+  }
+
+  const obj = value as Record<string, unknown>
+
+  return (
+    typeof obj.name === 'string' &&
+    (obj.type === undefined || typeof obj.type === 'string') &&
+    (obj.description === undefined || typeof obj.description === 'string') &&
+    (obj.optional === undefined || typeof obj.optional === 'boolean') &&
+    (obj.defaultValue === undefined || typeof obj.defaultValue === 'string')
+  )
+}
+
+export function isJSDocTag(value: unknown): value is JSDocTag {
+  if (typeof value !== 'object' || value === null) {
+    return false
+  }
+
+  const obj = value as Record<string, unknown>
+
+  return typeof obj.name === 'string' && (obj.value === undefined || typeof obj.value === 'string')
+}
+
+export function isJSDocInfo(value: unknown): value is JSDocInfo {
+  if (typeof value !== 'object' || value === null) {
+    return false
+  }
+
+  const obj = value as Record<string, unknown>
+
+  return (
+    (obj.description === undefined || typeof obj.description === 'string') &&
+    (obj.params === undefined || (Array.isArray(obj.params) && obj.params.every(isJSDocParam))) &&
+    (obj.returns === undefined || typeof obj.returns === 'string') &&
+    (obj.examples === undefined ||
+      (Array.isArray(obj.examples) && obj.examples.every(e => typeof e === 'string'))) &&
+    (obj.deprecated === undefined || typeof obj.deprecated === 'string') &&
+    (obj.since === undefined || typeof obj.since === 'string') &&
+    (obj.see === undefined ||
+      (Array.isArray(obj.see) && obj.see.every(s => typeof s === 'string'))) &&
+    (obj.customTags === undefined ||
+      (Array.isArray(obj.customTags) && obj.customTags.every(isJSDocTag)))
+  )
+}
+
+export function isExportedFunction(value: unknown): value is ExportedFunction {
+  if (typeof value !== 'object' || value === null) {
+    return false
+  }
+
+  const obj = value as Record<string, unknown>
+
+  return (
+    typeof obj.name === 'string' &&
+    typeof obj.signature === 'string' &&
+    typeof obj.isAsync === 'boolean' &&
+    typeof obj.isGenerator === 'boolean' &&
+    Array.isArray(obj.parameters) &&
+    typeof obj.returnType === 'string' &&
+    typeof obj.isDefault === 'boolean'
+  )
+}
+
+export function isExportedType(value: unknown): value is ExportedType {
+  if (typeof value !== 'object' || value === null) {
+    return false
+  }
+
+  const obj = value as Record<string, unknown>
+
+  return (
+    typeof obj.name === 'string' &&
+    typeof obj.definition === 'string' &&
+    typeof obj.kind === 'string' &&
+    ['interface', 'type', 'enum', 'class'].includes(obj.kind) &&
+    typeof obj.isDefault === 'boolean'
+  )
+}
+
+export function isReExport(value: unknown): value is ReExport {
+  if (typeof value !== 'object' || value === null) {
+    return false
+  }
+
+  const obj = value as Record<string, unknown>
+
+  return (
+    typeof obj.from === 'string' &&
+    (obj.exports === '*' ||
+      (Array.isArray(obj.exports) && obj.exports.every(e => typeof e === 'string')))
+  )
+}
+
+export function isPackageAPI(value: unknown): value is PackageAPI {
+  if (typeof value !== 'object' || value === null) {
+    return false
+  }
+
+  const obj = value as Record<string, unknown>
+
+  return (
+    Array.isArray(obj.functions) &&
+    obj.functions.every(isExportedFunction) &&
+    Array.isArray(obj.types) &&
+    obj.types.every(isExportedType) &&
+    Array.isArray(obj.reExports) &&
+    obj.reExports.every(isReExport)
+  )
+}
+
+export function isDocConfigSource(value: unknown): value is DocConfigSource {
+  if (typeof value !== 'object' || value === null) {
+    return false
+  }
+
+  const obj = value as Record<string, unknown>
+
+  return (
+    (obj.title === undefined || typeof obj.title === 'string') &&
+    (obj.description === undefined || typeof obj.description === 'string') &&
+    (obj.sidebar === undefined || typeof obj.sidebar === 'object') &&
+    (obj.excludeSections === undefined ||
+      (Array.isArray(obj.excludeSections) &&
+        obj.excludeSections.every(s => typeof s === 'string'))) &&
+    (obj.frontmatter === undefined || typeof obj.frontmatter === 'object')
+  )
+}
+
+export function isPackageInfo(value: unknown): value is PackageInfo {
+  if (typeof value !== 'object' || value === null) {
+    return false
+  }
+
+  const obj = value as Record<string, unknown>
+
+  return (
+    typeof obj.name === 'string' &&
+    typeof obj.version === 'string' &&
+    typeof obj.packagePath === 'string' &&
+    typeof obj.srcPath === 'string' &&
+    (obj.description === undefined || typeof obj.description === 'string') &&
+    (obj.keywords === undefined ||
+      (Array.isArray(obj.keywords) && obj.keywords.every(k => typeof k === 'string'))) &&
+    (obj.readmePath === undefined || typeof obj.readmePath === 'string') &&
+    (obj.docsConfig === undefined || isDocConfigSource(obj.docsConfig))
+  )
+}
+
+export function isReadmeSection(value: unknown): value is ReadmeSection {
+  if (typeof value !== 'object' || value === null) {
+    return false
+  }
+
+  const obj = value as Record<string, unknown>
+
+  return (
+    typeof obj.heading === 'string' &&
+    typeof obj.level === 'number' &&
+    obj.level >= 1 &&
+    obj.level <= 6 &&
+    typeof obj.content === 'string' &&
+    Array.isArray(obj.children) &&
+    obj.children.every(isReadmeSection)
+  )
+}
+
+export function isReadmeContent(value: unknown): value is ReadmeContent {
+  if (typeof value !== 'object' || value === null) {
+    return false
+  }
+
+  const obj = value as Record<string, unknown>
+
+  return (
+    (obj.title === undefined || typeof obj.title === 'string') &&
+    (obj.preamble === undefined || typeof obj.preamble === 'string') &&
+    Array.isArray(obj.sections) &&
+    obj.sections.every(isReadmeSection) &&
+    typeof obj.raw === 'string'
+  )
+}
+
+export function isMDXFrontmatter(value: unknown): value is MDXFrontmatter {
+  if (typeof value !== 'object' || value === null) {
+    return false
+  }
+
+  const obj = value as Record<string, unknown>
+
+  return (
+    typeof obj.title === 'string' &&
+    (obj.description === undefined || typeof obj.description === 'string') &&
+    (obj.sidebar === undefined || typeof obj.sidebar === 'object') &&
+    (obj.tableOfContents === undefined ||
+      typeof obj.tableOfContents === 'boolean' ||
+      typeof obj.tableOfContents === 'object') &&
+    (obj.template === undefined || obj.template === 'doc' || obj.template === 'splash')
+  )
+}
+
+export function isValidPackageName(name: string): boolean {
+  // Package names must not be empty
+  if (name.length === 0) {
+    return false
+  }
+
+  // Package names must not start with a dot or underscore
+  if (name.startsWith('.') || name.startsWith('_')) {
+    return false
+  }
+
+  // Scoped package names
+  if (name.startsWith('@')) {
+    const slashIndex = name.indexOf('/')
+    if (slashIndex <= 1 || slashIndex === name.length - 1) {
+      return false
+    }
+
+    const scope = name.slice(1, slashIndex)
+    const pkg = name.slice(slashIndex + 1)
+
+    return isValidUnscopedPackageName(scope) && isValidUnscopedPackageName(pkg)
+  }
+
+  return isValidUnscopedPackageName(name)
+}
+
+function isValidUnscopedPackageName(name: string): boolean {
+  return /^\w[\w.-]*$/.test(name)
+}
+
+export function isValidSemver(version: string): boolean {
+  return /^\d+\.\d+\.\d+(?:-[\w.-]+)?(?:\+[\w.-]+)?$/.test(version)
+}
+
+export function isValidHeadingLevel(level: number): level is 1 | 2 | 3 | 4 | 5 | 6 {
+  return Number.isInteger(level) && level >= 1 && level <= 6
+}
+
+/** Checks for potential XSS patterns to prevent injection attacks */
+export function isSafeContent(content: string): boolean {
+  const dangerousPatterns = [/<script\b/i, /javascript:/i, /on\w+\s*=/i, /data:/i, /vbscript:/i]
+
+  return !dangerousPatterns.some(pattern => pattern.test(content))
+}
+
+/** Prevents directory traversal attacks in file paths */
+export function isSafeFilePath(filePath: string): boolean {
+  const normalizedPath = filePath
+    .replaceAll('\\', '/')
+    .replaceAll(/\/+/g, '/')
+    .replaceAll('/./', '/')
+
+  // Check for directory traversal
+  if (normalizedPath.includes('../') || normalizedPath.includes('..\\')) {
+    return false
+  }
+
+  // Check for absolute paths on Unix
+  if (normalizedPath.startsWith('/') && !filePath.startsWith('/')) {
+    return false
+  }
+
+  return true
+}
+
+export function assertParseError(value: unknown): asserts value is ParseError {
+  if (!isParseError(value)) {
+    throw new TypeError('Expected ParseError')
+  }
+}
+
+export function assertPackageInfo(value: unknown): asserts value is PackageInfo {
+  if (!isPackageInfo(value)) {
+    throw new TypeError('Expected PackageInfo')
+  }
+}
+
+export function assertPackageAPI(value: unknown): asserts value is PackageAPI {
+  if (!isPackageAPI(value)) {
+    throw new TypeError('Expected PackageAPI')
+  }
+}

--- a/packages/doc-sync/src/parsers/index.ts
+++ b/packages/doc-sync/src/parsers/index.ts
@@ -1,0 +1,82 @@
+/**
+ * @bfra.me/doc-sync/parsers - Unified export of all parser modules
+ */
+
+// Export analyzer exports
+export {
+  analyzePublicAPI,
+  findExportedSymbols,
+  getExportedSymbolInfo,
+  getExportsByKind,
+  isSymbolExported,
+} from './export-analyzer'
+export type {ExportAnalyzerOptions, PublicAPIAnalysis, ResolvedExport} from './export-analyzer'
+
+// Type guards and validation exports
+export {
+  assertPackageAPI,
+  assertPackageInfo,
+  assertParseError,
+  isDocConfigSource,
+  isExportedFunction,
+  isExportedType,
+  isJSDocInfo,
+  isJSDocParam,
+  isJSDocTag,
+  isMDXFrontmatter,
+  isPackageAPI,
+  isPackageInfo,
+  isParseError,
+  isReadmeContent,
+  isReadmeSection,
+  isReExport,
+  isSafeContent,
+  isSafeFilePath,
+  isSyncError,
+  isValidHeadingLevel,
+  isValidPackageName,
+  isValidSemver,
+} from './guards'
+
+// JSDoc extractor exports
+export {extractJSDocInfo, hasJSDoc, parseJSDoc} from './jsdoc-extractor'
+export type {JSDocableDeclaration} from './jsdoc-extractor'
+
+// Package info exports
+export {
+  buildDocSlug,
+  extractDocsConfig,
+  findEntryPoint,
+  findReadmePath,
+  getPackageScope,
+  getUnscopedName,
+  parsePackageComplete,
+  parsePackageJson,
+  parsePackageJsonContent,
+} from './package-info'
+export type {PackageInfoOptions, PackageJsonSchema} from './package-info'
+
+// README parser exports
+export {
+  findSection,
+  flattenSections,
+  getSectionsByLevel,
+  getTableOfContents,
+  parseReadme,
+  parseReadmeFile,
+} from './readme-parser'
+export type {ReadmeParserOptions} from './readme-parser'
+
+// TypeScript parser exports
+export {
+  analyzeTypeScriptContent,
+  analyzeTypeScriptFile,
+  createProject,
+  extractExportedFunctions,
+  extractExportedTypes,
+  extractPackageAPI,
+  extractReExports,
+  parseSourceContent,
+  parseSourceFile,
+} from './typescript-parser'
+export type {TypeScriptParserOptions} from './typescript-parser'

--- a/packages/doc-sync/src/parsers/jsdoc-extractor.ts
+++ b/packages/doc-sync/src/parsers/jsdoc-extractor.ts
@@ -1,0 +1,313 @@
+/**
+ * @bfra.me/doc-sync/parsers/jsdoc-extractor - JSDoc annotation extraction from TypeScript AST nodes
+ */
+
+import type {
+  ClassDeclaration,
+  EnumDeclaration,
+  FunctionDeclaration,
+  InterfaceDeclaration,
+  JSDoc,
+  JSDocableNode,
+  Node,
+  TypeAliasDeclaration,
+} from 'ts-morph'
+
+import type {JSDocInfo, JSDocParam, JSDocTag} from '../types'
+
+/**
+ * Supported node types for JSDoc extraction
+ */
+export type JSDocableDeclaration =
+  | ClassDeclaration
+  | EnumDeclaration
+  | FunctionDeclaration
+  | InterfaceDeclaration
+  | TypeAliasDeclaration
+
+/**
+ * Type guard to check if a node has JSDoc
+ */
+export function hasJSDoc(node: Node): node is Node & JSDocableNode {
+  return 'getJsDocs' in node && typeof node.getJsDocs === 'function'
+}
+
+/**
+ * Extracts JSDoc information from an AST node
+ */
+export function extractJSDocInfo(node: JSDocableDeclaration): JSDocInfo | undefined {
+  if (!hasJSDoc(node)) {
+    return undefined
+  }
+
+  const jsDocs = node.getJsDocs()
+  if (jsDocs.length === 0) {
+    return undefined
+  }
+
+  const jsDoc = jsDocs[0]
+  if (jsDoc === undefined) {
+    return undefined
+  }
+
+  return parseJSDoc(jsDoc)
+}
+
+/**
+ * Parses a JSDoc node into structured information
+ */
+export function parseJSDoc(jsDoc: JSDoc): JSDocInfo {
+  const description = jsDoc.getDescription().trim() || undefined
+  const tags = jsDoc.getTags()
+
+  const params = extractParams(tags)
+  const returns = extractReturns(tags)
+  const examples = extractExamples(tags)
+  const deprecated = extractDeprecated(tags)
+  const since = extractSince(tags)
+  const see = extractSee(tags)
+  const customTags = extractCustomTags(tags)
+
+  return {
+    ...(description !== undefined && {description}),
+    ...(params.length > 0 && {params}),
+    ...(returns !== undefined && {returns}),
+    ...(examples.length > 0 && {examples}),
+    ...(deprecated !== undefined && {deprecated}),
+    ...(since !== undefined && {since}),
+    ...(see.length > 0 && {see}),
+    ...(customTags.length > 0 && {customTags}),
+  }
+}
+
+function extractParams(tags: ReturnType<JSDoc['getTags']>): readonly JSDocParam[] {
+  const params: JSDocParam[] = []
+
+  for (const tag of tags) {
+    const tagName = tag.getTagName()
+    if (tagName !== 'param') continue
+
+    const text = getTagText(tag)
+    if (text === undefined) continue
+
+    const parsed = parseParamText(text)
+    if (parsed !== undefined) {
+      params.push(parsed)
+    }
+  }
+
+  return params
+}
+
+/**
+ * Handles multiple @param text formats:
+ * - name - description
+ * - {type} name - description
+ * - name description
+ */
+function parseParamText(text: string): JSDocParam | undefined {
+  const trimmed = text.trim()
+  if (trimmed.length === 0) {
+    return undefined
+  }
+
+  let type: string | undefined
+  let remaining = trimmed
+
+  // Extract type if present: {type} ...
+  if (remaining.startsWith('{')) {
+    const typeEnd = remaining.indexOf('}')
+    if (typeEnd > 0) {
+      type = remaining.slice(1, typeEnd)
+      remaining = remaining.slice(typeEnd + 1).trim()
+    }
+  }
+
+  // Split name from description
+  const dashIndex = remaining.indexOf(' - ')
+  const spaceIndex = remaining.indexOf(' ')
+
+  let name: string
+  let description: string | undefined
+
+  if (dashIndex > 0) {
+    name = remaining.slice(0, dashIndex).trim()
+    description = remaining.slice(dashIndex + 3).trim() || undefined
+  } else if (spaceIndex > 0) {
+    name = remaining.slice(0, spaceIndex).trim()
+    description = remaining.slice(spaceIndex + 1).trim() || undefined
+  } else {
+    name = remaining
+  }
+
+  // Handle optional parameters [name]
+  let optional = false
+  if (name.startsWith('[') && name.endsWith(']')) {
+    optional = true
+    name = name.slice(1, -1)
+  }
+
+  // Handle default values [name=value]
+  let defaultValue: string | undefined
+  const defaultIndex = name.indexOf('=')
+  if (defaultIndex > 0) {
+    defaultValue = name.slice(defaultIndex + 1)
+    name = name.slice(0, defaultIndex)
+    optional = true
+  }
+
+  return {
+    name,
+    ...(type !== undefined && {type}),
+    ...(description !== undefined && {description}),
+    ...(optional && {optional}),
+    ...(defaultValue !== undefined && {defaultValue}),
+  }
+}
+
+function extractReturns(tags: ReturnType<JSDoc['getTags']>): string | undefined {
+  for (const tag of tags) {
+    const tagName = tag.getTagName()
+    if (tagName !== 'returns' && tagName !== 'return') continue
+
+    const text = getTagText(tag)
+    if (text !== undefined && text.trim().length > 0) {
+      // Strip leading type annotation if present
+      let result = text.trim()
+      if (result.startsWith('{')) {
+        const typeEnd = result.indexOf('}')
+        if (typeEnd > 0) {
+          result = result.slice(typeEnd + 1).trim()
+        }
+      }
+      return result.length > 0 ? result : undefined
+    }
+  }
+
+  return undefined
+}
+
+function extractExamples(tags: ReturnType<JSDoc['getTags']>): readonly string[] {
+  const examples: string[] = []
+
+  for (const tag of tags) {
+    const tagName = tag.getTagName()
+    if (tagName !== 'example') continue
+
+    const text = getTagText(tag)
+    if (text !== undefined && text.trim().length > 0) {
+      examples.push(text.trim())
+    }
+  }
+
+  return examples
+}
+
+function extractDeprecated(tags: ReturnType<JSDoc['getTags']>): string | undefined {
+  for (const tag of tags) {
+    const tagName = tag.getTagName()
+    if (tagName !== 'deprecated') continue
+
+    const text = getTagText(tag)
+    return text?.trim() ?? ''
+  }
+
+  return undefined
+}
+
+function extractSince(tags: ReturnType<JSDoc['getTags']>): string | undefined {
+  for (const tag of tags) {
+    const tagName = tag.getTagName()
+    if (tagName !== 'since') continue
+
+    const text = getTagText(tag)
+    if (text !== undefined && text.trim().length > 0) {
+      return text.trim()
+    }
+  }
+
+  return undefined
+}
+
+function extractSee(tags: ReturnType<JSDoc['getTags']>): readonly string[] {
+  const see: string[] = []
+
+  for (const tag of tags) {
+    const tagName = tag.getTagName()
+    if (tagName !== 'see') continue
+
+    const text = getTagText(tag)
+    if (text !== undefined && text.trim().length > 0) {
+      see.push(text.trim())
+    }
+  }
+
+  return see
+}
+
+const STANDARD_TAGS = new Set([
+  'param',
+  'returns',
+  'return',
+  'example',
+  'deprecated',
+  'since',
+  'see',
+  'type',
+  'typedef',
+  'callback',
+  'template',
+  'throws',
+  'async',
+  'generator',
+  'override',
+  'readonly',
+  'private',
+  'protected',
+  'public',
+  'module',
+  'exports',
+  'interface',
+  'enum',
+  'class',
+  'constructor',
+  'function',
+  'method',
+  'property',
+  'member',
+  'implements',
+  'extends',
+  'augments',
+])
+
+function extractCustomTags(tags: ReturnType<JSDoc['getTags']>): readonly JSDocTag[] {
+  const customTags: JSDocTag[] = []
+
+  for (const tag of tags) {
+    const tagName = tag.getTagName()
+    if (STANDARD_TAGS.has(tagName)) continue
+
+    const text = getTagText(tag)
+    const value = text !== undefined && text.trim().length > 0 ? text.trim() : undefined
+
+    customTags.push({
+      name: tagName,
+      ...(value !== undefined && {value}),
+    })
+  }
+
+  return customTags
+}
+
+function getTagText(tag: ReturnType<JSDoc['getTags']>[number]): string | undefined {
+  const fullText = tag.getText()
+  const tagName = tag.getTagName()
+  const prefix = `@${tagName}`
+
+  if (fullText.startsWith(prefix)) {
+    const text = fullText.slice(prefix.length).trim()
+    return text.length > 0 ? text : undefined
+  }
+
+  return undefined
+}

--- a/packages/doc-sync/src/parsers/package-info.ts
+++ b/packages/doc-sync/src/parsers/package-info.ts
@@ -1,0 +1,267 @@
+/**
+ * @bfra.me/doc-sync/parsers/package-info - Package.json metadata extraction
+ */
+
+import type {DocConfigSource, PackageInfo, ParseError, ParseResult} from '../types'
+
+import path from 'node:path'
+
+import {err, ok} from '@bfra.me/es/result'
+
+/**
+ * Schema for validating package.json structure (runtime validation)
+ */
+export interface PackageJsonSchema {
+  readonly name: string
+  readonly version: string
+  readonly description?: string
+  readonly keywords?: readonly string[]
+  readonly main?: string
+  readonly module?: string
+  readonly types?: string
+  readonly exports?: Record<string, unknown>
+  readonly repository?:
+    | string
+    | {
+        readonly type?: string
+        readonly url?: string
+        readonly directory?: string
+      }
+  readonly docs?: DocConfigSource
+}
+
+/**
+ * Options for parsing package.json files
+ */
+export interface PackageInfoOptions {
+  readonly validateSchema?: boolean
+  readonly extractDocsConfig?: boolean
+}
+
+/**
+ * Parses a package.json file and extracts relevant metadata
+ */
+export async function parsePackageJson(
+  packagePath: string,
+  options?: PackageInfoOptions,
+): Promise<ParseResult<PackageInfo>> {
+  const packageJsonPath = packagePath.endsWith('package.json')
+    ? packagePath
+    : path.join(packagePath, 'package.json')
+
+  try {
+    const fs = await import('node:fs/promises')
+    const content = await fs.readFile(packageJsonPath, 'utf-8')
+    return parsePackageJsonContent(content, packageJsonPath, options)
+  } catch (error) {
+    if (error instanceof Error && 'code' in error && error.code === 'ENOENT') {
+      return err({
+        code: 'FILE_NOT_FOUND',
+        message: `package.json not found: ${packageJsonPath}`,
+        filePath: packageJsonPath,
+        cause: error,
+      } satisfies ParseError)
+    }
+
+    return err({
+      code: 'READ_ERROR',
+      message: `Failed to read package.json: ${packageJsonPath}`,
+      filePath: packageJsonPath,
+      cause: error,
+    } satisfies ParseError)
+  }
+}
+
+/**
+ * Parses package.json content from a string
+ */
+export function parsePackageJsonContent(
+  content: string,
+  filePath: string,
+  options?: PackageInfoOptions,
+): ParseResult<PackageInfo> {
+  let parsed: unknown
+
+  try {
+    parsed = JSON.parse(content)
+  } catch (error) {
+    return err({
+      code: 'MALFORMED_JSON',
+      message: `Invalid JSON in package.json: ${filePath}`,
+      filePath,
+      cause: error,
+    } satisfies ParseError)
+  }
+
+  if (!isPackageJson(parsed)) {
+    return err({
+      code: 'INVALID_SYNTAX',
+      message: 'package.json is missing required fields (name, version)',
+      filePath,
+    } satisfies ParseError)
+  }
+
+  const packageDir = path.dirname(filePath)
+
+  return ok({
+    name: parsed.name,
+    version: parsed.version,
+    ...(parsed.description !== undefined && {description: parsed.description}),
+    ...(parsed.keywords !== undefined && {keywords: parsed.keywords}),
+    packagePath: packageDir,
+    srcPath: path.join(packageDir, 'src'),
+    ...(options?.extractDocsConfig !== false &&
+      parsed.docs !== undefined && {docsConfig: parsed.docs}),
+  })
+}
+
+function isPackageJson(value: unknown): value is PackageJsonSchema {
+  if (typeof value !== 'object' || value === null) {
+    return false
+  }
+
+  const obj = value as Record<string, unknown>
+
+  if (typeof obj.name !== 'string' || obj.name.length === 0) {
+    return false
+  }
+
+  if (typeof obj.version !== 'string' || obj.version.length === 0) {
+    return false
+  }
+
+  return true
+}
+
+/**
+ * Extracts documentation configuration from package.json
+ */
+export function extractDocsConfig(pkg: PackageInfo): DocConfigSource | undefined {
+  return pkg.docsConfig
+}
+
+/**
+ * Checks if a README file exists for a package
+ */
+export async function findReadmePath(packagePath: string): Promise<string | undefined> {
+  const fs = await import('node:fs/promises')
+  const candidates = ['README.md', 'readme.md', 'Readme.md', 'README.MD', 'README']
+
+  for (const candidate of candidates) {
+    const readmePath = path.join(packagePath, candidate)
+    try {
+      await fs.access(readmePath)
+      return readmePath
+    } catch {
+      // Continue to next candidate
+    }
+  }
+
+  return undefined
+}
+
+/**
+ * Extracts the source entry point from package.json
+ */
+export function findEntryPoint(pkg: PackageInfo, content: string): string {
+  try {
+    const parsed = JSON.parse(content) as PackageJsonSchema
+
+    // Check exports field first
+    if (parsed.exports !== undefined) {
+      const mainExport = parsed.exports['.']
+      if (mainExport !== undefined && typeof mainExport === 'object') {
+        const exportObj = mainExport as Record<string, unknown>
+        if (typeof exportObj.source === 'string') {
+          return path.join(pkg.packagePath, exportObj.source)
+        }
+        if (typeof exportObj.import === 'string') {
+          // Convert lib/ to src/ for source analysis
+          const importPath = exportObj.import
+          if (importPath.includes('/lib/')) {
+            return path.join(
+              pkg.packagePath,
+              importPath.replace('/lib/', '/src/').replace('.js', '.ts'),
+            )
+          }
+          return path.join(pkg.packagePath, importPath)
+        }
+      }
+      if (typeof mainExport === 'string') {
+        return path.join(pkg.packagePath, mainExport)
+      }
+    }
+
+    // Fall back to types or main field
+    if (typeof parsed.types === 'string') {
+      const typesPath = parsed.types.replace('/lib/', '/src/').replace('.d.ts', '.ts')
+      return path.join(pkg.packagePath, typesPath)
+    }
+
+    if (typeof parsed.main === 'string') {
+      const mainPath = parsed.main.replace('/lib/', '/src/').replace('.js', '.ts')
+      return path.join(pkg.packagePath, mainPath)
+    }
+  } catch {
+    // Ignore parsing errors
+  }
+
+  // Default to src/index.ts
+  return path.join(pkg.srcPath, 'index.ts')
+}
+
+/**
+ * Parses a complete package including README detection
+ */
+export async function parsePackageComplete(
+  packagePath: string,
+  options?: PackageInfoOptions,
+): Promise<ParseResult<PackageInfo>> {
+  const packageInfoResult = await parsePackageJson(packagePath, options)
+
+  if (!packageInfoResult.success) {
+    return packageInfoResult
+  }
+
+  const readmePath = await findReadmePath(packageInfoResult.data.packagePath)
+
+  return ok({
+    ...packageInfoResult.data,
+    ...(readmePath !== undefined && {readmePath}),
+  })
+}
+
+/**
+ * Gets the package scope from a scoped package name
+ */
+export function getPackageScope(packageName: string): string | undefined {
+  if (packageName.startsWith('@')) {
+    const slashIndex = packageName.indexOf('/')
+    if (slashIndex > 0) {
+      return packageName.slice(0, slashIndex)
+    }
+  }
+  return undefined
+}
+
+/**
+ * Gets the unscoped package name
+ */
+export function getUnscopedName(packageName: string): string {
+  if (packageName.startsWith('@')) {
+    const slashIndex = packageName.indexOf('/')
+    if (slashIndex > 0) {
+      return packageName.slice(slashIndex + 1)
+    }
+  }
+  return packageName
+}
+
+/**
+ * Builds a documentation slug from a package name
+ */
+export function buildDocSlug(packageName: string): string {
+  return getUnscopedName(packageName)
+    .toLowerCase()
+    .replaceAll(/[^a-z0-9-]/g, '-')
+}

--- a/packages/doc-sync/src/parsers/readme-parser.ts
+++ b/packages/doc-sync/src/parsers/readme-parser.ts
@@ -1,0 +1,334 @@
+/**
+ * @bfra.me/doc-sync/parsers/readme-parser - README Markdown parser with section extraction
+ */
+
+import type {Root, RootContent} from 'mdast'
+
+import type {ParseError, ParseResult, ReadmeContent, ReadmeSection} from '../types'
+
+import {err, ok} from '@bfra.me/es/result'
+import remarkParse from 'remark-parse'
+import {unified} from 'unified'
+
+/**
+ * Options for parsing README files
+ */
+export interface ReadmeParserOptions {
+  readonly extractSections?: boolean
+  readonly preserveRaw?: boolean
+}
+
+/**
+ * Parses a README markdown string into structured content
+ */
+export function parseReadme(
+  content: string,
+  options?: ReadmeParserOptions,
+): ParseResult<ReadmeContent> {
+  try {
+    const processor = unified().use(remarkParse)
+    const tree = processor.parse(content)
+
+    const title = extractTitle(tree)
+    const preamble = extractPreamble(tree)
+    const sections =
+      options?.extractSections === false ? ([] as readonly ReadmeSection[]) : extractSections(tree)
+
+    return ok({
+      ...(title !== undefined && {title}),
+      ...(preamble !== undefined && {preamble}),
+      sections,
+      raw: options?.preserveRaw === false ? '' : content,
+    })
+  } catch (error) {
+    return err({
+      code: 'INVALID_SYNTAX',
+      message: 'Failed to parse README content',
+      cause: error,
+    } satisfies ParseError)
+  }
+}
+
+/**
+ * Parses a README file from the file system
+ */
+export async function parseReadmeFile(
+  filePath: string,
+  options?: ReadmeParserOptions,
+): Promise<ParseResult<ReadmeContent>> {
+  try {
+    const fs = await import('node:fs/promises')
+    const content = await fs.readFile(filePath, 'utf-8')
+    return parseReadme(content, options)
+  } catch (error) {
+    if (error instanceof Error && 'code' in error && error.code === 'ENOENT') {
+      return err({
+        code: 'FILE_NOT_FOUND',
+        message: `README file not found: ${filePath}`,
+        filePath,
+        cause: error,
+      } satisfies ParseError)
+    }
+
+    return err({
+      code: 'READ_ERROR',
+      message: `Failed to read README file: ${filePath}`,
+      filePath,
+      cause: error,
+    } satisfies ParseError)
+  }
+}
+
+function extractTitle(tree: Root): string | undefined {
+  for (const node of tree.children) {
+    if (node.type === 'heading' && node.depth === 1) {
+      return extractTextFromNode(node)
+    }
+  }
+  return undefined
+}
+
+function extractPreamble(tree: Root): string | undefined {
+  const preambleNodes: RootContent[] = []
+
+  for (const node of tree.children) {
+    if (node.type === 'heading') {
+      break
+    }
+    preambleNodes.push(node)
+  }
+
+  if (preambleNodes.length === 0) {
+    return undefined
+  }
+
+  const text = preambleNodes.map(extractTextFromNode).join('\n\n').trim()
+  return text.length > 0 ? text : undefined
+}
+
+function extractSections(tree: Root): readonly ReadmeSection[] {
+  const sections: ReadmeSection[] = []
+  const stack: {level: number; section: ReadmeSection & {children: ReadmeSection[]}}[] = []
+
+  for (let i = 0; i < tree.children.length; i++) {
+    const node = tree.children[i]
+
+    if (node !== undefined && node.type === 'heading') {
+      const heading = extractTextFromNode(node)
+      const level = node.depth
+      const content = extractSectionContent(tree, i + 1)
+
+      const newSection: ReadmeSection & {children: ReadmeSection[]} = {
+        heading,
+        level,
+        content,
+        children: [],
+      }
+
+      // Pop sections from stack that are at same or higher level
+      while (stack.length > 0 && (stack.at(-1)?.level ?? 0) >= level) {
+        stack.pop()
+      }
+
+      if (stack.length === 0) {
+        // Top-level section
+        sections.push(newSection)
+      } else {
+        // Nested section
+        const parent = stack.at(-1)
+        parent?.section.children.push(newSection)
+      }
+
+      stack.push({level, section: newSection})
+    }
+  }
+
+  return freezeSections(sections)
+}
+
+function freezeSections(sections: ReadmeSection[]): readonly ReadmeSection[] {
+  return sections.map(s => ({
+    heading: s.heading,
+    level: s.level,
+    content: s.content,
+    children: freezeSections([...s.children]),
+  }))
+}
+
+function extractSectionContent(tree: Root, startIndex: number): string {
+  const contentNodes: RootContent[] = []
+
+  for (let i = startIndex; i < tree.children.length; i++) {
+    const node = tree.children[i]
+    if (node === undefined || node.type === 'heading') {
+      break
+    }
+    contentNodes.push(node)
+  }
+
+  return contentNodes.map(serializeNode).join('\n\n').trim()
+}
+
+function extractTextFromNode(node: RootContent): string {
+  if ('value' in node && typeof node.value === 'string') {
+    return node.value
+  }
+
+  if ('children' in node && Array.isArray(node.children)) {
+    return (node.children as RootContent[]).map(extractTextFromNode).join('')
+  }
+
+  return ''
+}
+
+function serializeNode(node: RootContent): string {
+  if (node.type === 'paragraph') {
+    return extractTextFromNode(node)
+  }
+
+  if (node.type === 'heading') {
+    const prefix = '#'.repeat(node.depth)
+    return `${prefix} ${extractTextFromNode(node)}`
+  }
+
+  if (node.type === 'code') {
+    return `\`\`\`${node.lang ?? ''}\n${node.value}\n\`\`\``
+  }
+
+  if (node.type === 'blockquote') {
+    return (node.children as RootContent[]).map(c => `> ${serializeNode(c)}`).join('\n')
+  }
+
+  if (node.type === 'list') {
+    const items = node.children
+      .map((item, index) => {
+        if (item.type !== 'listItem') return ''
+        const prefix = node.ordered === true ? `${index + 1}. ` : '- '
+        const content = (item.children as RootContent[]).map(serializeNode).join('\n')
+        return `${prefix}${content}`
+      })
+      .filter(s => s.length > 0)
+    return items.join('\n')
+  }
+
+  if (node.type === 'thematicBreak') {
+    return '---'
+  }
+
+  if (node.type === 'html') {
+    return node.value
+  }
+
+  if (node.type === 'table') {
+    return serializeTable(node)
+  }
+
+  // For all other node types, extract text content
+  return extractTextFromNode(node)
+}
+
+function serializeTable(node: RootContent): string {
+  if (node.type !== 'table' || !('children' in node)) {
+    return ''
+  }
+
+  const rows = node.children
+    .filter((row): row is (typeof node.children)[number] => row.type === 'tableRow')
+    .map(row => {
+      const cells = (row.children as RootContent[])
+        .filter((cell): cell is RootContent => cell.type === 'tableCell')
+        .map(cell => extractTextFromNode(cell))
+      return `| ${cells.join(' | ')} |`
+    })
+
+  if (rows.length === 0) {
+    return ''
+  }
+
+  // Insert separator after header row
+  const headerRow = rows[0]
+  if (headerRow !== undefined) {
+    const columnCount = (headerRow.match(/\|/g)?.length ?? 2) - 1
+    const separator = `|${' --- |'.repeat(columnCount)}`
+    rows.splice(1, 0, separator)
+  }
+
+  return rows.join('\n')
+}
+
+/**
+ * Finds a section by heading text (case-insensitive)
+ */
+export function findSection(
+  content: ReadmeContent,
+  headingText: string,
+): ReadmeSection | undefined {
+  const normalizedSearch = headingText.toLowerCase()
+
+  function searchInSections(sections: readonly ReadmeSection[]): ReadmeSection | undefined {
+    for (const section of sections) {
+      if (section.heading.toLowerCase() === normalizedSearch) {
+        return section
+      }
+
+      const found = searchInSections(section.children)
+      if (found !== undefined) {
+        return found
+      }
+    }
+    return undefined
+  }
+
+  return searchInSections(content.sections)
+}
+
+/**
+ * Gets all sections at a specific heading level
+ */
+export function getSectionsByLevel(
+  content: ReadmeContent,
+  level: number,
+): readonly ReadmeSection[] {
+  const result: ReadmeSection[] = []
+
+  function collectAtLevel(sections: readonly ReadmeSection[]): void {
+    for (const section of sections) {
+      if (section.level === level) {
+        result.push(section)
+      }
+      collectAtLevel(section.children)
+    }
+  }
+
+  collectAtLevel(content.sections)
+  return result
+}
+
+/**
+ * Flattens all sections into a single array
+ */
+export function flattenSections(content: ReadmeContent): readonly ReadmeSection[] {
+  const result: ReadmeSection[] = []
+
+  function collect(sections: readonly ReadmeSection[]): void {
+    for (const section of sections) {
+      result.push(section)
+      collect(section.children)
+    }
+  }
+
+  collect(content.sections)
+  return result
+}
+
+/**
+ * Gets the table of contents as a flat list
+ */
+export function getTableOfContents(
+  content: ReadmeContent,
+): readonly {readonly heading: string; readonly level: number}[] {
+  return flattenSections(content).map(s => ({
+    heading: s.heading,
+    level: s.level,
+  }))
+}

--- a/packages/doc-sync/src/parsers/typescript-parser.ts
+++ b/packages/doc-sync/src/parsers/typescript-parser.ts
@@ -1,0 +1,299 @@
+/**
+ * @bfra.me/doc-sync/parsers/typescript-parser - TypeScript source file parser using ts-morph
+ */
+
+import type {
+  ExportedFunction,
+  ExportedType,
+  FunctionParameter,
+  PackageAPI,
+  ParseError,
+  ParseResult,
+  ReExport,
+} from '../types'
+
+import {err, ok} from '@bfra.me/es/result'
+import {Project, type SourceFile} from 'ts-morph'
+
+import {extractJSDocInfo} from './jsdoc-extractor'
+
+/**
+ * Options for parsing TypeScript source files
+ */
+export interface TypeScriptParserOptions {
+  readonly tsConfigPath?: string
+  readonly compilerOptions?: Record<string, unknown>
+}
+
+/**
+ * Creates a ts-morph project instance for analyzing source files
+ */
+export function createProject(options?: TypeScriptParserOptions): Project {
+  return new Project({
+    tsConfigFilePath: options?.tsConfigPath,
+    compilerOptions: {
+      declaration: true,
+      ...(options?.compilerOptions as object),
+    },
+    skipAddingFilesFromTsConfig: true,
+  })
+}
+
+/**
+ * Parses a TypeScript source file and extracts its structure
+ */
+export function parseSourceFile(project: Project, filePath: string): ParseResult<SourceFile> {
+  try {
+    const sourceFile = project.addSourceFileAtPath(filePath)
+    return ok(sourceFile)
+  } catch (error) {
+    return err({
+      code: 'FILE_NOT_FOUND',
+      message: `Failed to parse source file: ${filePath}`,
+      filePath,
+      cause: error,
+    } satisfies ParseError)
+  }
+}
+
+/**
+ * Parses TypeScript source content from a string
+ */
+export function parseSourceContent(
+  project: Project,
+  content: string,
+  virtualPath = 'virtual.ts',
+): ParseResult<SourceFile> {
+  try {
+    const sourceFile = project.createSourceFile(virtualPath, content, {
+      overwrite: true,
+    })
+    return ok(sourceFile)
+  } catch (error) {
+    return err({
+      code: 'INVALID_SYNTAX',
+      message: 'Failed to parse TypeScript content',
+      filePath: virtualPath,
+      cause: error,
+    } satisfies ParseError)
+  }
+}
+
+/**
+ * Extracts exported functions from a source file
+ */
+export function extractExportedFunctions(sourceFile: SourceFile): readonly ExportedFunction[] {
+  const functions: ExportedFunction[] = []
+
+  for (const func of sourceFile.getFunctions()) {
+    if (!func.isExported()) continue
+
+    const name = func.getName() ?? 'default'
+    const parameters = extractFunctionParameters(func)
+    const returnType = func.getReturnType().getText()
+    const jsdoc = extractJSDocInfo(func)
+
+    functions.push({
+      name,
+      jsdoc,
+      signature: func.getSignature()?.getDeclaration().getText() ?? func.getText(),
+      isAsync: func.isAsync(),
+      isGenerator: func.isGenerator(),
+      parameters,
+      returnType,
+      isDefault: func.isDefaultExport(),
+    })
+  }
+
+  return functions
+}
+
+function extractFunctionParameters(
+  func: ReturnType<SourceFile['getFunctions']>[number],
+): readonly FunctionParameter[] {
+  return func.getParameters().map(param => ({
+    name: param.getName(),
+    type: param.getType().getText(),
+    optional: param.isOptional(),
+    defaultValue: param.getInitializer()?.getText(),
+  }))
+}
+
+/**
+ * Extracts exported types and interfaces from a source file
+ */
+export function extractExportedTypes(sourceFile: SourceFile): readonly ExportedType[] {
+  const types: ExportedType[] = []
+
+  // Extract interfaces
+  for (const iface of sourceFile.getInterfaces()) {
+    if (!iface.isExported()) continue
+
+    const jsdoc = extractJSDocInfo(iface)
+    const typeParams = iface.getTypeParameters().map(tp => tp.getText())
+
+    types.push({
+      name: iface.getName(),
+      jsdoc,
+      definition: iface.getText(),
+      kind: 'interface',
+      isDefault: iface.isDefaultExport(),
+      typeParameters: typeParams.length > 0 ? typeParams : undefined,
+    })
+  }
+
+  // Extract type aliases
+  for (const typeAlias of sourceFile.getTypeAliases()) {
+    if (!typeAlias.isExported()) continue
+
+    const jsdoc = extractJSDocInfo(typeAlias)
+    const typeParams = typeAlias.getTypeParameters().map(tp => tp.getText())
+
+    types.push({
+      name: typeAlias.getName(),
+      jsdoc,
+      definition: typeAlias.getText(),
+      kind: 'type',
+      isDefault: typeAlias.isDefaultExport(),
+      typeParameters: typeParams.length > 0 ? typeParams : undefined,
+    })
+  }
+
+  // Extract enums
+  for (const enumDecl of sourceFile.getEnums()) {
+    if (!enumDecl.isExported()) continue
+
+    const jsdoc = extractJSDocInfo(enumDecl)
+
+    types.push({
+      name: enumDecl.getName(),
+      jsdoc,
+      definition: enumDecl.getText(),
+      kind: 'enum',
+      isDefault: enumDecl.isDefaultExport(),
+    })
+  }
+
+  // Extract classes
+  for (const classDecl of sourceFile.getClasses()) {
+    if (!classDecl.isExported()) continue
+
+    const name = classDecl.getName()
+    if (name === undefined) continue
+
+    const jsdoc = extractJSDocInfo(classDecl)
+    const typeParams = classDecl.getTypeParameters().map(tp => tp.getText())
+
+    types.push({
+      name,
+      jsdoc,
+      definition: classDecl.getText(),
+      kind: 'class',
+      isDefault: classDecl.isDefaultExport(),
+      typeParameters: typeParams.length > 0 ? typeParams : undefined,
+    })
+  }
+
+  return types
+}
+
+/**
+ * Extracts re-export statements from a source file
+ */
+export function extractReExports(sourceFile: SourceFile): readonly ReExport[] {
+  const reExports: ReExport[] = []
+
+  for (const exportDecl of sourceFile.getExportDeclarations()) {
+    const moduleSpecifier = exportDecl.getModuleSpecifierValue()
+    if (moduleSpecifier === undefined || moduleSpecifier.length === 0) continue
+
+    if (exportDecl.isNamespaceExport()) {
+      const namespaceExport = exportDecl.getNamespaceExport()
+      reExports.push({
+        from: moduleSpecifier,
+        exports: '*',
+        alias: namespaceExport?.getName(),
+      })
+    } else {
+      const namedExports = exportDecl.getNamedExports().map(ne => {
+        const aliasNode = ne.getAliasNode()
+        const alias = aliasNode === undefined ? undefined : aliasNode.getText()
+        const name = ne.getName()
+        return alias === undefined ? name : `${name} as ${alias}`
+      })
+
+      if (namedExports.length > 0) {
+        reExports.push({
+          from: moduleSpecifier,
+          exports: namedExports,
+        })
+      }
+    }
+  }
+
+  return reExports
+}
+
+/**
+ * Extracts the complete API surface from a source file
+ */
+export function extractPackageAPI(sourceFile: SourceFile): PackageAPI {
+  return {
+    functions: extractExportedFunctions(sourceFile),
+    types: extractExportedTypes(sourceFile),
+    reExports: extractReExports(sourceFile),
+  }
+}
+
+/**
+ * Parses and analyzes a TypeScript file, returning the complete API
+ */
+export function analyzeTypeScriptFile(
+  filePath: string,
+  options?: TypeScriptParserOptions,
+): ParseResult<PackageAPI> {
+  const project = createProject(options)
+  const sourceFileResult = parseSourceFile(project, filePath)
+
+  if (!sourceFileResult.success) {
+    return sourceFileResult
+  }
+
+  try {
+    const api = extractPackageAPI(sourceFileResult.data)
+    return ok(api)
+  } catch (error) {
+    return err({
+      code: 'INVALID_SYNTAX',
+      message: `Failed to analyze TypeScript file: ${filePath}`,
+      filePath,
+      cause: error,
+    } satisfies ParseError)
+  }
+}
+
+/**
+ * Analyzes TypeScript content from a string
+ */
+export function analyzeTypeScriptContent(
+  content: string,
+  options?: TypeScriptParserOptions,
+): ParseResult<PackageAPI> {
+  const project = createProject(options)
+  const sourceFileResult = parseSourceContent(project, content)
+
+  if (!sourceFileResult.success) {
+    return sourceFileResult
+  }
+
+  try {
+    const api = extractPackageAPI(sourceFileResult.data)
+    return ok(api)
+  } catch (error) {
+    return err({
+      code: 'INVALID_SYNTAX',
+      message: 'Failed to analyze TypeScript content',
+      cause: error,
+    } satisfies ParseError)
+  }
+}

--- a/packages/doc-sync/tsup.config.ts
+++ b/packages/doc-sync/tsup.config.ts
@@ -3,7 +3,7 @@ import {defineConfig} from 'tsup'
 export default defineConfig({
   clean: true,
   dts: true,
-  entry: ['src/index.ts', 'src/types.ts', 'src/cli/index.ts'],
+  entry: ['src/index.ts', 'src/types.ts', 'src/parsers/index.ts', 'src/cli/index.ts'],
   format: ['esm'],
   outDir: 'lib',
   sourcemap: true,


### PR DESCRIPTION
- Introduce a unified export for all parser modules in `parsers/index.ts`.
- Implement JSDoc extraction functionality in `jsdoc-extractor.ts`.
- Create package info extraction logic in `package-info.ts`.
- Develop README parsing capabilities in `readme-parser.ts`.
- Add TypeScript source file parsing and analysis in `typescript-parser.ts`.
- Update `tsup.config.ts` to include new parser entry points.

Closes #2355.