### PR TITLE
feat: add generators for Starlight documentation

### DIFF
--- a/.ai/plan/feature-doc-sync-engine-1.md
+++ b/.ai/plan/feature-doc-sync-engine-1.md
@@ -84,13 +84,13 @@ Build an intelligent documentation synchronization engine that continuously moni
 
 | Task | Description | Completed | Date |
 |------|-------------|-----------|------|
-| TASK-015 | Create `src/generators/mdx-generator.ts` for MDX document structure generation | | |
-| TASK-016 | Implement `src/generators/frontmatter-generator.ts` for Starlight-compatible frontmatter | | |
-| TASK-017 | Create `src/generators/api-reference-generator.ts` for function/type documentation tables | | |
-| TASK-018 | Implement `src/generators/component-mapper.ts` to map content sections to Starlight components | | |
-| TASK-019 | Create `src/generators/content-merger.ts` to preserve manual sections using sentinel markers | | |
-| TASK-020 | Build `src/generators/code-example-formatter.ts` for syntax-highlighted code blocks | | |
-| TASK-021 | Create generator barrel export in `src/generators/index.ts` | | |
+| TASK-015 | Create `src/generators/mdx-generator.ts` for MDX document structure generation | ✅ | 2025-12-04 |
+| TASK-016 | Implement `src/generators/frontmatter-generator.ts` for Starlight-compatible frontmatter | ✅ | 2025-12-04 |
+| TASK-017 | Create `src/generators/api-reference-generator.ts` for function/type documentation tables | ✅ | 2025-12-04 |
+| TASK-018 | Implement `src/generators/component-mapper.ts` to map content sections to Starlight components | ✅ | 2025-12-04 |
+| TASK-019 | Create `src/generators/content-merger.ts` to preserve manual sections using sentinel markers | ✅ | 2025-12-04 |
+| TASK-020 | Build `src/generators/code-example-formatter.ts` for syntax-highlighted code blocks | ✅ | 2025-12-04 |
+| TASK-021 | Create generator barrel export in `src/generators/index.ts` | ✅ | 2025-12-04 |
 
 ### Implementation Phase 4: File System Watcher and Sync Orchestrator
 

--- a/packages/doc-sync/package.json
+++ b/packages/doc-sync/package.json
@@ -30,6 +30,11 @@
       "source": "./src/index.ts",
       "import": "./lib/index.js"
     },
+    "./generators": {
+      "types": "./lib/generators/index.d.ts",
+      "source": "./src/generators/index.ts",
+      "import": "./lib/generators/index.js"
+    },
     "./parsers": {
       "types": "./lib/parsers/index.d.ts",
       "source": "./src/parsers/index.ts",

--- a/packages/doc-sync/src/generators/api-reference-generator.ts
+++ b/packages/doc-sync/src/generators/api-reference-generator.ts
@@ -1,0 +1,268 @@
+/**
+ * @bfra.me/doc-sync/generators/api-reference-generator - API documentation table generation
+ */
+
+import type {ExportedFunction, ExportedType, PackageAPI} from '../types'
+
+export function generateAPIReference(api: PackageAPI): string {
+  const sections: string[] = []
+
+  if (api.functions.length > 0) {
+    sections.push('### Functions')
+    sections.push('')
+    sections.push(generateFunctionsTable(api.functions))
+    sections.push('')
+    sections.push(generateFunctionDetails(api.functions))
+  }
+
+  if (api.types.length > 0) {
+    sections.push('### Types')
+    sections.push('')
+    sections.push(generateTypesTable(api.types))
+    sections.push('')
+    sections.push(generateTypeDetails(api.types))
+  }
+
+  return sections.join('\n')
+}
+
+function generateFunctionsTable(functions: readonly ExportedFunction[]): string {
+  const lines: string[] = []
+
+  lines.push('| Function | Description |')
+  lines.push('| -------- | ----------- |')
+
+  for (const fn of functions) {
+    const name = formatFunctionName(fn)
+    const description = fn.jsdoc?.description ?? ''
+    const firstLine = getFirstLine(description)
+    lines.push(`| ${name} | ${escapeTableCell(firstLine)} |`)
+  }
+
+  return lines.join('\n')
+}
+
+function generateFunctionDetails(functions: readonly ExportedFunction[]): string {
+  const sections: string[] = []
+
+  for (const fn of functions) {
+    sections.push(generateFunctionDetail(fn))
+  }
+
+  return sections.join('\n\n')
+}
+
+function generateFunctionDetail(fn: ExportedFunction): string {
+  const lines: string[] = []
+
+  lines.push(`#### \`${fn.name}\``)
+  lines.push('')
+
+  if (fn.jsdoc?.description !== undefined) {
+    lines.push(fn.jsdoc.description)
+    lines.push('')
+  }
+
+  lines.push('```typescript')
+  lines.push(fn.signature)
+  lines.push('```')
+
+  if (fn.parameters.length > 0) {
+    lines.push('')
+    lines.push('**Parameters:**')
+    lines.push('')
+    lines.push('| Name | Type | Description |')
+    lines.push('| ---- | ---- | ----------- |')
+
+    for (const param of fn.parameters) {
+      const paramDoc = fn.jsdoc?.params?.find(p => p.name === param.name)
+      const description = paramDoc?.description ?? ''
+      const optional = param.optional ? ' (optional)' : ''
+      lines.push(
+        `| \`${param.name}\`${optional} | \`${escapeCode(param.type)}\` | ${escapeTableCell(description)} |`,
+      )
+    }
+  }
+
+  if (fn.returnType !== 'void') {
+    lines.push('')
+    lines.push(`**Returns:** \`${escapeCode(fn.returnType)}\``)
+
+    if (fn.jsdoc?.returns !== undefined) {
+      lines.push('')
+      lines.push(fn.jsdoc.returns)
+    }
+  }
+
+  if (fn.jsdoc?.deprecated !== undefined) {
+    lines.push('')
+    lines.push(`:::caution[Deprecated]`)
+    lines.push(fn.jsdoc.deprecated)
+    lines.push(':::')
+  }
+
+  if (fn.jsdoc?.since !== undefined) {
+    lines.push('')
+    lines.push(`*Since: ${fn.jsdoc.since}*`)
+  }
+
+  return lines.join('\n')
+}
+
+function generateTypesTable(types: readonly ExportedType[]): string {
+  const lines: string[] = []
+
+  lines.push('| Type | Kind | Description |')
+  lines.push('| ---- | ---- | ----------- |')
+
+  for (const type of types) {
+    const name = `[\`${type.name}\`](#${type.name.toLowerCase()})`
+    const kind = type.kind
+    const description = type.jsdoc?.description ?? ''
+    const firstLine = getFirstLine(description)
+    lines.push(`| ${name} | ${kind} | ${escapeTableCell(firstLine)} |`)
+  }
+
+  return lines.join('\n')
+}
+
+function generateTypeDetails(types: readonly ExportedType[]): string {
+  const sections: string[] = []
+
+  for (const type of types) {
+    sections.push(generateTypeDetail(type))
+  }
+
+  return sections.join('\n\n')
+}
+
+function generateTypeDetail(type: ExportedType): string {
+  const lines: string[] = []
+
+  lines.push(`#### \`${type.name}\``)
+  lines.push('')
+
+  if (type.jsdoc?.description !== undefined) {
+    lines.push(type.jsdoc.description)
+    lines.push('')
+  }
+
+  lines.push('```typescript')
+  lines.push(type.definition)
+  lines.push('```')
+
+  if (type.typeParameters !== undefined && type.typeParameters.length > 0) {
+    lines.push('')
+    lines.push(`**Type Parameters:** ${type.typeParameters.map(t => `\`${t}\``).join(', ')}`)
+  }
+
+  if (type.jsdoc?.deprecated !== undefined) {
+    lines.push('')
+    lines.push(`:::caution[Deprecated]`)
+    lines.push(type.jsdoc.deprecated)
+    lines.push(':::')
+  }
+
+  if (type.jsdoc?.since !== undefined) {
+    lines.push('')
+    lines.push(`*Since: ${type.jsdoc.since}*`)
+  }
+
+  return lines.join('\n')
+}
+
+function formatFunctionName(fn: ExportedFunction): string {
+  const name = `[\`${fn.name}\`](#${fn.name.toLowerCase()})`
+  const badges: string[] = []
+
+  if (fn.isAsync) {
+    badges.push('<Badge text="async" variant="note" size="small" />')
+  }
+
+  if (fn.isGenerator) {
+    badges.push('<Badge text="generator" variant="tip" size="small" />')
+  }
+
+  if (fn.isDefault) {
+    badges.push('<Badge text="default" variant="caution" size="small" />')
+  }
+
+  return badges.length > 0 ? `${name} ${badges.join(' ')}` : name
+}
+
+function getFirstLine(text: string): string {
+  const firstLine = text.split('\n')[0]?.trim() ?? ''
+
+  if (firstLine.length > 100) {
+    const truncated = firstLine.slice(0, 97)
+    const lastSpace = truncated.lastIndexOf(' ')
+    if (lastSpace > 50) {
+      return `${truncated.slice(0, lastSpace)}...`
+    }
+    return `${truncated}...`
+  }
+
+  return firstLine
+}
+
+function escapeTableCell(content: string): string {
+  return content.replaceAll('|', String.raw`\|`).replaceAll('\n', ' ')
+}
+
+function escapeCode(code: string): string {
+  return code.replaceAll('`', '\\`')
+}
+
+export function generateAPICompact(api: PackageAPI): string {
+  const lines: string[] = []
+
+  if (api.functions.length > 0) {
+    lines.push('**Functions:**')
+    for (const fn of api.functions) {
+      lines.push(`- \`${fn.name}(${formatParameterList(fn)})\` → \`${fn.returnType}\``)
+    }
+  }
+
+  if (api.types.length > 0) {
+    if (lines.length > 0) lines.push('')
+    lines.push('**Types:**')
+    for (const type of api.types) {
+      lines.push(`- \`${type.name}\` (${type.kind})`)
+    }
+  }
+
+  return lines.join('\n')
+}
+
+function formatParameterList(fn: ExportedFunction): string {
+  return fn.parameters.map(p => (p.optional ? `${p.name}?` : p.name)).join(', ')
+}
+
+export function generateCategoryReference(
+  functions: readonly ExportedFunction[],
+  types: readonly ExportedType[],
+  categoryName: string,
+): string {
+  const sections: string[] = []
+
+  sections.push(`### ${categoryName}`)
+  sections.push('')
+
+  if (functions.length > 0) {
+    sections.push('#### Functions')
+    sections.push('')
+    sections.push(generateFunctionsTable(functions))
+    sections.push('')
+    sections.push(generateFunctionDetails(functions))
+  }
+
+  if (types.length > 0) {
+    sections.push('#### Types')
+    sections.push('')
+    sections.push(generateTypesTable(types))
+    sections.push('')
+    sections.push(generateTypeDetails(types))
+  }
+
+  return sections.join('\n')
+}

--- a/packages/doc-sync/src/generators/code-example-formatter.ts
+++ b/packages/doc-sync/src/generators/code-example-formatter.ts
@@ -1,0 +1,313 @@
+/**
+ * @bfra.me/doc-sync/generators/code-example-formatter - Syntax-highlighted code blocks from JSDoc examples
+ */
+
+import type {ExportedFunction, ExportedType, PackageAPI} from '../types'
+
+/**
+ * Options for code example formatting
+ */
+export interface CodeExampleOptions {
+  /** Default language for code blocks */
+  readonly defaultLanguage?: string
+  /** Whether to add function name as title */
+  readonly includeTitle?: boolean
+  /** Maximum number of examples per function */
+  readonly maxExamplesPerFunction?: number
+  /** Whether to wrap examples in collapsible sections */
+  readonly collapsible?: boolean
+}
+
+/**
+ * Default options for code example formatting
+ */
+const DEFAULT_OPTIONS: Required<CodeExampleOptions> = {
+  defaultLanguage: 'typescript',
+  includeTitle: true,
+  maxExamplesPerFunction: 3,
+  collapsible: false,
+}
+
+export function formatCodeExamples(api: PackageAPI, options: CodeExampleOptions = {}): string {
+  const mergedOptions = {...DEFAULT_OPTIONS, ...options}
+  const examples: string[] = []
+
+  for (const fn of api.functions) {
+    const fnExamples = formatFunctionExamples(fn, mergedOptions)
+    if (fnExamples.length > 0) {
+      examples.push(fnExamples)
+    }
+  }
+
+  for (const type of api.types) {
+    const typeExamples = formatTypeExamples(type, mergedOptions)
+    if (typeExamples.length > 0) {
+      examples.push(typeExamples)
+    }
+  }
+
+  return examples.join('\n\n')
+}
+
+export function formatFunctionExamples(
+  fn: ExportedFunction,
+  options: CodeExampleOptions = {},
+): string {
+  const mergedOptions = {...DEFAULT_OPTIONS, ...options}
+
+  if (fn.jsdoc?.examples === undefined || fn.jsdoc.examples.length === 0) {
+    return ''
+  }
+
+  const exampleCount = Math.min(fn.jsdoc.examples.length, mergedOptions.maxExamplesPerFunction)
+  const examples = fn.jsdoc.examples.slice(0, exampleCount)
+
+  const sections: string[] = []
+
+  if (mergedOptions.includeTitle) {
+    sections.push(`### ${fn.name}`)
+    sections.push('')
+  }
+
+  for (const [index, example] of examples.entries()) {
+    const formattedExample = formatCodeBlock(example, mergedOptions.defaultLanguage)
+
+    if (mergedOptions.collapsible && examples.length > 1) {
+      sections.push(`<details>`)
+      sections.push(`<summary>Example ${index + 1}</summary>`)
+      sections.push('')
+      sections.push(formattedExample)
+      sections.push('')
+      sections.push(`</details>`)
+    } else {
+      sections.push(formattedExample)
+    }
+
+    if (index < examples.length - 1) {
+      sections.push('')
+    }
+  }
+
+  return sections.join('\n')
+}
+
+export function formatTypeExamples(type: ExportedType, options: CodeExampleOptions = {}): string {
+  const mergedOptions = {...DEFAULT_OPTIONS, ...options}
+
+  if (type.jsdoc?.examples === undefined || type.jsdoc.examples.length === 0) {
+    return ''
+  }
+
+  const exampleCount = Math.min(type.jsdoc.examples.length, mergedOptions.maxExamplesPerFunction)
+  const examples = type.jsdoc.examples.slice(0, exampleCount)
+
+  const sections: string[] = []
+
+  if (mergedOptions.includeTitle) {
+    sections.push(`### ${type.name}`)
+    sections.push('')
+  }
+
+  for (const [index, example] of examples.entries()) {
+    const formattedExample = formatCodeBlock(example, mergedOptions.defaultLanguage)
+
+    if (mergedOptions.collapsible && examples.length > 1) {
+      sections.push(`<details>`)
+      sections.push(`<summary>Example ${index + 1}</summary>`)
+      sections.push('')
+      sections.push(formattedExample)
+      sections.push('')
+      sections.push(`</details>`)
+    } else {
+      sections.push(formattedExample)
+    }
+
+    if (index < examples.length - 1) {
+      sections.push('')
+    }
+  }
+
+  return sections.join('\n')
+}
+
+export function formatCodeBlock(code: string, language = 'typescript'): string {
+  const cleanedCode = cleanCodeExample(code)
+  const detectedLanguage = detectLanguage(cleanedCode) ?? language
+
+  return `\`\`\`${detectedLanguage}\n${cleanedCode}\n\`\`\``
+}
+
+export function cleanCodeExample(code: string): string {
+  let cleaned = code.trim()
+
+  if (cleaned.startsWith('```')) {
+    const lines = cleaned.split('\n')
+    lines.shift()
+    if (lines.at(-1)?.trim() === '```') {
+      lines.pop()
+    }
+    cleaned = lines.join('\n')
+  }
+
+  cleaned = cleaned
+    .split('\n')
+    .map(line => {
+      if (line.startsWith(' * ')) {
+        return line.slice(3)
+      }
+      if (line.startsWith('* ')) {
+        return line.slice(2)
+      }
+      return line
+    })
+    .join('\n')
+
+  const lines = cleaned.split('\n')
+  const nonEmptyLines = lines.filter(line => line.trim().length > 0)
+
+  if (nonEmptyLines.length === 0) {
+    return cleaned
+  }
+
+  const minIndent = Math.min(
+    ...nonEmptyLines.map(line => {
+      const match = /^(\s*)/.exec(line)
+      return match?.[1]?.length ?? 0
+    }),
+  )
+
+  if (minIndent > 0) {
+    cleaned = lines.map(line => line.slice(minIndent)).join('\n')
+  }
+
+  return cleaned.trim()
+}
+
+export function detectLanguage(code: string): string | undefined {
+  if (code.includes('import ') || code.includes('export ') || code.includes(': ')) {
+    if (code.includes('<') && code.includes('/>')) {
+      return 'tsx'
+    }
+    return 'typescript'
+  }
+
+  if (code.includes('const ') || code.includes('let ') || code.includes('function ')) {
+    if (code.includes('<') && code.includes('/>')) {
+      return 'jsx'
+    }
+    return 'javascript'
+  }
+
+  if (code.startsWith('{') || code.startsWith('[')) {
+    return 'json'
+  }
+
+  if (code.includes('$ ') || code.includes('npm ') || code.includes('pnpm ')) {
+    return 'bash'
+  }
+
+  return undefined
+}
+
+export function formatUsageExample(fn: ExportedFunction): string {
+  const params = fn.parameters.map(p => {
+    if (p.optional && p.defaultValue !== undefined) {
+      return `${p.name} = ${p.defaultValue}`
+    }
+    if (p.optional) {
+      return `${p.name}?`
+    }
+    return p.name
+  })
+
+  const call = `${fn.name}(${params.join(', ')})`
+
+  if (fn.isAsync) {
+    return `const result = await ${call}`
+  }
+
+  if (fn.returnType !== 'void') {
+    return `const result = ${call}`
+  }
+
+  return call
+}
+
+export function groupExamplesByCategory(
+  api: PackageAPI,
+): Map<string, {functions: ExportedFunction[]; types: ExportedType[]}> {
+  const categories = new Map<string, {functions: ExportedFunction[]; types: ExportedType[]}>()
+
+  for (const fn of api.functions) {
+    if (fn.jsdoc?.examples === undefined || fn.jsdoc.examples.length === 0) {
+      continue
+    }
+
+    const category = inferCategory(fn.name)
+    const existing = categories.get(category) ?? {functions: [], types: []}
+    existing.functions.push(fn)
+    categories.set(category, existing)
+  }
+
+  for (const type of api.types) {
+    if (type.jsdoc?.examples === undefined || type.jsdoc.examples.length === 0) {
+      continue
+    }
+
+    const category = inferCategory(type.name)
+    const existing = categories.get(category) ?? {functions: [], types: []}
+    existing.types.push(type)
+    categories.set(category, existing)
+  }
+
+  return categories
+}
+
+function inferCategory(name: string): string {
+  const prefixes = ['create', 'get', 'set', 'is', 'has', 'parse', 'format', 'validate', 'build']
+
+  for (const prefix of prefixes) {
+    if (name.toLowerCase().startsWith(prefix)) {
+      return capitalizeFirst(prefix)
+    }
+  }
+
+  return 'General'
+}
+
+function capitalizeFirst(str: string): string {
+  if (str.length === 0) return str
+  return str.charAt(0).toUpperCase() + str.slice(1)
+}
+
+export function formatGroupedExamples(api: PackageAPI, options: CodeExampleOptions = {}): string {
+  const categories = groupExamplesByCategory(api)
+  const sections: string[] = []
+
+  for (const [category, items] of categories) {
+    sections.push(`### ${category}`)
+    sections.push('')
+
+    for (const fn of items.functions) {
+      const examples = formatFunctionExamples(fn, {...options, includeTitle: false})
+      if (examples.length > 0) {
+        sections.push(`#### \`${fn.name}\``)
+        sections.push('')
+        sections.push(examples)
+        sections.push('')
+      }
+    }
+
+    for (const type of items.types) {
+      const examples = formatTypeExamples(type, {...options, includeTitle: false})
+      if (examples.length > 0) {
+        sections.push(`#### \`${type.name}\``)
+        sections.push('')
+        sections.push(examples)
+        sections.push('')
+      }
+    }
+  }
+
+  return sections.join('\n').trim()
+}

--- a/packages/doc-sync/src/generators/component-mapper.ts
+++ b/packages/doc-sync/src/generators/component-mapper.ts
@@ -1,0 +1,327 @@
+/**
+ * @bfra.me/doc-sync/generators/component-mapper - Map content sections to Starlight components
+ */
+
+import type {PackageInfo, ReadmeContent, ReadmeSection} from '../types'
+
+/**
+ * Configuration for Starlight component mapping
+ */
+export interface ComponentMapperConfig {
+  /** Section titles that should use CardGrid for features */
+  readonly featureSections?: readonly string[]
+  /** Section titles that should use Tabs for installation */
+  readonly tabSections?: readonly string[]
+  /** Section titles to exclude from output */
+  readonly excludeSections?: readonly string[]
+  /** Custom component mappings by section title */
+  readonly customMappings?: Record<string, SectionMapper>
+}
+
+/**
+ * A function that maps section content to MDX output
+ */
+export type SectionMapper = (section: ReadmeSection, info: PackageInfo) => string
+
+/**
+ * Default configuration for component mapping
+ */
+const DEFAULT_CONFIG: Required<Omit<ComponentMapperConfig, 'customMappings'>> = {
+  featureSections: ['features', 'highlights', 'key features'],
+  tabSections: ['installation', 'getting started', 'setup'],
+  excludeSections: ['license', 'contributing', 'contributors', 'changelog'],
+}
+
+export function mapToStarlightComponents(
+  readme: ReadmeContent,
+  packageInfo: PackageInfo,
+  config: ComponentMapperConfig = {},
+): string {
+  const mergedConfig = {...DEFAULT_CONFIG, ...config}
+  const sections: string[] = []
+
+  if (readme.preamble !== undefined && readme.preamble.trim().length > 0) {
+    sections.push(readme.preamble)
+    sections.push('')
+  }
+
+  for (const section of readme.sections) {
+    const output = mapSection(section, packageInfo, mergedConfig)
+    if (output.length > 0) {
+      sections.push(output)
+      sections.push('')
+    }
+  }
+
+  return sections.join('\n').trim()
+}
+
+function mapSection(
+  section: ReadmeSection,
+  packageInfo: PackageInfo,
+  config: Required<Omit<ComponentMapperConfig, 'customMappings'>> &
+    Pick<ComponentMapperConfig, 'customMappings'>,
+): string {
+  const normalizedHeading = section.heading.toLowerCase().trim()
+
+  if (isExcludedSection(normalizedHeading, config.excludeSections, packageInfo)) {
+    return ''
+  }
+
+  if (config.customMappings?.[normalizedHeading] !== undefined) {
+    return config.customMappings[normalizedHeading](section, packageInfo)
+  }
+
+  if (isFeatureSection(normalizedHeading, config.featureSections)) {
+    return mapFeatureSection(section)
+  }
+
+  if (isInstallationSection(normalizedHeading, config.tabSections)) {
+    return mapInstallationSection(section, packageInfo)
+  }
+
+  return mapDefaultSection(section, config)
+}
+
+function isExcludedSection(
+  heading: string,
+  excludeSections: readonly string[],
+  packageInfo: PackageInfo,
+): boolean {
+  if (excludeSections.some(excluded => heading.includes(excluded.toLowerCase()))) {
+    return true
+  }
+
+  if (packageInfo.docsConfig?.excludeSections !== undefined) {
+    return packageInfo.docsConfig.excludeSections.some(excluded =>
+      heading.includes(excluded.toLowerCase()),
+    )
+  }
+
+  return false
+}
+
+function isFeatureSection(heading: string, featureSections: readonly string[]): boolean {
+  return featureSections.some(feature => heading.includes(feature.toLowerCase()))
+}
+
+function isInstallationSection(heading: string, tabSections: readonly string[]): boolean {
+  return tabSections.some(tab => heading.includes(tab.toLowerCase()))
+}
+
+function mapFeatureSection(section: ReadmeSection): string {
+  const lines: string[] = []
+
+  lines.push(`## ${section.heading}`)
+  lines.push('')
+
+  const features = extractFeatureItems(section.content)
+
+  if (features.length > 0) {
+    lines.push('<CardGrid>')
+    for (const feature of features) {
+      const icon = inferFeatureIcon(feature.title)
+      lines.push(`  <Card title="${escapeAttribute(feature.title)}" icon="${icon}">`)
+      lines.push(`    ${feature.description}`)
+      lines.push('  </Card>')
+    }
+    lines.push('</CardGrid>')
+  } else {
+    lines.push(section.content)
+  }
+
+  return lines.join('\n')
+}
+
+interface FeatureItem {
+  readonly title: string
+  readonly description: string
+}
+
+function extractFeatureItems(content: string): FeatureItem[] {
+  const features: FeatureItem[] = []
+
+  const listItemPattern = /^[-*]\s+\*\*([^*]+)\*\*[:\s-](.+)$/gm
+
+  for (const match of content.matchAll(listItemPattern)) {
+    if (match[1] !== undefined && match[2] !== undefined) {
+      features.push({
+        title: match[1].trim(),
+        description: match[2].trim(),
+      })
+    }
+  }
+
+  if (features.length === 0) {
+    const boldPattern = /\*\*([^*]+)\*\*/g
+    const boldMatches = [...content.matchAll(boldPattern)]
+
+    for (const match of boldMatches) {
+      if (match[1] !== undefined) {
+        const title = match[1].trim()
+        const afterMatch = content.slice((match.index ?? 0) + match[0].length)
+        const description = afterMatch.split(/\n\n|\*\*/)[0]?.trim() ?? ''
+
+        if (description.length > 0 && description.length < 200) {
+          features.push({title, description})
+        }
+      }
+    }
+  }
+
+  return features
+}
+
+function inferFeatureIcon(title: string): string {
+  const lowerTitle = title.toLowerCase()
+
+  const iconMap: Record<string, string> = {
+    typescript: 'approve-check',
+    type: 'approve-check',
+    test: 'approve-check',
+    fast: 'rocket',
+    speed: 'rocket',
+    performance: 'rocket',
+    tree: 'seti:plan',
+    modular: 'puzzle',
+    plugin: 'puzzle',
+    extensible: 'puzzle',
+    document: 'document',
+    doc: 'document',
+    config: 'setting',
+    setting: 'setting',
+    star: 'star',
+    feature: 'star',
+    safe: 'approve-check',
+    secure: 'approve-check',
+    error: 'warning',
+    async: 'rocket',
+    result: 'approve-check',
+    function: 'puzzle',
+  }
+
+  for (const [keyword, icon] of Object.entries(iconMap)) {
+    if (lowerTitle.includes(keyword)) {
+      return icon
+    }
+  }
+
+  return 'star'
+}
+
+function mapInstallationSection(section: ReadmeSection, packageInfo: PackageInfo): string {
+  const lines: string[] = []
+
+  lines.push(`## ${section.heading}`)
+  lines.push('')
+
+  const hasExistingTabs = section.content.includes('```bash')
+  const hasMultiplePackageManagers =
+    section.content.includes('pnpm') ||
+    section.content.includes('npm') ||
+    section.content.includes('yarn')
+
+  if (hasExistingTabs && hasMultiplePackageManagers) {
+    lines.push(section.content)
+  } else {
+    lines.push(generateInstallTabs(packageInfo.name))
+
+    const contentWithoutInstall = removeInstallCommand(section.content)
+    if (contentWithoutInstall.trim().length > 0) {
+      lines.push('')
+      lines.push(contentWithoutInstall)
+    }
+  }
+
+  return lines.join('\n')
+}
+
+export function generateInstallTabs(packageName: string): string {
+  return `<Tabs>
+  <TabItem label="pnpm">
+    \`\`\`bash
+    pnpm add ${packageName}
+    \`\`\`
+  </TabItem>
+  <TabItem label="npm">
+    \`\`\`bash
+    npm install ${packageName}
+    \`\`\`
+  </TabItem>
+  <TabItem label="yarn">
+    \`\`\`bash
+    yarn add ${packageName}
+    \`\`\`
+  </TabItem>
+</Tabs>`
+}
+
+function removeInstallCommand(content: string): string {
+  return content
+    .replaceAll(/```(?:bash|sh)\n(?:npm|pnpm|yarn)\s+(?:install|add|i)\s+\S+\n```/g, '')
+    .trim()
+}
+
+function mapDefaultSection(
+  section: ReadmeSection,
+  config: Required<Omit<ComponentMapperConfig, 'customMappings'>> &
+    Pick<ComponentMapperConfig, 'customMappings'>,
+): string {
+  const lines: string[] = []
+
+  const headingLevel = '#'.repeat(Math.min(section.level + 1, 6))
+  lines.push(`${headingLevel} ${section.heading}`)
+  lines.push('')
+  lines.push(section.content)
+
+  for (const child of section.children) {
+    const childOutput = mapSection(child, {} as PackageInfo, config)
+    if (childOutput.length > 0) {
+      lines.push('')
+      lines.push(childOutput)
+    }
+  }
+
+  return lines.join('\n')
+}
+
+function escapeAttribute(value: string): string {
+  return value
+    .replaceAll('&', '&amp;')
+    .replaceAll('"', '&quot;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+}
+
+export function createBadge(
+  text: string,
+  variant: 'note' | 'tip' | 'caution' | 'danger' | 'success' | 'default' = 'note',
+): string {
+  return `<Badge text="${escapeAttribute(text)}" variant="${variant}" />`
+}
+
+export function createCard(title: string, content: string, icon?: string): string {
+  const iconAttr = icon === undefined ? '' : ` icon="${icon}"`
+  return `<Card title="${escapeAttribute(title)}"${iconAttr}>
+  ${content}
+</Card>`
+}
+
+export function createCardGrid(cards: {title: string; content: string; icon?: string}[]): string {
+  const cardElements = cards.map(card => createCard(card.title, card.content, card.icon))
+  return `<CardGrid>
+${cardElements.map(c => `  ${c}`).join('\n')}
+</CardGrid>`
+}
+
+export function createTabs(items: {label: string; content: string}[]): string {
+  const tabItems = items.map(
+    item => `  <TabItem label="${escapeAttribute(item.label)}">
+    ${item.content}
+  </TabItem>`,
+  )
+
+  return `<Tabs>
+${tabItems.join('\n')}
+</Tabs>`
+}

--- a/packages/doc-sync/src/generators/content-merger.ts
+++ b/packages/doc-sync/src/generators/content-merger.ts
@@ -1,0 +1,295 @@
+/**
+ * @bfra.me/doc-sync/generators/content-merger - Preserve manual sections using sentinel markers
+ */
+
+import type {Result} from '@bfra.me/es/result'
+import type {SyncError} from '../types'
+
+import {err, ok} from '@bfra.me/es/result'
+import {SENTINEL_MARKERS} from '../types'
+
+/**
+ * A section of content extracted from MDX
+ */
+export interface ContentSection {
+  /** Section type */
+  readonly type: 'auto' | 'manual' | 'unchanged'
+  /** Section content */
+  readonly content: string
+  /** Start position in source */
+  readonly startIndex: number
+  /** End position in source */
+  readonly endIndex: number
+}
+
+/**
+ * Merge options
+ */
+export interface MergeOptions {
+  /** Strategy for handling conflicts */
+  readonly conflictStrategy?: 'keep-manual' | 'keep-auto' | 'merge'
+  /** Preserve empty manual sections */
+  readonly preserveEmptyManual?: boolean
+}
+
+/**
+ * Result of a merge operation
+ */
+export interface MergeResult {
+  /** Merged content */
+  readonly content: string
+  /** Number of manual sections preserved */
+  readonly preservedCount: number
+  /** Number of auto-generated sections updated */
+  readonly updatedCount: number
+  /** Whether content changed */
+  readonly hasChanges: boolean
+}
+
+export function mergeContent(
+  existingContent: string,
+  newContent: string,
+  options: MergeOptions = {},
+): Result<MergeResult, SyncError> {
+  const {conflictStrategy = 'keep-manual', preserveEmptyManual = true} = options
+
+  try {
+    const existingManualSections = extractManualSections(existingContent)
+    const newAutoSections = extractAutoSections(newContent)
+
+    if (existingManualSections.length === 0 && newAutoSections.length === 0) {
+      const hasChanges = existingContent.trim() !== newContent.trim()
+      return ok({
+        content: newContent,
+        preservedCount: 0,
+        updatedCount: hasChanges ? 1 : 0,
+        hasChanges,
+      })
+    }
+
+    let merged = newContent
+    let preservedCount = 0
+
+    for (const manual of existingManualSections) {
+      if (!preserveEmptyManual && manual.content.trim().length === 0) {
+        continue
+      }
+
+      const manualMarker = `${SENTINEL_MARKERS.MANUAL_START}\n${manual.content}\n${SENTINEL_MARKERS.MANUAL_END}`
+
+      if (!merged.includes(SENTINEL_MARKERS.MANUAL_START)) {
+        const autoEndIndex = merged.indexOf(SENTINEL_MARKERS.AUTO_END)
+        if (autoEndIndex === -1) {
+          merged = `${merged}\n\n${manualMarker}`
+        } else {
+          merged = `${merged.slice(0, autoEndIndex + SENTINEL_MARKERS.AUTO_END.length)}\n\n${manualMarker}\n${merged.slice(autoEndIndex + SENTINEL_MARKERS.AUTO_END.length)}`
+        }
+      } else if (conflictStrategy === 'keep-manual') {
+        const existingManualInNew = extractManualSections(merged)
+        if (existingManualInNew.length > 0) {
+          const firstManualInNew = existingManualInNew[0]
+          if (firstManualInNew !== undefined) {
+            merged = replaceSection(merged, firstManualInNew, manual.content)
+          }
+        }
+      }
+
+      preservedCount++
+    }
+
+    const hasChanges = existingContent.trim() !== merged.trim()
+
+    return ok({
+      content: merged,
+      preservedCount,
+      updatedCount: newAutoSections.length,
+      hasChanges,
+    })
+  } catch (error) {
+    return err({
+      code: 'GENERATION_ERROR',
+      message: `Failed to merge content: ${error instanceof Error ? error.message : String(error)}`,
+      cause: error,
+    })
+  }
+}
+
+export function extractManualSections(content: string): ContentSection[] {
+  const sections: ContentSection[] = []
+  let searchStart = 0
+
+  while (searchStart < content.length) {
+    const startIndex = content.indexOf(SENTINEL_MARKERS.MANUAL_START, searchStart)
+    if (startIndex === -1) break
+
+    const endIndex = content.indexOf(SENTINEL_MARKERS.MANUAL_END, startIndex)
+    if (endIndex === -1) break
+
+    const contentStart = startIndex + SENTINEL_MARKERS.MANUAL_START.length
+    const sectionContent = content.slice(contentStart, endIndex).trim()
+
+    sections.push({
+      type: 'manual',
+      content: sectionContent,
+      startIndex,
+      endIndex: endIndex + SENTINEL_MARKERS.MANUAL_END.length,
+    })
+
+    searchStart = endIndex + SENTINEL_MARKERS.MANUAL_END.length
+  }
+
+  return sections
+}
+
+export function extractAutoSections(content: string): ContentSection[] {
+  const sections: ContentSection[] = []
+  let searchStart = 0
+
+  while (searchStart < content.length) {
+    const startIndex = content.indexOf(SENTINEL_MARKERS.AUTO_START, searchStart)
+    if (startIndex === -1) break
+
+    const endIndex = content.indexOf(SENTINEL_MARKERS.AUTO_END, startIndex)
+    if (endIndex === -1) break
+
+    const contentStart = startIndex + SENTINEL_MARKERS.AUTO_START.length
+    const sectionContent = content.slice(contentStart, endIndex).trim()
+
+    sections.push({
+      type: 'auto',
+      content: sectionContent,
+      startIndex,
+      endIndex: endIndex + SENTINEL_MARKERS.AUTO_END.length,
+    })
+
+    searchStart = endIndex + SENTINEL_MARKERS.AUTO_END.length
+  }
+
+  return sections
+}
+
+function replaceSection(content: string, section: ContentSection, newContent: string): string {
+  const marker =
+    section.type === 'manual' ? SENTINEL_MARKERS.MANUAL_START : SENTINEL_MARKERS.AUTO_START
+  const endMarker =
+    section.type === 'manual' ? SENTINEL_MARKERS.MANUAL_END : SENTINEL_MARKERS.AUTO_END
+
+  const before = content.slice(0, section.startIndex)
+  const after = content.slice(section.endIndex)
+
+  return `${before}${marker}\n${newContent}\n${endMarker}${after}`
+}
+
+export function hasManualContent(content: string): boolean {
+  return content.includes(SENTINEL_MARKERS.MANUAL_START)
+}
+
+export function hasAutoContent(content: string): boolean {
+  return content.includes(SENTINEL_MARKERS.AUTO_START)
+}
+
+export function wrapManualSection(content: string): string {
+  return `${SENTINEL_MARKERS.MANUAL_START}\n${content}\n${SENTINEL_MARKERS.MANUAL_END}`
+}
+
+export function wrapAutoSection(content: string): string {
+  return `${SENTINEL_MARKERS.AUTO_START}\n${content}\n${SENTINEL_MARKERS.AUTO_END}`
+}
+
+export function stripSentinelMarkers(content: string): string {
+  return content
+    .replaceAll(SENTINEL_MARKERS.AUTO_START, '')
+    .replaceAll(SENTINEL_MARKERS.AUTO_END, '')
+    .replaceAll(SENTINEL_MARKERS.MANUAL_START, '')
+    .replaceAll(SENTINEL_MARKERS.MANUAL_END, '')
+    .replaceAll(/\n{3,}/g, '\n\n')
+    .trim()
+}
+
+export function validateMarkerPairing(content: string): Result<true, SyncError> {
+  const autoStartCount = countOccurrences(content, SENTINEL_MARKERS.AUTO_START)
+  const autoEndCount = countOccurrences(content, SENTINEL_MARKERS.AUTO_END)
+  const manualStartCount = countOccurrences(content, SENTINEL_MARKERS.MANUAL_START)
+  const manualEndCount = countOccurrences(content, SENTINEL_MARKERS.MANUAL_END)
+
+  if (autoStartCount !== autoEndCount) {
+    return err({
+      code: 'VALIDATION_ERROR',
+      message: `Mismatched AUTO-GENERATED markers: ${autoStartCount} starts, ${autoEndCount} ends`,
+    })
+  }
+
+  if (manualStartCount !== manualEndCount) {
+    return err({
+      code: 'VALIDATION_ERROR',
+      message: `Mismatched MANUAL-CONTENT markers: ${manualStartCount} starts, ${manualEndCount} ends`,
+    })
+  }
+
+  const autoNesting = checkNesting(content, SENTINEL_MARKERS.AUTO_START, SENTINEL_MARKERS.AUTO_END)
+  if (!autoNesting) {
+    return err({
+      code: 'VALIDATION_ERROR',
+      message: 'AUTO-GENERATED markers are improperly nested',
+    })
+  }
+
+  const manualNesting = checkNesting(
+    content,
+    SENTINEL_MARKERS.MANUAL_START,
+    SENTINEL_MARKERS.MANUAL_END,
+  )
+  if (!manualNesting) {
+    return err({
+      code: 'VALIDATION_ERROR',
+      message: 'MANUAL-CONTENT markers are improperly nested',
+    })
+  }
+
+  return ok(true)
+}
+
+function countOccurrences(content: string, substring: string): number {
+  let count = 0
+  let position = content.indexOf(substring, 0)
+
+  while (position !== -1) {
+    count++
+    position = content.indexOf(substring, position + substring.length)
+  }
+
+  return count
+}
+
+function checkNesting(content: string, startMarker: string, endMarker: string): boolean {
+  let depth = 0
+  let position = 0
+
+  while (position < content.length) {
+    const startPos = content.indexOf(startMarker, position)
+    const endPos = content.indexOf(endMarker, position)
+
+    if (startPos === -1 && endPos === -1) break
+
+    if (startPos !== -1 && (endPos === -1 || startPos < endPos)) {
+      depth++
+      position = startPos + startMarker.length
+    } else {
+      depth--
+      if (depth < 0) return false
+      position = endPos + endMarker.length
+    }
+  }
+
+  return depth === 0
+}
+
+export function createDiffSummary(oldContent: string, newContent: string): string {
+  const oldLines = oldContent.split('\n')
+  const newLines = newContent.split('\n')
+
+  const added = newLines.filter(line => !oldLines.includes(line)).length
+  const removed = oldLines.filter(line => !newLines.includes(line)).length
+
+  return `${added} lines added, ${removed} lines removed`
+}

--- a/packages/doc-sync/src/generators/frontmatter-generator.ts
+++ b/packages/doc-sync/src/generators/frontmatter-generator.ts
@@ -1,0 +1,277 @@
+/**
+ * @bfra.me/doc-sync/generators/frontmatter-generator - Starlight-compatible frontmatter generation
+ */
+
+import type {MDXFrontmatter, PackageInfo, ReadmeContent} from '../types'
+
+/**
+ * Mutable frontmatter for internal construction before freezing
+ */
+interface MutableFrontmatter {
+  title: string
+  description?: string
+  sidebar?: MDXFrontmatter['sidebar']
+  tableOfContents?: MDXFrontmatter['tableOfContents']
+  template?: MDXFrontmatter['template']
+  hero?: MDXFrontmatter['hero']
+}
+
+export function generateFrontmatter(
+  packageInfo: PackageInfo,
+  readme: ReadmeContent | undefined,
+  overrides?: Partial<MDXFrontmatter>,
+): MDXFrontmatter {
+  const title = resolveTitle(packageInfo, readme, overrides?.title)
+  const description = resolveDescription(packageInfo, readme, overrides?.description)
+
+  const frontmatter: MutableFrontmatter = {
+    title,
+    ...(description !== undefined && {description}),
+    ...(overrides?.sidebar !== undefined && {sidebar: overrides.sidebar}),
+    ...(overrides?.tableOfContents !== undefined && {tableOfContents: overrides.tableOfContents}),
+    ...(overrides?.template !== undefined && {template: overrides.template}),
+    ...(overrides?.hero !== undefined && {hero: overrides.hero}),
+  }
+
+  if (packageInfo.docsConfig?.sidebar !== undefined) {
+    frontmatter.sidebar = {
+      ...packageInfo.docsConfig.sidebar,
+      ...frontmatter.sidebar,
+    }
+  }
+
+  if (packageInfo.docsConfig?.frontmatter !== undefined) {
+    const customFrontmatter = packageInfo.docsConfig.frontmatter
+    return {...customFrontmatter, ...frontmatter} as MDXFrontmatter
+  }
+
+  return frontmatter as MDXFrontmatter
+}
+
+function resolveTitle(
+  packageInfo: PackageInfo,
+  readme: ReadmeContent | undefined,
+  override?: string,
+): string {
+  if (override !== undefined) {
+    return override
+  }
+
+  if (packageInfo.docsConfig?.title !== undefined) {
+    return packageInfo.docsConfig.title
+  }
+
+  if (readme?.title !== undefined) {
+    return readme.title
+  }
+
+  return packageInfo.name
+}
+
+function resolveDescription(
+  packageInfo: PackageInfo,
+  readme: ReadmeContent | undefined,
+  override?: string,
+): string | undefined {
+  if (override !== undefined) {
+    return override
+  }
+
+  if (packageInfo.docsConfig?.description !== undefined) {
+    return packageInfo.docsConfig.description
+  }
+
+  if (packageInfo.description !== undefined) {
+    return packageInfo.description
+  }
+
+  if (readme?.preamble !== undefined) {
+    return extractFirstSentence(readme.preamble)
+  }
+
+  return undefined
+}
+
+function extractFirstSentence(text: string): string {
+  const cleaned = text.trim().replaceAll(/\s+/g, ' ')
+
+  const sentenceEnd = cleaned.search(/[.!?](?:\s|$)/)
+  if (sentenceEnd > 0) {
+    return cleaned.slice(0, sentenceEnd + 1)
+  }
+
+  if (cleaned.length > 160) {
+    const truncated = cleaned.slice(0, 157)
+    const lastSpace = truncated.lastIndexOf(' ')
+    if (lastSpace > 100) {
+      return `${truncated.slice(0, lastSpace)}...`
+    }
+    return `${truncated}...`
+  }
+
+  return cleaned
+}
+
+export function stringifyFrontmatter(frontmatter: MDXFrontmatter): string {
+  const lines: string[] = []
+
+  lines.push(`title: ${yamlString(frontmatter.title)}`)
+
+  if (frontmatter.description !== undefined) {
+    lines.push(`description: ${yamlString(frontmatter.description)}`)
+  }
+
+  if (frontmatter.sidebar !== undefined) {
+    lines.push('sidebar:')
+    const sidebar = frontmatter.sidebar
+
+    if (sidebar.label !== undefined) {
+      lines.push(`  label: ${yamlString(sidebar.label)}`)
+    }
+
+    if (sidebar.order !== undefined) {
+      lines.push(`  order: ${sidebar.order}`)
+    }
+
+    if (sidebar.hidden !== undefined) {
+      lines.push(`  hidden: ${sidebar.hidden}`)
+    }
+
+    if (sidebar.badge !== undefined) {
+      if (typeof sidebar.badge === 'string') {
+        lines.push(`  badge: ${yamlString(sidebar.badge)}`)
+      } else {
+        lines.push('  badge:')
+        lines.push(`    text: ${yamlString(sidebar.badge.text)}`)
+        if (sidebar.badge.variant !== undefined) {
+          lines.push(`    variant: ${sidebar.badge.variant}`)
+        }
+      }
+    }
+  }
+
+  if (frontmatter.tableOfContents !== undefined) {
+    if (typeof frontmatter.tableOfContents === 'boolean') {
+      lines.push(`tableOfContents: ${frontmatter.tableOfContents}`)
+    } else {
+      lines.push('tableOfContents:')
+      if (frontmatter.tableOfContents.minHeadingLevel !== undefined) {
+        lines.push(`  minHeadingLevel: ${frontmatter.tableOfContents.minHeadingLevel}`)
+      }
+      if (frontmatter.tableOfContents.maxHeadingLevel !== undefined) {
+        lines.push(`  maxHeadingLevel: ${frontmatter.tableOfContents.maxHeadingLevel}`)
+      }
+    }
+  }
+
+  if (frontmatter.template !== undefined) {
+    lines.push(`template: ${frontmatter.template}`)
+  }
+
+  if (frontmatter.hero !== undefined) {
+    lines.push('hero:')
+    const hero = frontmatter.hero
+
+    if (hero.title !== undefined) {
+      lines.push(`  title: ${yamlString(hero.title)}`)
+    }
+
+    if (hero.tagline !== undefined) {
+      lines.push(`  tagline: ${yamlString(hero.tagline)}`)
+    }
+
+    if (hero.image !== undefined) {
+      lines.push('  image:')
+      lines.push(`    src: ${yamlString(hero.image.src)}`)
+      lines.push(`    alt: ${yamlString(hero.image.alt)}`)
+    }
+
+    if (hero.actions !== undefined && hero.actions.length > 0) {
+      lines.push('  actions:')
+      for (const action of hero.actions) {
+        lines.push(`    - text: ${yamlString(action.text)}`)
+        lines.push(`      link: ${yamlString(action.link)}`)
+        if (action.icon !== undefined) {
+          lines.push(`      icon: ${yamlString(action.icon)}`)
+        }
+        if (action.variant !== undefined) {
+          lines.push(`      variant: ${action.variant}`)
+        }
+      }
+    }
+  }
+
+  return lines.join('\n')
+}
+
+function yamlString(value: string): string {
+  if (needsQuoting(value)) {
+    return `'${value.replaceAll("'", "''")}'`
+  }
+  return value
+}
+
+function needsQuoting(value: string): boolean {
+  if (value.length === 0) {
+    return true
+  }
+
+  if (value.startsWith(' ') || value.endsWith(' ')) {
+    return true
+  }
+
+  const specialChars = /[:#{}[\]&*?|<>=!%@`"',]/
+  if (specialChars.test(value)) {
+    return true
+  }
+
+  const reserved = ['true', 'false', 'null', 'yes', 'no', 'on', 'off']
+  if (reserved.includes(value.toLowerCase())) {
+    return true
+  }
+
+  if (/^-?\d+(?:\.\d+)?$/.test(value)) {
+    return true
+  }
+
+  return false
+}
+
+/**
+ * Mutable frontmatter for internal parsing
+ */
+interface MutableParsedFrontmatter {
+  title?: string
+  description?: string
+}
+
+export function parseFrontmatter(yaml: string): Partial<MDXFrontmatter> {
+  const result: MutableParsedFrontmatter = {}
+  const lines = yaml.split('\n')
+
+  for (const line of lines) {
+    const trimmedLine = line.trim()
+
+    if (trimmedLine.startsWith('title:')) {
+      const value = trimmedLine.slice(6).trim()
+      result.title = stripQuotes(value)
+    }
+
+    if (trimmedLine.startsWith('description:')) {
+      const value = trimmedLine.slice(12).trim()
+      result.description = stripQuotes(value)
+    }
+  }
+
+  return result as Partial<MDXFrontmatter>
+}
+
+function stripQuotes(value: string): string {
+  if (
+    (value.startsWith("'") && value.endsWith("'")) ||
+    (value.startsWith('"') && value.endsWith('"'))
+  ) {
+    return value.slice(1, -1)
+  }
+  return value
+}

--- a/packages/doc-sync/src/generators/index.ts
+++ b/packages/doc-sync/src/generators/index.ts
@@ -1,0 +1,56 @@
+/**
+ * @bfra.me/doc-sync/generators - Unified export of all generator modules
+ */
+
+export {
+  generateAPICompact,
+  generateAPIReference,
+  generateCategoryReference,
+} from './api-reference-generator'
+
+export {
+  cleanCodeExample,
+  detectLanguage,
+  formatCodeBlock,
+  formatCodeExamples,
+  formatFunctionExamples,
+  formatGroupedExamples,
+  formatTypeExamples,
+  formatUsageExample,
+  groupExamplesByCategory,
+} from './code-example-formatter'
+export type {CodeExampleOptions} from './code-example-formatter'
+
+export {
+  createBadge,
+  createCard,
+  createCardGrid,
+  createTabs,
+  generateInstallTabs,
+  mapToStarlightComponents,
+} from './component-mapper'
+export type {ComponentMapperConfig, SectionMapper} from './component-mapper'
+
+export {
+  createDiffSummary,
+  extractAutoSections,
+  extractManualSections,
+  hasAutoContent,
+  hasManualContent,
+  mergeContent,
+  stripSentinelMarkers,
+  validateMarkerPairing,
+  wrapAutoSection,
+  wrapManualSection,
+} from './content-merger'
+export type {ContentSection, MergeOptions, MergeResult} from './content-merger'
+
+export {generateFrontmatter, parseFrontmatter, stringifyFrontmatter} from './frontmatter-generator'
+
+export {
+  generateMDXDocument,
+  sanitizeContent,
+  sanitizeTextContent,
+  validateMDXSyntax,
+} from './mdx-generator'
+export type {MDXGeneratorOptions} from './mdx-generator'

--- a/packages/doc-sync/src/generators/mdx-generator.ts
+++ b/packages/doc-sync/src/generators/mdx-generator.ts
@@ -1,0 +1,278 @@
+/**
+ * @bfra.me/doc-sync/generators/mdx-generator - MDX document structure generation for Starlight
+ */
+
+import type {Result} from '@bfra.me/es/result'
+import type {
+  MDXDocument,
+  MDXFrontmatter,
+  PackageAPI,
+  PackageInfo,
+  ReadmeContent,
+  SyncError,
+} from '../types'
+
+import {err, ok} from '@bfra.me/es/result'
+import {SENTINEL_MARKERS} from '../types'
+
+import {generateAPIReference} from './api-reference-generator'
+import {formatCodeExamples} from './code-example-formatter'
+import {mapToStarlightComponents} from './component-mapper'
+import {generateFrontmatter, stringifyFrontmatter} from './frontmatter-generator'
+
+/**
+ * Options for MDX generation
+ */
+export interface MDXGeneratorOptions {
+  /** Include API reference section */
+  readonly includeAPI?: boolean
+  /** Include examples from JSDoc */
+  readonly includeExamples?: boolean
+  /** Custom frontmatter overrides */
+  readonly frontmatterOverrides?: Partial<MDXFrontmatter>
+  /** Preserve manual content sections */
+  readonly preserveManualContent?: boolean
+  /** Existing MDX content for merging */
+  readonly existingContent?: string
+}
+
+/**
+ * Default options for MDX generation
+ */
+const DEFAULT_OPTIONS: Required<
+  Omit<MDXGeneratorOptions, 'frontmatterOverrides' | 'existingContent'>
+> = {
+  includeAPI: true,
+  includeExamples: true,
+  preserveManualContent: true,
+}
+
+/**
+ * Starlight component imports required for generated documentation
+ */
+const STARLIGHT_IMPORTS = `import { Badge, Card, CardGrid, Tabs, TabItem } from '@astrojs/starlight/components';`
+
+export function generateMDXDocument(
+  packageInfo: PackageInfo,
+  readme: ReadmeContent | undefined,
+  api: PackageAPI | undefined,
+  options: MDXGeneratorOptions = {},
+): Result<MDXDocument, SyncError> {
+  const mergedOptions = {...DEFAULT_OPTIONS, ...options}
+
+  try {
+    const frontmatter = generateFrontmatter(packageInfo, readme, options.frontmatterOverrides)
+    const contentSections = buildContentSections(packageInfo, readme, api, mergedOptions)
+    const content = contentSections.join('\n\n')
+    const rendered = renderMDXDocument(frontmatter, content)
+
+    return ok({
+      frontmatter,
+      content,
+      rendered,
+    })
+  } catch (error) {
+    return err({
+      code: 'GENERATION_ERROR',
+      message: `Failed to generate MDX for ${packageInfo.name}: ${error instanceof Error ? error.message : String(error)}`,
+      packageName: packageInfo.name,
+      cause: error,
+    })
+  }
+}
+
+function buildContentSections(
+  packageInfo: PackageInfo,
+  readme: ReadmeContent | undefined,
+  api: PackageAPI | undefined,
+  options: Required<Omit<MDXGeneratorOptions, 'frontmatterOverrides' | 'existingContent'>>,
+): string[] {
+  const sections: string[] = []
+
+  sections.push(STARLIGHT_IMPORTS)
+  sections.push('')
+  sections.push(generatePackageHeader(packageInfo))
+
+  if (readme !== undefined) {
+    const mappedContent = mapToStarlightComponents(readme, packageInfo)
+    sections.push(mappedContent)
+  }
+
+  if (options.includeAPI && api !== undefined && hasAPIContent(api)) {
+    sections.push(SENTINEL_MARKERS.AUTO_START)
+    sections.push('')
+    sections.push('## API Reference')
+    sections.push('')
+    sections.push(generateAPIReference(api))
+
+    if (options.includeExamples) {
+      const examples = formatCodeExamples(api)
+      if (examples.length > 0) {
+        sections.push('')
+        sections.push('## Examples')
+        sections.push('')
+        sections.push(examples)
+      }
+    }
+
+    sections.push('')
+    sections.push(SENTINEL_MARKERS.AUTO_END)
+  }
+
+  return sections
+}
+
+function generatePackageHeader(packageInfo: PackageInfo): string {
+  const lines: string[] = []
+
+  lines.push(`# ${packageInfo.name}`)
+  lines.push('')
+
+  const badges: string[] = []
+
+  if (packageInfo.keywords?.includes('cli')) {
+    badges.push(`<Badge text="CLI Tool" variant="tip" />`)
+  } else if (packageInfo.keywords?.includes('library')) {
+    badges.push(`<Badge text="Library" variant="tip" />`)
+  } else if (packageInfo.keywords?.includes('config')) {
+    badges.push(`<Badge text="Config" variant="tip" />`)
+  }
+
+  badges.push(`<Badge text="v${packageInfo.version}" variant="note" />`)
+
+  if (badges.length > 0) {
+    lines.push(badges.join('\n'))
+    lines.push('')
+  }
+
+  if (packageInfo.description !== undefined) {
+    lines.push(packageInfo.description)
+    lines.push('')
+  }
+
+  return lines.join('\n')
+}
+
+function hasAPIContent(api: PackageAPI): boolean {
+  return api.functions.length > 0 || api.types.length > 0
+}
+
+function renderMDXDocument(frontmatter: MDXFrontmatter, content: string): string {
+  const frontmatterYaml = stringifyFrontmatter(frontmatter)
+  return `---\n${frontmatterYaml}---\n\n${content}\n`
+}
+
+/**
+ * Sanitizes content for safe MDX rendering
+ * Prevents XSS by escaping potentially dangerous content
+ */
+export function sanitizeContent(content: string): string {
+  return content
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('{', '&#123;')
+    .replaceAll('}', '&#125;')
+}
+
+/**
+ * Sanitizes content within MDX while preserving JSX components
+ * Only escapes content that appears to be user-provided text
+ */
+export function sanitizeTextContent(content: string): string {
+  const jsxPattern = /<[A-Z][^>]*>/g
+  const parts: string[] = []
+  let lastIndex = 0
+
+  for (const match of content.matchAll(jsxPattern)) {
+    if (match.index !== undefined && match.index > lastIndex) {
+      parts.push(sanitizeContent(content.slice(lastIndex, match.index)))
+    }
+    parts.push(match[0])
+    lastIndex = (match.index ?? 0) + match[0].length
+  }
+
+  if (lastIndex < content.length) {
+    parts.push(sanitizeContent(content.slice(lastIndex)))
+  }
+
+  return parts.join('')
+}
+
+export function validateMDXSyntax(mdx: string): Result<true, SyncError> {
+  const unclosedTags = checkForUnclosedTags(mdx)
+  if (unclosedTags.length > 0) {
+    return err({
+      code: 'VALIDATION_ERROR',
+      message: `Unclosed MDX tags: ${unclosedTags.join(', ')}`,
+    })
+  }
+
+  const invalidFrontmatter = checkFrontmatter(mdx)
+  if (invalidFrontmatter !== undefined) {
+    return err({
+      code: 'VALIDATION_ERROR',
+      message: invalidFrontmatter,
+    })
+  }
+
+  return ok(true)
+}
+
+function checkForUnclosedTags(mdx: string): string[] {
+  const unclosed: string[] = []
+  const tagStack: string[] = []
+
+  const openTagPattern = /<([A-Z][a-zA-Z]*)(?:\s[^>]*)?[^/]>/g
+  const closeTagPattern = /<\/([A-Z][a-zA-Z]*)>/g
+  const selfClosingPattern = /<([A-Z][a-zA-Z]*)(?:\s[^>]*)?\/?\/>/g
+
+  const selfClosingTags = new Set<string>()
+  for (const match of mdx.matchAll(selfClosingPattern)) {
+    if (match[1] !== undefined) {
+      selfClosingTags.add(match[1])
+    }
+  }
+
+  for (const match of mdx.matchAll(openTagPattern)) {
+    const tagName = match[1]
+    if (tagName !== undefined && !selfClosingTags.has(tagName)) {
+      tagStack.push(tagName)
+    }
+  }
+
+  for (const match of mdx.matchAll(closeTagPattern)) {
+    const tagName = match[1]
+    if (tagName !== undefined) {
+      const lastOpenTag = tagStack.pop()
+      if (lastOpenTag !== tagName && lastOpenTag !== undefined) {
+        unclosed.push(lastOpenTag)
+      }
+    }
+  }
+
+  unclosed.push(...tagStack)
+
+  return unclosed
+}
+
+function checkFrontmatter(mdx: string): string | undefined {
+  if (!mdx.startsWith('---')) {
+    return 'MDX document must start with frontmatter'
+  }
+
+  const secondDashIndex = mdx.indexOf('---', 3)
+  if (secondDashIndex === -1) {
+    return 'Frontmatter is not properly closed'
+  }
+
+  const frontmatterContent = mdx.slice(3, secondDashIndex).trim()
+  if (frontmatterContent.length === 0) {
+    return 'Frontmatter cannot be empty'
+  }
+
+  if (!frontmatterContent.includes('title:')) {
+    return 'Frontmatter must include a title'
+  }
+
+  return undefined
+}

--- a/packages/doc-sync/src/index.ts
+++ b/packages/doc-sync/src/index.ts
@@ -5,6 +5,55 @@
  * automatically update Astro Starlight documentation sites.
  */
 
+// Re-export generators
+export {
+  cleanCodeExample,
+  createBadge,
+  createCard,
+  createCardGrid,
+  createDiffSummary,
+  createTabs,
+  detectLanguage,
+  extractAutoSections,
+  extractManualSections,
+  formatCodeBlock,
+  formatCodeExamples,
+  formatFunctionExamples,
+  formatGroupedExamples,
+  formatTypeExamples,
+  formatUsageExample,
+  generateAPICompact,
+  generateAPIReference,
+  generateCategoryReference,
+  generateFrontmatter,
+  generateInstallTabs,
+  generateMDXDocument,
+  groupExamplesByCategory,
+  hasAutoContent,
+  hasManualContent,
+  mapToStarlightComponents,
+  mergeContent,
+  parseFrontmatter,
+  sanitizeContent,
+  sanitizeTextContent,
+  stringifyFrontmatter,
+  stripSentinelMarkers,
+  validateMarkerPairing,
+  validateMDXSyntax,
+  wrapAutoSection,
+  wrapManualSection,
+} from './generators'
+
+export type {
+  CodeExampleOptions,
+  ComponentMapperConfig,
+  ContentSection,
+  MDXGeneratorOptions,
+  MergeOptions,
+  MergeResult,
+  SectionMapper,
+} from './generators'
+
 export type {
   CLIOptions,
   DocConfig,


### PR DESCRIPTION
- Introduce component mapper for mapping README sections to Starlight components.
- Implement content merger to preserve manual sections using sentinel markers.
- Create frontmatter generator for Starlight-compatible frontmatter.
- Develop MDX generator for creating structured MDX documents.
- Add unified export for all generator modules in the index file.
- Enhance sanitization functions for safe MDX rendering.

Closes #2356.