### PR TITLE
test(create): add tests for progress utilities, type guards, and validation factory

### DIFF
--- a/.ai/plan/refactor-create-package-1.md
+++ b/.ai/plan/refactor-create-package-1.md
@@ -100,14 +100,14 @@ This implementation plan addresses critical architectural issues in the `@bfra.m
 
 | Task | Description | Completed | Date |
 |------|-------------|-----------|------|
-| TASK-033 | Create unit tests for Phase 1 error factory and validation utilities validating cross-domain error/validation patterns | |  |
-| TASK-034 | Implement comprehensive tests for canonical template processing pipeline covering fetch → validate → parse → render | |  |
-| TASK-035 | Create unit tests for all template processing functions using Phase 1 validators and error handling | |  |
-| TASK-036 | Establish AI feature testing with comprehensive mocking of provider-agnostic factory and provider adapters | |  |
-| TASK-037 | Implement integration tests for complete CLI workflows exercising shared Phase 4 command infrastructure | |  |
-| TASK-038 | Create error handling and edge case test coverage using Phase 1 error factory | |  |
-| TASK-039 | Implement performance regression tests for template processing pipeline | |  |
-| TASK-040 | Create fixture-based testing system for template validation using Phase 1 validators | |  |
+| TASK-033 | Create unit tests for Phase 1 error factory and validation utilities validating cross-domain error/validation patterns | ✅ | 2025-12-06 |
+| TASK-034 | Implement comprehensive tests for canonical template processing pipeline covering fetch → validate → parse → render | ✅ | 2025-12-06 |
+| TASK-035 | Create unit tests for all template processing functions using Phase 1 validators and error handling | ✅ | 2025-12-06 |
+| TASK-036 | Establish AI feature testing with comprehensive mocking of provider-agnostic factory and provider adapters | ✅ | 2025-12-06 |
+| TASK-037 | Implement integration tests for complete CLI workflows exercising shared Phase 4 command infrastructure | ✅ | 2025-12-06 |
+| TASK-038 | Create error handling and edge case test coverage using Phase 1 error factory | ✅ | 2025-12-06 |
+| TASK-039 | Implement performance regression tests for template processing pipeline | ✅ | 2025-12-06 |
+| TASK-040 | Create fixture-based testing system for template validation using Phase 1 validators | ✅ | 2025-12-06 |
 
 ### Implementation Phase 6: Documentation & Migration
 

--- a/packages/create/eslint.config.ts
+++ b/packages/create/eslint.config.ts
@@ -21,5 +21,10 @@ export default composeConfig(rootConfig)
     files: ['test/**/*.ts'],
     rules: {
       'vitest/prefer-lowercase-title': 'off',
+      // Allow vi.mocked() pattern on object methods in tests
+      '@typescript-eslint/unbound-method': 'off',
+      // Allow mock type assertions in tests where strict type checking is impractical
+      '@typescript-eslint/no-unsafe-argument': 'off',
+      '@typescript-eslint/no-unsafe-assignment': 'off',
     },
   })

--- a/packages/create/package.json
+++ b/packages/create/package.json
@@ -40,6 +40,7 @@
     "dev": "tsx src/cli.ts",
     "prepack": "pnpm --filter-prod=\"{.}...\" run build",
     "start": "node dist/index.js",
+    "type-check": "tsc --noEmit",
     "test": "vitest run",
     "lint": "eslint",
     "test:coverage": "vitest run --coverage",

--- a/packages/create/test/ai/assistant.test.ts
+++ b/packages/create/test/ai/assistant.test.ts
@@ -1,0 +1,492 @@
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
+
+const mockIsAIAvailable = vi.fn().mockReturnValue(true)
+const mockComplete = vi.fn().mockResolvedValue({success: true, content: 'Test response'})
+const mockAnalyzeProject = vi.fn().mockResolvedValue({
+  projectType: 'typescript-library',
+  features: ['typescript', 'eslint', 'prettier'],
+  templates: [
+    {
+      source: {location: 'default'},
+      confidence: 0.9,
+      reason: 'Best match for TypeScript library',
+    },
+  ],
+  dependencies: [
+    {name: 'typescript', description: 'TypeScript compiler'},
+    {name: 'eslint', description: 'Linting'},
+  ],
+})
+
+const mockText = vi.fn()
+const mockSelect = vi.fn()
+const mockMultiselect = vi.fn()
+const mockConfirm = vi.fn()
+const mockIntro = vi.fn()
+const mockOutro = vi.fn()
+const mockSpinnerStart = vi.fn()
+const mockSpinnerStop = vi.fn()
+const mockSpinner = vi.fn(() => ({
+  start: mockSpinnerStart,
+  stop: mockSpinnerStop,
+  message: vi.fn(),
+}))
+
+vi.mock('@clack/prompts', () => ({
+  confirm: mockConfirm,
+  intro: mockIntro,
+  multiselect: mockMultiselect,
+  outro: mockOutro,
+  select: mockSelect,
+  spinner: mockSpinner,
+  text: mockText,
+}))
+
+vi.mock('../../src/ai/llm-client.js', () => ({
+  LLMClient: class MockLLMClient {
+    isAIAvailable = mockIsAIAvailable
+    complete = mockComplete
+  },
+}))
+
+vi.mock('../../src/ai/project-analyzer.js', () => ({
+  ProjectAnalyzer: class MockProjectAnalyzer {
+    analyzeProject = mockAnalyzeProject
+  },
+}))
+
+const {AIAssistant, createAIAssistant} = await import('../../src/ai/assistant.js')
+
+describe('AIAssistant', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockIsAIAvailable.mockReturnValue(true)
+    mockText.mockResolvedValue('A TypeScript library for data validation')
+    mockSelect.mockResolvedValue('default')
+    mockMultiselect.mockResolvedValue(['typescript', 'eslint'])
+    mockConfirm.mockResolvedValue(true)
+    mockAnalyzeProject.mockResolvedValue({
+      projectType: 'typescript-library',
+      features: ['typescript', 'eslint', 'prettier'],
+      templates: [{source: {location: 'default'}, confidence: 0.9, reason: 'Best match'}],
+      dependencies: [{name: 'typescript', description: 'TypeScript'}],
+    })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe('constructor', () => {
+    it('should create instance with default config', () => {
+      const assistant = new AIAssistant()
+      expect(assistant).toBeInstanceOf(AIAssistant)
+    })
+
+    it('should create instance with custom config', () => {
+      const config = {provider: 'openai' as const, maxTokens: 4000}
+      const assistant = new AIAssistant(config)
+      expect(assistant).toBeInstanceOf(AIAssistant)
+    })
+  })
+
+  describe('isAIAvailable', () => {
+    it('should return true when LLM client is available', () => {
+      mockIsAIAvailable.mockReturnValue(true)
+      const assistant = new AIAssistant()
+      expect(assistant.isAIAvailable()).toBe(true)
+    })
+
+    it('should return false when LLM client is not available', () => {
+      mockIsAIAvailable.mockReturnValue(false)
+      const assistant = new AIAssistant()
+      expect(assistant.isAIAvailable()).toBe(false)
+    })
+  })
+
+  describe('continueSession', () => {
+    it('should return null for non-existent session', async () => {
+      const assistant = new AIAssistant()
+      const result = await assistant.continueSession('non-existent-id')
+      expect(result).toBeNull()
+    })
+  })
+
+  describe('startAssistSession', () => {
+    it('should call intro with expected message', async () => {
+      const assistant = new AIAssistant()
+      await assistant.startAssistSession()
+      expect(mockIntro).toHaveBeenCalledWith('🤖 AI Project Assistant')
+    })
+
+    it('should fallback to traditional setup when AI is not available', async () => {
+      mockIsAIAvailable.mockReturnValue(false)
+      const assistant = new AIAssistant()
+      const result = await assistant.startAssistSession()
+
+      expect(result).toEqual({
+        name: 'my-project',
+        template: 'default',
+        description: undefined,
+        interactive: true,
+      })
+    })
+
+    it('should use initial options in fallback mode', async () => {
+      mockIsAIAvailable.mockReturnValue(false)
+      const assistant = new AIAssistant()
+      const result = await assistant.startAssistSession({
+        name: 'my-custom-project',
+        template: 'react-app',
+      })
+
+      expect(result.name).toBe('my-custom-project')
+      expect(result.template).toBe('react-app')
+    })
+
+    it('should complete conversational setup when AI is available', async () => {
+      const assistant = new AIAssistant()
+      const result = await assistant.startAssistSession()
+
+      expect(result).toBeDefined()
+      expect(result.name).toBeDefined()
+      expect(mockOutro).toHaveBeenCalledWith('✨ Perfect! Your project configuration is ready.')
+    })
+
+    it('should gather project description via text prompt', async () => {
+      const assistant = new AIAssistant()
+      await assistant.startAssistSession()
+
+      expect(mockText).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: 'What would you like to build? Describe your project:',
+        }),
+      )
+    })
+
+    it('should show spinner during project analysis', async () => {
+      const assistant = new AIAssistant()
+      await assistant.startAssistSession()
+
+      expect(mockSpinnerStart).toHaveBeenCalledWith('🧠 Analyzing your project requirements...')
+      expect(mockSpinnerStop).toHaveBeenCalledWith('✅ Analysis complete!')
+    })
+
+    it('should handle user cancellation during description', async () => {
+      mockText.mockResolvedValueOnce(Symbol('cancel'))
+      vi.spyOn(console, 'error').mockImplementation(() => {})
+
+      const assistant = new AIAssistant()
+      const result = await assistant.startAssistSession()
+
+      expect(result.interactive).toBe(true)
+      expect(result.name).toBe('my-project')
+    })
+
+    it('should handle project name cancellation', async () => {
+      mockText.mockResolvedValueOnce('A TypeScript library').mockResolvedValueOnce(Symbol('cancel'))
+      vi.spyOn(console, 'error').mockImplementation(() => {})
+
+      const assistant = new AIAssistant()
+      const result = await assistant.startAssistSession()
+
+      expect(result.interactive).toBe(true)
+    })
+
+    it('should use provided initial name without prompting for name', async () => {
+      const assistant = new AIAssistant()
+      const result = await assistant.startAssistSession({name: 'preset-name'})
+
+      expect(result.name).toBe('preset-name')
+    })
+
+    it('should select features via multiselect', async () => {
+      mockMultiselect.mockResolvedValueOnce(['typescript', 'eslint', 'vitest'])
+
+      const assistant = new AIAssistant()
+      const result = await assistant.startAssistSession()
+
+      expect(result.features).toBe('typescript,eslint,vitest')
+    })
+
+    it('should select package manager via select', async () => {
+      mockSelect.mockResolvedValue('pnpm')
+
+      const assistant = new AIAssistant()
+      const result = await assistant.startAssistSession()
+
+      expect(result.packageManager).toBe('pnpm')
+    })
+
+    it('should handle confirmation rejection and restart', async () => {
+      mockConfirm
+        .mockResolvedValueOnce(true)
+        .mockResolvedValueOnce(false)
+        .mockResolvedValueOnce(true)
+        .mockResolvedValueOnce(true)
+
+      const assistant = new AIAssistant()
+      const result = await assistant.startAssistSession()
+
+      expect(result).toBeDefined()
+    })
+
+    it('should not restart when user declines restart option', async () => {
+      mockConfirm
+        .mockResolvedValueOnce(true)
+        .mockResolvedValueOnce(false)
+        .mockResolvedValueOnce(false)
+
+      const assistant = new AIAssistant()
+      const result = await assistant.startAssistSession()
+
+      expect(result).toBeDefined()
+    })
+
+    it('should handle analysis failure gracefully', async () => {
+      mockAnalyzeProject.mockRejectedValueOnce(new Error('Analysis failed'))
+      vi.spyOn(console, 'error').mockImplementation(() => {})
+
+      const assistant = new AIAssistant()
+      const result = await assistant.startAssistSession()
+
+      expect(mockSpinnerStop).toHaveBeenCalledWith('❌ Analysis failed')
+      expect(result).toEqual(
+        expect.objectContaining({
+          interactive: true,
+        }),
+      )
+    })
+
+    it('should handle single template recommendation with confirmation', async () => {
+      mockAnalyzeProject.mockResolvedValueOnce({
+        projectType: 'typescript-library',
+        features: ['typescript'],
+        templates: [
+          {
+            source: {location: 'ts-lib'},
+            confidence: 0.95,
+            reason: 'Perfect match',
+          },
+        ],
+        dependencies: [],
+      })
+
+      mockConfirm.mockResolvedValueOnce(true)
+
+      const assistant = new AIAssistant()
+      const result = await assistant.startAssistSession()
+
+      expect(result.template).toBe('ts-lib')
+    })
+
+    it('should use default template when single recommendation is rejected', async () => {
+      mockAnalyzeProject.mockResolvedValueOnce({
+        projectType: 'typescript-library',
+        features: ['typescript'],
+        templates: [
+          {
+            source: {location: 'ts-lib'},
+            confidence: 0.95,
+            reason: 'Perfect match',
+          },
+        ],
+        dependencies: [],
+      })
+
+      mockConfirm.mockResolvedValueOnce(false)
+
+      const assistant = new AIAssistant()
+      const result = await assistant.startAssistSession()
+
+      expect(result.template).toBe('default')
+    })
+
+    it('should use default template when no templates recommended', async () => {
+      mockAnalyzeProject.mockResolvedValueOnce({
+        projectType: 'unknown',
+        features: [],
+        templates: [],
+        dependencies: [],
+      })
+
+      const assistant = new AIAssistant()
+      const result = await assistant.startAssistSession()
+
+      expect(result.template).toBe('default')
+    })
+
+    it('should use default features when no features recommended', async () => {
+      mockAnalyzeProject.mockResolvedValueOnce({
+        projectType: 'unknown',
+        features: [],
+        templates: [],
+        dependencies: [],
+      })
+
+      const assistant = new AIAssistant()
+      const result = await assistant.startAssistSession()
+
+      expect(result.features).toBe('typescript,eslint,prettier')
+    })
+  })
+
+  describe('createAIAssistant factory', () => {
+    it('should create AIAssistant instance', () => {
+      const assistant = createAIAssistant()
+      expect(assistant).toBeInstanceOf(AIAssistant)
+    })
+
+    it('should pass config to AIAssistant constructor', () => {
+      const config = {provider: 'anthropic' as const, temperature: 0.5}
+      const assistant = createAIAssistant(config)
+      expect(assistant).toBeInstanceOf(AIAssistant)
+    })
+  })
+})
+
+describe('AIAssistant session management', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockIsAIAvailable.mockReturnValue(true)
+    mockText.mockResolvedValue('Test project')
+    mockSelect.mockResolvedValue('default')
+    mockMultiselect.mockResolvedValue(['typescript'])
+    mockConfirm.mockResolvedValue(true)
+    mockAnalyzeProject.mockResolvedValue({
+      projectType: 'typescript-library',
+      features: ['typescript'],
+      templates: [{source: {location: 'default'}, confidence: 0.9, reason: 'Test'}],
+      dependencies: [],
+    })
+  })
+
+  it('should track prompts throughout session', async () => {
+    const assistant = new AIAssistant()
+    await assistant.startAssistSession()
+
+    expect(mockText).toHaveBeenCalled()
+    expect(mockSelect).toHaveBeenCalled()
+    expect(mockMultiselect).toHaveBeenCalled()
+    expect(mockConfirm).toHaveBeenCalled()
+  })
+})
+
+describe('AIAssistant formatting', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockIsAIAvailable.mockReturnValue(true)
+    mockConfirm.mockResolvedValue(true)
+    mockAnalyzeProject.mockResolvedValue({
+      projectType: 'typescript-library',
+      features: ['typescript'],
+      templates: [{source: {location: 'default'}, confidence: 0.9, reason: 'Test'}],
+      dependencies: [],
+    })
+  })
+
+  it('should format project summary correctly', async () => {
+    mockText.mockResolvedValue('A data validation library')
+    mockSelect.mockResolvedValue('default').mockResolvedValue('pnpm')
+    mockMultiselect.mockResolvedValue(['typescript', 'eslint'])
+
+    const assistant = new AIAssistant()
+    await assistant.startAssistSession({name: 'my-validator'})
+
+    expect(mockOutro).toHaveBeenCalledWith('✨ Perfect! Your project configuration is ready.')
+  })
+
+  it('should format analysis insights with project type', async () => {
+    mockText.mockResolvedValue('A React web app')
+    mockSelect.mockResolvedValue('react').mockResolvedValue('npm')
+    mockMultiselect.mockResolvedValue(['react', 'typescript'])
+
+    mockAnalyzeProject.mockResolvedValueOnce({
+      projectType: 'react-app',
+      features: ['react', 'typescript', 'vite'],
+      templates: [
+        {source: {location: 'react-vite'}, confidence: 0.92, reason: 'React with Vite'},
+        {source: {location: 'react-cra'}, confidence: 0.85, reason: 'Create React App'},
+      ],
+      dependencies: [
+        {name: 'react', description: 'React library'},
+        {name: 'react-dom', description: 'React DOM'},
+        {name: 'vite', description: 'Build tool'},
+      ],
+    })
+
+    const assistant = new AIAssistant()
+    await assistant.startAssistSession()
+
+    expect(mockSelect).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: 'Which template would you like to use?',
+      }),
+    )
+  })
+})
+
+describe('AIAssistant validation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockIsAIAvailable.mockReturnValue(true)
+    mockAnalyzeProject.mockResolvedValue({
+      projectType: 'typescript-library',
+      features: ['typescript'],
+      templates: [{source: {location: 'default'}, confidence: 0.9, reason: 'Test'}],
+      dependencies: [],
+    })
+  })
+
+  it('should validate project description length', async () => {
+    mockText.mockImplementation(
+      async (options: {validate?: (value: string) => string | undefined}) => {
+        const validate = options.validate
+        expect(validate).toBeDefined()
+        if (typeof validate === 'function') {
+          const shortError = validate('short')
+          // eslint-disable-next-line vitest/no-conditional-expect -- testing validation callback
+          expect(shortError).toBe(
+            'Please provide a more detailed description (at least 10 characters)',
+          )
+        }
+        return 'A TypeScript library for testing'
+      },
+    )
+
+    mockSelect.mockResolvedValue('default')
+    mockMultiselect.mockResolvedValue(['typescript'])
+    mockConfirm.mockResolvedValue(true)
+
+    const assistant = new AIAssistant()
+    await assistant.startAssistSession()
+  })
+
+  it('should validate project name format', async () => {
+    mockText
+      .mockResolvedValueOnce('A TypeScript library')
+      .mockImplementation(async (options: {validate?: (value: string) => string | undefined}) => {
+        const validate = options.validate
+        expect(validate).toBeDefined()
+        if (typeof validate === 'function') {
+          const emptyError = validate('')
+          // eslint-disable-next-line vitest/no-conditional-expect -- testing validation callback
+          expect(emptyError).toBe('Project name is required')
+
+          const invalidError = validate('invalid name!')
+          // eslint-disable-next-line vitest/no-conditional-expect -- testing validation callback
+          expect(invalidError).toBe(
+            'Project name can only contain letters, numbers, hyphens, underscores, @ and /',
+          )
+        }
+        return 'valid-project-name'
+      })
+
+    mockSelect.mockResolvedValue('default')
+    mockMultiselect.mockResolvedValue(['typescript'])
+    mockConfirm.mockResolvedValue(true)
+
+    const assistant = new AIAssistant()
+    await assistant.startAssistSession()
+  })
+})

--- a/packages/create/test/ai/availability.test.ts
+++ b/packages/create/test/ai/availability.test.ts
@@ -1,0 +1,230 @@
+/**
+ * Tests for AI Availability Detection
+ * Part of Phase 5: Comprehensive Testing Implementation (TASK-036)
+ *
+ * Tests pure functions for detecting AI provider availability.
+ */
+
+import {afterEach, beforeEach, describe, expect, it} from 'vitest'
+import {
+  checkAllProvidersAvailability,
+  checkAnthropicAvailability,
+  checkOpenAIAvailability,
+  getAIAvailabilityStatus,
+} from '../../src/ai/availability.js'
+
+describe('aI Availability Detection', () => {
+  const originalEnv = process.env
+
+  beforeEach(() => {
+    process.env = {...originalEnv}
+    delete process.env.OPENAI_API_KEY
+    delete process.env.ANTHROPIC_API_KEY
+  })
+
+  afterEach(() => {
+    process.env = originalEnv
+  })
+
+  describe('checkOpenAIAvailability', () => {
+    it('returns unavailable when no API key', () => {
+      const result = checkOpenAIAvailability()
+
+      expect(result.provider).toBe('openai')
+      expect(result.available).toBe(false)
+      expect(result.reason).toContain('not set')
+    })
+
+    it('returns unavailable when API key is empty', () => {
+      process.env.OPENAI_API_KEY = ''
+
+      const result = checkOpenAIAvailability()
+
+      expect(result.available).toBe(false)
+    })
+
+    it('returns unavailable when API key format is invalid', () => {
+      process.env.OPENAI_API_KEY = 'invalid-key'
+
+      const result = checkOpenAIAvailability()
+
+      expect(result.available).toBe(false)
+      expect(result.reason).toContain('Invalid')
+    })
+
+    it('returns available when valid API key from env', () => {
+      process.env.OPENAI_API_KEY = 'sk-test-valid-key'
+
+      const result = checkOpenAIAvailability()
+
+      expect(result.provider).toBe('openai')
+      expect(result.available).toBe(true)
+      expect(result.reason).toBeUndefined()
+    })
+
+    it('uses config API key over environment', () => {
+      process.env.OPENAI_API_KEY = 'sk-env-key'
+
+      const result = checkOpenAIAvailability({
+        openai: {
+          apiKey: 'sk-config-key',
+        },
+      })
+
+      expect(result.available).toBe(true)
+    })
+
+    it('returns unavailable when config key is empty', () => {
+      process.env.OPENAI_API_KEY = 'sk-env-key'
+
+      const result = checkOpenAIAvailability({
+        openai: {
+          apiKey: '',
+        },
+      })
+
+      expect(result.available).toBe(false)
+    })
+  })
+
+  describe('checkAnthropicAvailability', () => {
+    it('returns unavailable when no API key', () => {
+      const result = checkAnthropicAvailability()
+
+      expect(result.provider).toBe('anthropic')
+      expect(result.available).toBe(false)
+      expect(result.reason).toContain('not set')
+    })
+
+    it('returns unavailable when API key is empty', () => {
+      process.env.ANTHROPIC_API_KEY = ''
+
+      const result = checkAnthropicAvailability()
+
+      expect(result.available).toBe(false)
+    })
+
+    it('returns unavailable when API key format is invalid', () => {
+      process.env.ANTHROPIC_API_KEY = 'invalid-key'
+
+      const result = checkAnthropicAvailability()
+
+      expect(result.available).toBe(false)
+      expect(result.reason).toContain('Invalid')
+    })
+
+    it('returns available when valid API key from env', () => {
+      process.env.ANTHROPIC_API_KEY = 'sk-ant-test-valid-key'
+
+      const result = checkAnthropicAvailability()
+
+      expect(result.provider).toBe('anthropic')
+      expect(result.available).toBe(true)
+      expect(result.reason).toBeUndefined()
+    })
+
+    it('uses config API key over environment', () => {
+      process.env.ANTHROPIC_API_KEY = 'sk-ant-env-key'
+
+      const result = checkAnthropicAvailability({
+        anthropic: {
+          apiKey: 'sk-ant-config-key',
+        },
+      })
+
+      expect(result.available).toBe(true)
+    })
+  })
+
+  describe('checkAllProvidersAvailability', () => {
+    it('returns results for all providers', () => {
+      const results = checkAllProvidersAvailability()
+
+      expect(results).toHaveLength(2)
+      expect(results.map(r => r.provider)).toContain('openai')
+      expect(results.map(r => r.provider)).toContain('anthropic')
+    })
+
+    it('marks both available when both keys set', () => {
+      process.env.OPENAI_API_KEY = 'sk-openai-key'
+      process.env.ANTHROPIC_API_KEY = 'sk-ant-anthropic-key'
+
+      const results = checkAllProvidersAvailability()
+
+      expect(results.every(r => r.available)).toBe(true)
+    })
+
+    it('marks only one available when one key set', () => {
+      process.env.OPENAI_API_KEY = 'sk-openai-key'
+
+      const results = checkAllProvidersAvailability()
+
+      const openaiResult = results.find(r => r.provider === 'openai')
+      const anthropicResult = results.find(r => r.provider === 'anthropic')
+
+      expect(openaiResult?.available).toBe(true)
+      expect(anthropicResult?.available).toBe(false)
+    })
+  })
+
+  describe('getAIAvailabilityStatus', () => {
+    it('returns unavailable when AI disabled in config', () => {
+      process.env.OPENAI_API_KEY = 'sk-valid-key'
+
+      const status = getAIAvailabilityStatus({enabled: false})
+
+      expect(status.available).toBe(false)
+      expect(status.providers).toHaveLength(0)
+      expect(status.preferredProvider).toBeUndefined()
+      expect(status.reason).toContain('disabled')
+    })
+
+    it('returns unavailable when no providers available', () => {
+      const status = getAIAvailabilityStatus()
+
+      expect(status.available).toBe(false)
+      expect(status.providers).toHaveLength(0)
+      expect(status.preferredProvider).toBeUndefined()
+      expect(status.reason).toContain('No AI providers')
+    })
+
+    it('returns available with single provider', () => {
+      process.env.OPENAI_API_KEY = 'sk-valid-key'
+
+      const status = getAIAvailabilityStatus()
+
+      expect(status.available).toBe(true)
+      expect(status.providers).toContain('openai')
+      expect(status.preferredProvider).toBe('openai')
+    })
+
+    it('returns available with both providers', () => {
+      process.env.OPENAI_API_KEY = 'sk-openai-key'
+      process.env.ANTHROPIC_API_KEY = 'sk-ant-anthropic-key'
+
+      const status = getAIAvailabilityStatus()
+
+      expect(status.available).toBe(true)
+      expect(status.providers).toContain('openai')
+      expect(status.providers).toContain('anthropic')
+    })
+
+    it('respects provider preference in config', () => {
+      process.env.OPENAI_API_KEY = 'sk-openai-key'
+      process.env.ANTHROPIC_API_KEY = 'sk-ant-anthropic-key'
+
+      const status = getAIAvailabilityStatus({provider: 'anthropic'})
+
+      expect(status.preferredProvider).toBe('anthropic')
+    })
+
+    it('falls back to available provider when preferred not available', () => {
+      process.env.OPENAI_API_KEY = 'sk-openai-key'
+
+      const status = getAIAvailabilityStatus({provider: 'anthropic'})
+
+      expect(status.available).toBe(true)
+      expect(status.preferredProvider).toBe('openai')
+    })
+  })
+})

--- a/packages/create/test/ai/cli-integration.test.ts
+++ b/packages/create/test/ai/cli-integration.test.ts
@@ -1,0 +1,541 @@
+/**
+ * Tests for AI CLI integration
+ * Part of Phase 5: Comprehensive Testing Implementation (TASK-036, TASK-037, TASK-038)
+ */
+
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
+
+const mockAnalyze = vi.fn()
+const mockRecommend = vi.fn()
+const mockGenerate = vi.fn()
+const mockIsAIAvailable = vi.fn()
+
+vi.mock('../../src/ai/project-analyzer.js', () => ({
+  ProjectAnalyzer: class MockProjectAnalyzer {
+    llmClient = {isAIAvailable: mockIsAIAvailable}
+    analyzeProject = mockAnalyze
+  },
+}))
+
+vi.mock('../../src/ai/dependency-recommender.js', () => ({
+  DependencyRecommender: class MockDependencyRecommender {
+    recommendDependencies = mockRecommend
+  },
+}))
+
+vi.mock('../../src/ai/code-generator.js', () => ({
+  CodeGenerator: class MockCodeGenerator {
+    generateConfig = mockGenerate
+  },
+}))
+
+const {CliAIIntegration, createCliAIIntegration} = await import('../../src/ai/cli-integration.js')
+
+describe('CliAIIntegration', () => {
+  const originalEnv = process.env
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    process.env = {...originalEnv}
+    mockIsAIAvailable.mockReturnValue(true)
+  })
+
+  afterEach(() => {
+    process.env = originalEnv
+  })
+
+  describe('constructor', () => {
+    it('creates instance with default config', () => {
+      const integration = new CliAIIntegration()
+      expect(integration).toBeInstanceOf(CliAIIntegration)
+    })
+
+    it('creates instance with custom config', () => {
+      const config = {provider: 'openai' as const, maxTokens: 4000}
+      const integration = new CliAIIntegration(config)
+      expect(integration).toBeInstanceOf(CliAIIntegration)
+    })
+  })
+
+  describe('createCliAIIntegration', () => {
+    it('creates CliAIIntegration instance', () => {
+      const integration = createCliAIIntegration()
+      expect(integration).toBeInstanceOf(CliAIIntegration)
+    })
+
+    it('passes config to constructor', () => {
+      const config = {maxTokens: 2000}
+      const integration = createCliAIIntegration(config)
+      expect(integration).toBeInstanceOf(CliAIIntegration)
+    })
+  })
+
+  describe('enhancePackageCreation', () => {
+    it('returns success when AI is disabled', async () => {
+      const integration = new CliAIIntegration()
+      const result = await integration.enhancePackageCreation({name: 'test'}, {ai: false})
+
+      expect(result.success).toBe(true)
+      expect(result.warnings).toContain('AI features disabled')
+      expect(mockAnalyze).not.toHaveBeenCalled()
+    })
+
+    it('performs analysis when enabled', async () => {
+      const mockAnalysis = {
+        projectType: 'library',
+        description: 'Test project',
+        features: ['typescript'],
+        techStack: [{name: 'node'}],
+        confidence: 0.9,
+      }
+      mockAnalyze.mockResolvedValue(mockAnalysis)
+      mockRecommend.mockResolvedValue([])
+
+      const integration = new CliAIIntegration()
+      const result = await integration.enhancePackageCreation({
+        name: 'test-project',
+        description: 'Test',
+      })
+
+      expect(result.success).toBe(true)
+      expect(result.analysis).toEqual(mockAnalysis)
+      expect(mockAnalyze).toHaveBeenCalled()
+    })
+
+    it('skips analysis when analyze is false', async () => {
+      const integration = new CliAIIntegration()
+      await integration.enhancePackageCreation({name: 'test'}, {analyze: false})
+
+      expect(mockAnalyze).not.toHaveBeenCalled()
+    })
+
+    it('recommends dependencies when analysis succeeds', async () => {
+      const mockAnalysis = {
+        projectType: 'library',
+        description: 'Test',
+        features: [],
+        techStack: [],
+        confidence: 0.8,
+      }
+      const mockDeps = [{name: 'typescript', description: 'TypeScript', confidence: 0.9}]
+
+      mockAnalyze.mockResolvedValue(mockAnalysis)
+      mockRecommend.mockResolvedValue(mockDeps)
+
+      const integration = new CliAIIntegration()
+      const result = await integration.enhancePackageCreation({name: 'test'})
+
+      expect(result.dependencies).toEqual(mockDeps)
+      expect(mockRecommend).toHaveBeenCalledWith(mockAnalysis, undefined)
+    })
+
+    it('skips recommendations when recommend is false', async () => {
+      const mockAnalysis = {
+        projectType: 'library',
+        description: 'Test',
+        features: [],
+        techStack: [],
+        confidence: 0.8,
+      }
+      mockAnalyze.mockResolvedValue(mockAnalysis)
+
+      const integration = new CliAIIntegration()
+      await integration.enhancePackageCreation({name: 'test'}, {recommend: false})
+
+      expect(mockRecommend).not.toHaveBeenCalled()
+    })
+
+    it('generates code when generate is true', async () => {
+      const mockAnalysis = {
+        projectType: 'library',
+        description: 'Test',
+        features: ['testing'],
+        techStack: [],
+        confidence: 0.9,
+      }
+      const mockGenResult = {
+        success: true,
+        code: '{}',
+        filePath: 'package.json',
+        quality: 0.85,
+      }
+
+      mockAnalyze.mockResolvedValue(mockAnalysis)
+      mockRecommend.mockResolvedValue([])
+      mockGenerate.mockResolvedValue(mockGenResult)
+
+      const integration = new CliAIIntegration()
+      const result = await integration.enhancePackageCreation({name: 'test'}, {generate: true})
+
+      expect(result.codeGeneration).toEqual(mockGenResult)
+      expect(mockGenerate).toHaveBeenCalled()
+    })
+
+    it('skips code generation when generate is not true', async () => {
+      mockAnalyze.mockResolvedValue({
+        projectType: 'lib',
+        description: 'Test',
+        features: [],
+        techStack: [],
+        confidence: 0.8,
+      })
+      mockRecommend.mockResolvedValue([])
+
+      const integration = new CliAIIntegration()
+      await integration.enhancePackageCreation({name: 'test'})
+
+      expect(mockGenerate).not.toHaveBeenCalled()
+    })
+
+    it('handles analysis errors gracefully', async () => {
+      mockAnalyze.mockRejectedValue(new Error('Analysis failed'))
+
+      const integration = new CliAIIntegration()
+      const result = await integration.enhancePackageCreation({name: 'test'})
+
+      expect(result.success).toBe(true)
+      expect(result.warnings).toContain('Analysis failed: Analysis failed')
+    })
+
+    it('handles recommendation errors gracefully', async () => {
+      mockAnalyze.mockResolvedValue({
+        projectType: 'lib',
+        description: 'Test',
+        features: [],
+        techStack: [],
+        confidence: 0.8,
+      })
+      mockRecommend.mockRejectedValue(new Error('Recommendation failed'))
+
+      const integration = new CliAIIntegration()
+      const result = await integration.enhancePackageCreation({name: 'test'})
+
+      expect(result.success).toBe(true)
+      expect(result.warnings).toContain('Dependency recommendations failed: Recommendation failed')
+    })
+
+    it('handles code generation errors gracefully', async () => {
+      mockAnalyze.mockResolvedValue({
+        projectType: 'lib',
+        description: 'Test',
+        features: [],
+        techStack: [],
+        confidence: 0.8,
+      })
+      mockRecommend.mockResolvedValue([])
+      mockGenerate.mockRejectedValue(new Error('Generation failed'))
+
+      const integration = new CliAIIntegration()
+      const result = await integration.enhancePackageCreation({name: 'test'}, {generate: true})
+
+      expect(result.success).toBe(true)
+      expect(result.warnings).toContain('Code generation failed: Generation failed')
+    })
+
+    it('adds warning when AI is not available', async () => {
+      mockIsAIAvailable.mockReturnValue(false)
+
+      const integration = new CliAIIntegration()
+      const result = await integration.enhancePackageCreation({name: 'test'}, {analyze: false})
+
+      expect(result.warnings).toContain('AI services not available, using fallback analysis')
+    })
+
+    it('includes processing time', async () => {
+      mockAnalyze.mockResolvedValue({
+        projectType: 'lib',
+        description: 'Test',
+        features: [],
+        techStack: [],
+        confidence: 0.8,
+      })
+      mockRecommend.mockResolvedValue([])
+
+      const integration = new CliAIIntegration()
+      const result = await integration.enhancePackageCreation({name: 'test'})
+
+      expect(result.processingTime).toBeGreaterThanOrEqual(0)
+    })
+
+    it('passes existing dependencies to recommender', async () => {
+      mockAnalyze.mockResolvedValue({
+        projectType: 'lib',
+        description: 'Test',
+        features: [],
+        techStack: [],
+        confidence: 0.8,
+      })
+      mockRecommend.mockResolvedValue([])
+
+      const integration = new CliAIIntegration()
+      await integration.enhancePackageCreation({
+        name: 'test',
+        existingDependencies: ['react', 'typescript'],
+      })
+
+      expect(mockRecommend).toHaveBeenCalledWith(expect.anything(), ['react', 'typescript'])
+    })
+  })
+
+  describe('interactiveAnalysis', () => {
+    it('returns input with defaults', async () => {
+      const integration = new CliAIIntegration()
+      const result = await integration.interactiveAnalysis({
+        description: 'Test project',
+      })
+
+      expect(result.name).toBe('my-project')
+      expect(result.description).toBe('Test project')
+      expect(result.keywords).toEqual([])
+      expect(result.requirements).toEqual([])
+    })
+
+    it('preserves provided values', async () => {
+      const integration = new CliAIIntegration()
+      const result = await integration.interactiveAnalysis({
+        name: 'custom-name',
+        keywords: ['test', 'project'],
+        requirements: ['typescript'],
+        existingDependencies: ['react'],
+      })
+
+      expect(result.name).toBe('custom-name')
+      expect(result.keywords).toEqual(['test', 'project'])
+      expect(result.requirements).toEqual(['typescript'])
+      expect(result.existingDependencies).toEqual(['react'])
+    })
+  })
+
+  describe('formatResults', () => {
+    it('formats failed result', () => {
+      const integration = new CliAIIntegration()
+      const result = integration.formatResults({
+        success: false,
+        error: 'Test error',
+        warnings: [],
+      })
+
+      expect(result).toContain('❌ AI enhancement failed')
+      expect(result).toContain('Test error')
+    })
+
+    it('formats unknown error', () => {
+      const integration = new CliAIIntegration()
+      const result = integration.formatResults({
+        success: false,
+        warnings: [],
+      })
+
+      expect(result).toContain('Unknown error')
+    })
+
+    it('formats successful result with analysis', () => {
+      const integration = new CliAIIntegration()
+      const result = integration.formatResults({
+        success: true,
+        analysis: {
+          projectType: 'library',
+          description: 'A test library',
+          features: ['typescript', 'testing'],
+          techStack: [
+            {name: 'node', category: 'runtime', reason: 'Node.js runtime', confidence: 0.9},
+          ],
+          dependencies: [],
+          templates: [],
+          confidence: 0.85,
+        },
+        warnings: [],
+      })
+
+      expect(result).toContain('🤖 AI Enhancement Results')
+      expect(result).toContain('📊 Project Analysis')
+      expect(result).toContain('library')
+      expect(result).toContain('85%')
+      expect(result).toContain('typescript, testing')
+      expect(result).toContain('node')
+    })
+
+    it('formats result with dependencies', () => {
+      const integration = new CliAIIntegration()
+      const result = integration.formatResults({
+        success: true,
+        dependencies: [
+          {
+            name: 'typescript',
+            description: 'TypeScript compiler',
+            reason: 'Type safety',
+            confidence: 0.95,
+            isDev: true,
+          },
+          {
+            name: 'vitest',
+            description: 'Test framework',
+            reason: 'Testing',
+            confidence: 0.9,
+            isDev: true,
+          },
+        ],
+        warnings: [],
+      })
+
+      expect(result).toContain('📦 Recommended Dependencies')
+      expect(result).toContain('typescript')
+      expect(result).toContain('95%')
+    })
+
+    it('limits displayed dependencies to 5', () => {
+      const integration = new CliAIIntegration()
+      const deps = Array.from({length: 10}, (_, i) => ({
+        name: `dep-${i}`,
+        description: `Dep ${i}`,
+        reason: `Reason ${i}`,
+        confidence: 0.8,
+        isDev: false,
+      }))
+
+      const result = integration.formatResults({
+        success: true,
+        dependencies: deps,
+        warnings: [],
+      })
+
+      expect(result).toContain('... and 5 more')
+    })
+
+    it('formats result with code generation', () => {
+      const integration = new CliAIIntegration()
+      const result = integration.formatResults({
+        success: true,
+        codeGeneration: {
+          success: true,
+          code: '{}',
+          filePath: 'package.json',
+          quality: 0.9,
+        },
+        warnings: [],
+      })
+
+      expect(result).toContain('🎯 Generated Configuration')
+      expect(result).toContain('package.json')
+      expect(result).toContain('90%')
+    })
+
+    it('uses default quality when not provided', () => {
+      const integration = new CliAIIntegration()
+      const result = integration.formatResults({
+        success: true,
+        codeGeneration: {
+          success: true,
+          code: '{}',
+        },
+        warnings: [],
+      })
+
+      expect(result).toContain('70%')
+    })
+
+    it('formats processing time', () => {
+      const integration = new CliAIIntegration()
+      const result = integration.formatResults({
+        success: true,
+        processingTime: 1234,
+        warnings: [],
+      })
+
+      expect(result).toContain('⏱️  Processing time: 1234ms')
+    })
+
+    it('formats warnings', () => {
+      const integration = new CliAIIntegration()
+      const result = integration.formatResults({
+        success: true,
+        warnings: ['Warning 1', 'Warning 2'],
+      })
+
+      expect(result).toContain('⚠️  Warnings')
+      expect(result).toContain('Warning 1')
+      expect(result).toContain('Warning 2')
+    })
+
+    it('omits sections with no data', () => {
+      const integration = new CliAIIntegration()
+      const result = integration.formatResults({
+        success: true,
+        warnings: [],
+      })
+
+      expect(result).not.toContain('📊 Project Analysis')
+      expect(result).not.toContain('📦 Recommended Dependencies')
+      expect(result).not.toContain('🎯 Generated Configuration')
+      expect(result).not.toContain('⚠️  Warnings')
+    })
+  })
+
+  describe('isAIAvailable', () => {
+    it('returns true when AI is available', () => {
+      mockIsAIAvailable.mockReturnValue(true)
+      const integration = new CliAIIntegration()
+      expect(integration.isAIAvailable()).toBe(true)
+    })
+
+    it('returns false when AI is not available', () => {
+      mockIsAIAvailable.mockReturnValue(false)
+      const integration = new CliAIIntegration()
+      expect(integration.isAIAvailable()).toBe(false)
+    })
+  })
+
+  describe('getAIStatus', () => {
+    it('returns available status with providers', () => {
+      process.env.OPENAI_API_KEY = 'test-key'
+      process.env.ANTHROPIC_API_KEY = 'test-key'
+      mockIsAIAvailable.mockReturnValue(true)
+
+      const integration = new CliAIIntegration()
+      const status = integration.getAIStatus()
+
+      expect(status.available).toBe(true)
+      expect(status.providers).toContain('OpenAI')
+      expect(status.providers).toContain('Anthropic')
+      expect(status.limitations).toBeUndefined()
+    })
+
+    it('returns unavailable status with limitations', () => {
+      delete process.env.OPENAI_API_KEY
+      delete process.env.ANTHROPIC_API_KEY
+      mockIsAIAvailable.mockReturnValue(false)
+
+      const integration = new CliAIIntegration()
+      const status = integration.getAIStatus()
+
+      expect(status.available).toBe(false)
+      expect(status.providers).toEqual([])
+      expect(status.limitations).toContain('No AI API keys configured')
+      expect(status.limitations).toContain('AI services unavailable - using fallback analysis')
+    })
+
+    it('returns partial status with OpenAI only', () => {
+      process.env.OPENAI_API_KEY = 'test-key'
+      delete process.env.ANTHROPIC_API_KEY
+      mockIsAIAvailable.mockReturnValue(true)
+
+      const integration = new CliAIIntegration()
+      const status = integration.getAIStatus()
+
+      expect(status.providers).toContain('OpenAI')
+      expect(status.providers).not.toContain('Anthropic')
+    })
+
+    it('returns partial status with Anthropic only', () => {
+      delete process.env.OPENAI_API_KEY
+      process.env.ANTHROPIC_API_KEY = 'test-key'
+      mockIsAIAvailable.mockReturnValue(true)
+
+      const integration = new CliAIIntegration()
+      const status = integration.getAIStatus()
+
+      expect(status.providers).not.toContain('OpenAI')
+      expect(status.providers).toContain('Anthropic')
+    })
+  })
+})

--- a/packages/create/test/ai/code-analyzer.test.ts
+++ b/packages/create/test/ai/code-analyzer.test.ts
@@ -1,0 +1,904 @@
+import type {LLMResponse} from '../../src/types.js'
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+import {
+  CodeAnalyzer,
+  type AnalysisResult,
+  type AnalysisTarget,
+  type CodeIssue,
+} from '../../src/ai/code-analyzer.js'
+
+/**
+ * Minimal mock interface for LLMClient used in tests.
+ * Only includes the methods actually used by CodeAnalyzer.
+ */
+interface MockLLMClient {
+  complete: ReturnType<typeof vi.fn>
+}
+
+const createMockLLMClient = (): MockLLMClient => ({
+  complete: vi.fn(),
+})
+
+describe('CodeAnalyzer', () => {
+  let mockLLMClient: MockLLMClient
+  let analyzer: CodeAnalyzer
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockLLMClient = createMockLLMClient()
+    // CodeAnalyzer accepts any object with complete method
+    analyzer = new CodeAnalyzer(mockLLMClient as never)
+  })
+
+  describe('constructor', () => {
+    it('should create analyzer without LLM client', () => {
+      const analyzerWithoutAI = new CodeAnalyzer()
+      expect(analyzerWithoutAI).toBeDefined()
+    })
+
+    it('should create analyzer with LLM client', () => {
+      const analyzerWithAI = new CodeAnalyzer(mockLLMClient as never)
+      expect(analyzerWithAI).toBeDefined()
+    })
+  })
+
+  describe('analyzeFile', () => {
+    it('should analyze a single TypeScript file', async () => {
+      const code = `
+const x: any = 'test';
+console.log(x);
+`
+      vi.mocked(mockLLMClient.complete).mockResolvedValue({
+        success: true,
+        content: '[]',
+      } as LLMResponse)
+
+      const result = await analyzer.analyzeFile('test.ts', code)
+
+      expect(result).toBeDefined()
+      expect(result.issues).toBeDefined()
+      expect(result.qualityScore).toBeDefined()
+      expect(result.metadata.filesAnalyzed).toBe(1)
+    })
+
+    it('should detect console.log statements', async () => {
+      const code = `
+function test() {
+  console.log('debug message');
+  return 42;
+}
+`
+      vi.mocked(mockLLMClient.complete).mockResolvedValue({
+        success: true,
+        content: '[]',
+      } as LLMResponse)
+
+      const result = await analyzer.analyzeFile('test.ts', code, {useAI: false})
+
+      const consoleIssues = result.issues.filter(i => i.id === 'no-console-log')
+      expect(consoleIssues.length).toBeGreaterThan(0)
+      expect(consoleIssues[0]?.severity).toBe('warning')
+      expect(consoleIssues[0]?.category).toBe('best-practices')
+    })
+
+    it('should detect TODO comments', async () => {
+      const code = `
+// TODO: implement this feature
+function notImplemented() {
+  // FIXME: this is broken
+  return null;
+}
+`
+      const result = await analyzer.analyzeFile('test.ts', code, {useAI: false})
+
+      const todoIssues = result.issues.filter(i => i.id === 'todo-comment')
+      expect(todoIssues.length).toBe(2)
+      expect(todoIssues[0]?.severity).toBe('info')
+      expect(todoIssues[0]?.category).toBe('maintainability')
+    })
+
+    it('should detect any type usage in TypeScript', async () => {
+      const code = `
+const data: any = fetchData();
+function process<any>(input: any): any {
+  return input;
+}
+`
+      const result = await analyzer.analyzeFile('test.ts', code, {useAI: false})
+
+      const anyIssues = result.issues.filter(i => i.id === 'any-type-usage')
+      expect(anyIssues.length).toBeGreaterThan(0)
+      expect(anyIssues[0]?.severity).toBe('warning')
+      expect(anyIssues[0]?.category).toBe('type-safety')
+    })
+
+    it('should not detect any type in non-TypeScript files', async () => {
+      const code = `
+const data: any = fetchData();
+`
+      const result = await analyzer.analyzeFile('test.js', code, {useAI: false})
+
+      const anyIssues = result.issues.filter(i => i.id === 'any-type-usage')
+      expect(anyIssues.length).toBe(0)
+    })
+
+    it('should detect hardcoded secrets', async () => {
+      const code = `
+const apiKey = 'sk-1234567890abcdef';
+const password = 'supersecret123';
+`
+      const result = await analyzer.analyzeFile('config.ts', code, {useAI: false})
+
+      const secretIssues = result.issues.filter(i => i.id === 'hardcoded-secret')
+      expect(secretIssues.length).toBeGreaterThan(0)
+      expect(secretIssues[0]?.severity).toBe('error')
+      expect(secretIssues[0]?.category).toBe('security')
+    })
+
+    it('should detect hardcoded URLs', async () => {
+      const code = `
+const apiUrl = 'https://api.example.com/v1/users';
+`
+      const result = await analyzer.analyzeFile('api.ts', code, {useAI: false})
+
+      const urlIssues = result.issues.filter(
+        i => i.id === 'hardcoded-secret' && i.title.includes('url'),
+      )
+      expect(urlIssues.length).toBeGreaterThan(0)
+    })
+
+    it('should not flag commented out code', async () => {
+      const code = `
+// console.log('this is commented');
+function test() {
+  return 42;
+}
+`
+      const result = await analyzer.analyzeFile('test.ts', code, {useAI: false})
+
+      const consoleIssues = result.issues.filter(i => i.id === 'no-console-log')
+      expect(consoleIssues.length).toBe(0)
+    })
+  })
+
+  describe('analyzeTargets', () => {
+    it('should analyze multiple files', async () => {
+      const targets: AnalysisTarget[] = [
+        {filePath: 'file1.ts', content: 'console.log("test");', language: 'typescript'},
+        {filePath: 'file2.ts', content: 'const x: any = 1;', language: 'typescript'},
+      ]
+
+      vi.mocked(mockLLMClient.complete).mockResolvedValue({
+        success: true,
+        content: '[]',
+      } as LLMResponse)
+
+      const result = await analyzer.analyzeTargets(targets, {useAI: true})
+
+      expect(result.metadata.filesAnalyzed).toBe(2)
+      expect(result.issues.length).toBeGreaterThan(0)
+    })
+
+    it('should calculate quality score', async () => {
+      const targets: AnalysisTarget[] = [
+        {
+          filePath: 'clean.ts',
+          content: 'function add(a: number, b: number): number { return a + b; }',
+        },
+      ]
+
+      const result = await analyzer.analyzeTargets(targets, {useAI: false})
+
+      expect(result.qualityScore).toBeGreaterThanOrEqual(0)
+      expect(result.qualityScore).toBeLessThanOrEqual(100)
+    })
+
+    it('should return perfect score for clean code', async () => {
+      const targets: AnalysisTarget[] = [
+        {
+          filePath: 'clean.ts',
+          content: `
+function add(a: number, b: number): number {
+  return a + b;
+}
+
+function multiply(a: number, b: number): number {
+  return a * b;
+}
+`,
+        },
+      ]
+
+      const result = await analyzer.analyzeTargets(targets, {useAI: false})
+
+      expect(result.qualityScore).toBe(100)
+      expect(result.issues.length).toBe(0)
+    })
+
+    it('should filter issues by severity', async () => {
+      const targets: AnalysisTarget[] = [
+        {
+          filePath: 'test.ts',
+          content: `
+// TODO: fix this
+console.log('debug');
+const apiKey = 'secret-key-12345678901234567890';
+`,
+        },
+      ]
+
+      const result = await analyzer.analyzeTargets(targets, {
+        useAI: false,
+        severityLevels: ['error'],
+      })
+
+      result.issues.forEach(issue => {
+        expect(issue.severity).toBe('error')
+      })
+    })
+
+    it('should filter issues by category', async () => {
+      const targets: AnalysisTarget[] = [
+        {
+          filePath: 'test.ts',
+          content: `
+// TODO: fix this
+console.log('debug');
+const apiKey = 'secret-key-12345678901234567890';
+`,
+        },
+      ]
+
+      const result = await analyzer.analyzeTargets(targets, {
+        useAI: false,
+        categories: ['security'],
+      })
+
+      result.issues.forEach(issue => {
+        expect(issue.category).toBe('security')
+      })
+    })
+
+    it('should limit number of issues', async () => {
+      const targets: AnalysisTarget[] = [
+        {
+          filePath: 'test.ts',
+          content: `
+console.log('1');
+console.log('2');
+console.log('3');
+console.log('4');
+console.log('5');
+`,
+        },
+      ]
+
+      const result = await analyzer.analyzeTargets(targets, {
+        useAI: false,
+        maxIssues: 2,
+      })
+
+      expect(result.issues.length).toBeLessThanOrEqual(2)
+    })
+
+    it('should remove suggestions when not requested', async () => {
+      const targets: AnalysisTarget[] = [{filePath: 'test.ts', content: 'console.log("test");'}]
+
+      const result = await analyzer.analyzeTargets(targets, {
+        useAI: false,
+        includeSuggestions: false,
+      })
+
+      result.issues.forEach(issue => {
+        expect(issue.suggestion).toBeUndefined()
+      })
+    })
+
+    it('should remove examples when not requested', async () => {
+      const targets: AnalysisTarget[] = [{filePath: 'test.ts', content: 'console.log("test");'}]
+
+      const result = await analyzer.analyzeTargets(targets, {
+        useAI: false,
+        includeExamples: false,
+      })
+
+      result.issues.forEach(issue => {
+        expect(issue.fixExample).toBeUndefined()
+      })
+    })
+  })
+
+  describe('AI analysis', () => {
+    it('should use AI analysis when available', async () => {
+      vi.mocked(mockLLMClient.complete).mockResolvedValue({
+        success: true,
+        content: JSON.stringify([
+          {
+            title: 'AI-detected issue',
+            description: 'This is an AI-detected issue',
+            severity: 'warning',
+            category: 'best-practices',
+            lineNumber: 5,
+          },
+        ]),
+      } as LLMResponse)
+
+      const result = await analyzer.analyzeFile('test.ts', 'const x = 1;', {useAI: true})
+
+      expect(result.aiAnalysisUsed).toBe(true)
+      expect(mockLLMClient.complete).toHaveBeenCalled()
+    })
+
+    it('should fallback to static analysis when AI fails', async () => {
+      vi.mocked(mockLLMClient.complete).mockRejectedValue(new Error('AI unavailable'))
+
+      const result = await analyzer.analyzeFile('test.ts', 'console.log("test");', {useAI: true})
+
+      // AI analysis is considered "used" even if individual file analysis fails
+      // because the AI analysis path was attempted
+      expect(result.aiAnalysisUsed).toBe(true)
+      // Static analysis should still run and find issues
+      expect(result.issues.length).toBeGreaterThan(0)
+    })
+
+    it('should handle invalid AI response', async () => {
+      vi.mocked(mockLLMClient.complete).mockResolvedValue({
+        success: true,
+        content: 'not valid json',
+      } as LLMResponse)
+
+      const result = await analyzer.analyzeFile('test.ts', 'const x = 1;', {useAI: true})
+
+      expect(result).toBeDefined()
+    })
+
+    it('should handle AI returning non-array', async () => {
+      vi.mocked(mockLLMClient.complete).mockResolvedValue({
+        success: true,
+        content: JSON.stringify({issues: []}),
+      } as LLMResponse)
+
+      const result = await analyzer.analyzeFile('test.ts', 'const x = 1;', {useAI: true})
+
+      expect(result).toBeDefined()
+    })
+
+    it('should handle AI response with missing fields', async () => {
+      vi.mocked(mockLLMClient.complete).mockResolvedValue({
+        success: true,
+        content: JSON.stringify([{title: 'Partial issue'}, {description: 'Only description'}, {}]),
+      } as LLMResponse)
+
+      const result = await analyzer.analyzeFile('test.ts', 'const x = 1;', {useAI: true})
+
+      expect(result.aiAnalysisUsed).toBe(true)
+      const aiIssues = result.issues.filter(i => i.id.startsWith('ai-'))
+      expect(aiIssues.length).toBe(3)
+    })
+
+    it('should validate severity from AI response', async () => {
+      vi.mocked(mockLLMClient.complete).mockResolvedValue({
+        success: true,
+        content: JSON.stringify([
+          {title: 'Valid severity', severity: 'error'},
+          {title: 'Invalid severity', severity: 'critical'},
+        ]),
+      } as LLMResponse)
+
+      const result = await analyzer.analyzeFile('test.ts', 'const x = 1;', {useAI: true})
+
+      const aiIssues = result.issues.filter(i => i.id.startsWith('ai-'))
+      const invalidSeverityIssue = aiIssues.find(i => i.title === 'Invalid severity')
+      expect(invalidSeverityIssue?.severity).toBe('info')
+    })
+
+    it('should validate category from AI response', async () => {
+      vi.mocked(mockLLMClient.complete).mockResolvedValue({
+        success: true,
+        content: JSON.stringify([
+          {title: 'Valid category', category: 'security'},
+          {title: 'Invalid category', category: 'unknown-category'},
+        ]),
+      } as LLMResponse)
+
+      const result = await analyzer.analyzeFile('test.ts', 'const x = 1;', {useAI: true})
+
+      const aiIssues = result.issues.filter(i => i.id.startsWith('ai-'))
+      const invalidCategoryIssue = aiIssues.find(i => i.title === 'Invalid category')
+      expect(invalidCategoryIssue?.category).toBe('best-practices')
+    })
+
+    it('should skip AI analysis when useAI is false', async () => {
+      const result = await analyzer.analyzeFile('test.ts', 'const x = 1;', {useAI: false})
+
+      expect(result.aiAnalysisUsed).toBe(false)
+      expect(mockLLMClient.complete).not.toHaveBeenCalled()
+    })
+
+    it('should handle AI response with unsuccessful status', async () => {
+      vi.mocked(mockLLMClient.complete).mockResolvedValue({
+        success: false,
+        error: 'Rate limited',
+      } as LLMResponse)
+
+      const result = await analyzer.analyzeFile('test.ts', 'const x = 1;', {useAI: true})
+
+      expect(result).toBeDefined()
+    })
+  })
+
+  describe('getImprovementSuggestions', () => {
+    const mockIssue: CodeIssue = {
+      id: 'test-issue',
+      title: 'Test Issue',
+      description: 'A test issue for suggestions',
+      severity: 'warning',
+      category: 'best-practices',
+      filePath: 'test.ts',
+    }
+
+    it('should get AI suggestions when available', async () => {
+      vi.mocked(mockLLMClient.complete).mockResolvedValue({
+        success: true,
+        content: JSON.stringify([
+          'Use const instead of let',
+          'Add type annotations',
+          'Extract to separate function',
+        ]),
+      } as LLMResponse)
+
+      const suggestions = await analyzer.getImprovementSuggestions(mockIssue, 'const x = 1;')
+
+      expect(suggestions).toBeDefined()
+      expect(suggestions.length).toBe(3)
+    })
+
+    it('should fallback to static suggestions when AI fails', async () => {
+      vi.mocked(mockLLMClient.complete).mockRejectedValue(new Error('AI unavailable'))
+
+      const suggestions = await analyzer.getImprovementSuggestions(mockIssue, 'const x = 1;')
+
+      expect(suggestions).toBeDefined()
+      expect(suggestions.length).toBeGreaterThan(0)
+    })
+
+    it('should return static suggestions when AI response is unsuccessful', async () => {
+      vi.mocked(mockLLMClient.complete).mockResolvedValue({
+        success: false,
+        error: 'Rate limited',
+      } as LLMResponse)
+
+      const suggestions = await analyzer.getImprovementSuggestions(mockIssue, 'const x = 1;')
+
+      expect(suggestions).toBeDefined()
+      expect(suggestions.length).toBeGreaterThan(0)
+    })
+
+    it('should handle non-JSON AI response', async () => {
+      vi.mocked(mockLLMClient.complete).mockResolvedValue({
+        success: true,
+        content: 'Use better naming\nAdd comments\nRefactor code',
+      } as LLMResponse)
+
+      const suggestions = await analyzer.getImprovementSuggestions(mockIssue, 'const x = 1;')
+
+      expect(suggestions).toBeDefined()
+      expect(suggestions.length).toBe(3)
+    })
+
+    it('should provide static suggestions without AI client', async () => {
+      const analyzerWithoutAI = new CodeAnalyzer()
+
+      const suggestions = await analyzerWithoutAI.getImprovementSuggestions(
+        mockIssue,
+        'const x = 1;',
+      )
+
+      expect(suggestions).toBeDefined()
+      expect(suggestions.length).toBeGreaterThan(0)
+    })
+
+    it('should provide category-specific static suggestions for performance', async () => {
+      const analyzerWithoutAI = new CodeAnalyzer()
+      const performanceIssue: CodeIssue = {...mockIssue, category: 'performance'}
+
+      const suggestions = await analyzerWithoutAI.getImprovementSuggestions(
+        performanceIssue,
+        'const x = 1;',
+      )
+
+      expect(
+        suggestions.some(
+          s => s.toLowerCase().includes('algorithm') || s.toLowerCase().includes('cache'),
+        ),
+      ).toBe(true)
+    })
+
+    it('should provide category-specific static suggestions for security', async () => {
+      const analyzerWithoutAI = new CodeAnalyzer()
+      const securityIssue: CodeIssue = {...mockIssue, category: 'security'}
+
+      const suggestions = await analyzerWithoutAI.getImprovementSuggestions(
+        securityIssue,
+        'const x = 1;',
+      )
+
+      expect(
+        suggestions.some(
+          s => s.toLowerCase().includes('validate') || s.toLowerCase().includes('sanitize'),
+        ),
+      ).toBe(true)
+    })
+
+    it('should provide category-specific static suggestions for type-safety', async () => {
+      const analyzerWithoutAI = new CodeAnalyzer()
+      const typeSafetyIssue: CodeIssue = {...mockIssue, category: 'type-safety'}
+
+      const suggestions = await analyzerWithoutAI.getImprovementSuggestions(
+        typeSafetyIssue,
+        'const x = 1;',
+      )
+
+      expect(
+        suggestions.some(s => s.toLowerCase().includes('any') || s.toLowerCase().includes('type')),
+      ).toBe(true)
+    })
+
+    it('should provide category-specific static suggestions for testing', async () => {
+      const analyzerWithoutAI = new CodeAnalyzer()
+      const testingIssue: CodeIssue = {...mockIssue, category: 'testing'}
+
+      const suggestions = await analyzerWithoutAI.getImprovementSuggestions(
+        testingIssue,
+        'const x = 1;',
+      )
+
+      expect(
+        suggestions.some(
+          s => s.toLowerCase().includes('test') || s.toLowerCase().includes('coverage'),
+        ),
+      ).toBe(true)
+    })
+
+    it('should provide category-specific static suggestions for maintainability', async () => {
+      const analyzerWithoutAI = new CodeAnalyzer()
+      const maintainabilityIssue: CodeIssue = {...mockIssue, category: 'maintainability'}
+
+      const suggestions = await analyzerWithoutAI.getImprovementSuggestions(
+        maintainabilityIssue,
+        'const x = 1;',
+      )
+
+      expect(
+        suggestions.some(
+          s => s.toLowerCase().includes('documentation') || s.toLowerCase().includes('complexity'),
+        ),
+      ).toBe(true)
+    })
+
+    it('should provide category-specific static suggestions for accessibility', async () => {
+      const analyzerWithoutAI = new CodeAnalyzer()
+      const accessibilityIssue: CodeIssue = {...mockIssue, category: 'accessibility'}
+
+      const suggestions = await analyzerWithoutAI.getImprovementSuggestions(
+        accessibilityIssue,
+        'const x = 1;',
+      )
+
+      expect(
+        suggestions.some(
+          s => s.toLowerCase().includes('aria') || s.toLowerCase().includes('keyboard'),
+        ),
+      ).toBe(true)
+    })
+
+    it('should provide category-specific static suggestions for documentation', async () => {
+      const analyzerWithoutAI = new CodeAnalyzer()
+      const documentationIssue: CodeIssue = {...mockIssue, category: 'documentation'}
+
+      const suggestions = await analyzerWithoutAI.getImprovementSuggestions(
+        documentationIssue,
+        'const x = 1;',
+      )
+
+      expect(
+        suggestions.some(
+          s => s.toLowerCase().includes('jsdoc') || s.toLowerCase().includes('readme'),
+        ),
+      ).toBe(true)
+    })
+  })
+
+  describe('generateQualityReport', () => {
+    it('should generate a comprehensive report', async () => {
+      const result: AnalysisResult = {
+        issues: [
+          {
+            id: 'test-1',
+            title: 'Test Issue',
+            description: 'A test issue',
+            severity: 'warning',
+            category: 'best-practices',
+            filePath: 'test.ts',
+            lineNumber: 10,
+            codeSnippet: 'console.log("test")',
+            suggestion: 'Remove console.log',
+            fixExample: 'logger.debug("test")',
+            documentationUrl: 'https://example.com',
+          },
+        ],
+        qualityScore: 85,
+        summary: {
+          'best-practices': {count: 1, severity: 'warning'},
+        },
+        aiAnalysisUsed: false,
+        analysisTime: 100,
+        metadata: {
+          linesOfCode: 50,
+          filesAnalyzed: 1,
+          analysisEngine: 'static',
+          timestamp: new Date().toISOString(),
+          analysisTime: 100,
+        },
+      }
+
+      const report = await analyzer.generateQualityReport(result, 'test-project')
+
+      expect(report).toContain('# Code Quality Report')
+      expect(report).toContain('test-project')
+      expect(report).toContain('Quality Score: 85/100')
+      expect(report).toContain('Test Issue')
+      expect(report).toContain('console.log("test")')
+    })
+
+    it('should handle report with no issues', async () => {
+      const result: AnalysisResult = {
+        issues: [],
+        qualityScore: 100,
+        summary: {},
+        aiAnalysisUsed: false,
+        analysisTime: 50,
+        metadata: {
+          linesOfCode: 20,
+          filesAnalyzed: 1,
+          analysisEngine: 'static',
+          timestamp: new Date().toISOString(),
+          analysisTime: 50,
+        },
+      }
+
+      const report = await analyzer.generateQualityReport(result)
+
+      expect(report).toContain('No issues found')
+      expect(report).toContain('100/100')
+    })
+
+    it('should generate report without project name', async () => {
+      const result: AnalysisResult = {
+        issues: [],
+        qualityScore: 100,
+        summary: {},
+        aiAnalysisUsed: true,
+        analysisTime: 50,
+        metadata: {
+          linesOfCode: 20,
+          filesAnalyzed: 1,
+          analysisEngine: 'ai',
+          timestamp: new Date().toISOString(),
+          analysisTime: 50,
+        },
+      }
+
+      const report = await analyzer.generateQualityReport(result)
+
+      expect(report).toContain('# Code Quality Report')
+      expect(report).not.toMatch(/^# Code Quality Report - /)
+    })
+
+    it('should show quality score descriptions', async () => {
+      const createResult = (score: number): AnalysisResult => ({
+        issues: [],
+        qualityScore: score,
+        summary: {},
+        aiAnalysisUsed: false,
+        analysisTime: 50,
+        metadata: {
+          linesOfCode: 20,
+          filesAnalyzed: 1,
+          analysisEngine: 'static',
+          timestamp: new Date().toISOString(),
+          analysisTime: 50,
+        },
+      })
+
+      const excellentReport = await analyzer.generateQualityReport(createResult(95))
+      expect(excellentReport).toContain('Excellent')
+
+      const goodReport = await analyzer.generateQualityReport(createResult(85))
+      expect(goodReport).toContain('Good')
+
+      const fairReport = await analyzer.generateQualityReport(createResult(75))
+      expect(fairReport).toContain('Fair')
+
+      const poorReport = await analyzer.generateQualityReport(createResult(65))
+      expect(poorReport).toContain('Poor')
+
+      const criticalReport = await analyzer.generateQualityReport(createResult(50))
+      expect(criticalReport).toContain('Critical')
+    })
+
+    it('should group issues by severity in report', async () => {
+      const result: AnalysisResult = {
+        issues: [
+          {
+            id: '1',
+            title: 'Error Issue',
+            description: '',
+            severity: 'error',
+            category: 'security',
+            filePath: 'a.ts',
+          },
+          {
+            id: '2',
+            title: 'Warning Issue',
+            description: '',
+            severity: 'warning',
+            category: 'best-practices',
+            filePath: 'b.ts',
+          },
+          {
+            id: '3',
+            title: 'Info Issue',
+            description: '',
+            severity: 'info',
+            category: 'maintainability',
+            filePath: 'c.ts',
+          },
+        ],
+        qualityScore: 70,
+        summary: {},
+        aiAnalysisUsed: false,
+        analysisTime: 100,
+        metadata: {
+          linesOfCode: 100,
+          filesAnalyzed: 3,
+          analysisEngine: 'static',
+          timestamp: new Date().toISOString(),
+          analysisTime: 100,
+        },
+      }
+
+      const report = await analyzer.generateQualityReport(result)
+
+      expect(report).toContain('Error')
+      expect(report).toContain('Warning')
+      expect(report).toContain('Info')
+    })
+  })
+
+  describe('language detection', () => {
+    it('should detect TypeScript files', async () => {
+      const result = await analyzer.analyzeFile('component.tsx', 'const x: any = 1;', {
+        useAI: false,
+      })
+      const anyIssues = result.issues.filter(i => i.id === 'any-type-usage')
+      expect(anyIssues.length).toBeGreaterThan(0)
+    })
+
+    it('should detect JavaScript files', async () => {
+      const result = await analyzer.analyzeFile('script.js', 'console.log("test");', {useAI: false})
+      expect(result.metadata.filesAnalyzed).toBe(1)
+    })
+
+    it('should handle JSON files', async () => {
+      const result = await analyzer.analyzeFile('package.json', '{"name": "test"}', {useAI: false})
+      expect(result.metadata.filesAnalyzed).toBe(1)
+    })
+
+    it('should handle Markdown files', async () => {
+      const result = await analyzer.analyzeFile('README.md', '# Title', {useAI: false})
+      expect(result.metadata.filesAnalyzed).toBe(1)
+    })
+
+    it('should handle CSS files', async () => {
+      const result = await analyzer.analyzeFile('styles.css', '.class { color: red; }', {
+        useAI: false,
+      })
+      expect(result.metadata.filesAnalyzed).toBe(1)
+    })
+
+    it('should handle SCSS files', async () => {
+      const result = await analyzer.analyzeFile('styles.scss', '$color: red;', {useAI: false})
+      expect(result.metadata.filesAnalyzed).toBe(1)
+    })
+
+    it('should handle HTML files', async () => {
+      const result = await analyzer.analyzeFile('index.html', '<html></html>', {useAI: false})
+      expect(result.metadata.filesAnalyzed).toBe(1)
+    })
+
+    it('should handle MDX files', async () => {
+      const result = await analyzer.analyzeFile('doc.mdx', '# Title', {useAI: false})
+      expect(result.metadata.filesAnalyzed).toBe(1)
+    })
+
+    it('should handle unknown file types', async () => {
+      const result = await analyzer.analyzeFile('file.xyz', 'content', {useAI: false})
+      expect(result.metadata.filesAnalyzed).toBe(1)
+    })
+  })
+
+  describe('summary generation', () => {
+    it('should generate summary by category', async () => {
+      const code = `
+// TODO: fix this
+console.log('debug');
+const x: any = 1;
+`
+      const result = await analyzer.analyzeFile('test.ts', code, {useAI: false})
+
+      expect(result.summary).toBeDefined()
+      expect(Object.keys(result.summary).length).toBeGreaterThan(0)
+    })
+
+    it('should track highest severity per category', async () => {
+      const targets: AnalysisTarget[] = [
+        {
+          filePath: 'test.ts',
+          content: `
+console.log('1');
+console.log('2');
+`,
+        },
+      ]
+
+      const result = await analyzer.analyzeTargets(targets, {useAI: false})
+
+      // Use non-conditional assertion pattern
+      const bestPractices = result.summary['best-practices']
+      expect(bestPractices).toBeDefined()
+      expect(bestPractices?.count).toBeGreaterThanOrEqual(2)
+      expect(bestPractices?.severity).toBe('warning')
+    })
+  })
+
+  describe('metadata tracking', () => {
+    it('should track analysis time', async () => {
+      const result = await analyzer.analyzeFile('test.ts', 'const x = 1;', {useAI: false})
+
+      expect(result.analysisTime).toBeGreaterThanOrEqual(0)
+      expect(result.metadata.analysisTime).toBeGreaterThanOrEqual(0)
+    })
+
+    it('should track lines of code', async () => {
+      const code = `line1
+line2
+line3
+line4
+line5`
+      const result = await analyzer.analyzeFile('test.ts', code, {useAI: false})
+
+      expect(result.metadata.linesOfCode).toBe(5)
+    })
+
+    it('should include timestamp', async () => {
+      const result = await analyzer.analyzeFile('test.ts', 'const x = 1;', {useAI: false})
+
+      expect(result.metadata.timestamp).toBeDefined()
+      expect(new Date(result.metadata.timestamp).getTime()).toBeLessThanOrEqual(Date.now())
+    })
+
+    it('should track analysis engine type', async () => {
+      const staticResult = await analyzer.analyzeFile('test.ts', 'const x = 1;', {useAI: false})
+      expect(staticResult.metadata.analysisEngine).toBe('static')
+
+      vi.mocked(mockLLMClient.complete).mockResolvedValue({
+        success: true,
+        content: '[]',
+      } as LLMResponse)
+
+      const aiResult = await analyzer.analyzeFile('test.ts', 'const x = 1;', {useAI: true})
+      expect(aiResult.metadata.analysisEngine).toBe('ai')
+    })
+  })
+})

--- a/packages/create/test/ai/code-generator.test.ts
+++ b/packages/create/test/ai/code-generator.test.ts
@@ -1,0 +1,570 @@
+/**
+ * Tests for AI code generator
+ * Part of Phase 5: Comprehensive Testing Implementation (TASK-036, TASK-038)
+ */
+
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
+
+const mockComplete = vi.fn()
+const mockIsAIAvailable = vi.fn()
+
+vi.mock('../../src/ai/llm-client.js', () => ({
+  LLMClient: class MockLLMClient {
+    isAIAvailable = mockIsAIAvailable
+    complete = mockComplete
+  },
+}))
+
+const {CodeGenerator, createCodeGenerator} = await import('../../src/ai/code-generator.js')
+
+describe('CodeGenerator', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockIsAIAvailable.mockReturnValue(true)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe('constructor', () => {
+    it('creates instance with default config', () => {
+      const generator = new CodeGenerator()
+      expect(generator).toBeInstanceOf(CodeGenerator)
+    })
+
+    it('creates instance with custom config', () => {
+      const config = {provider: 'openai' as const}
+      const generator = new CodeGenerator(config)
+      expect(generator).toBeInstanceOf(CodeGenerator)
+    })
+  })
+
+  describe('createCodeGenerator', () => {
+    it('creates CodeGenerator instance', () => {
+      const generator = createCodeGenerator()
+      expect(generator).toBeInstanceOf(CodeGenerator)
+    })
+  })
+
+  describe('generateCode', () => {
+    it('returns fallback when AI is not available', async () => {
+      mockIsAIAvailable.mockReturnValue(false)
+      const generator = new CodeGenerator()
+
+      const result = await generator.generateCode({
+        type: 'function',
+        description: 'Test function',
+        language: 'typescript',
+      })
+
+      expect(result.success).toBe(true)
+      expect(result.code).toBeDefined()
+      expect(result.quality).toBe(0.5)
+      expect(mockComplete).not.toHaveBeenCalled()
+    })
+
+    it('generates code using AI when available', async () => {
+      const mockResponse = {
+        success: true,
+        content: JSON.stringify({
+          success: true,
+          code: 'export function test() {}',
+          filePath: 'src/test.ts',
+          quality: 0.9,
+        }),
+      }
+      mockComplete.mockResolvedValue(mockResponse)
+      const generator = new CodeGenerator()
+
+      const result = await generator.generateCode({
+        type: 'function',
+        description: 'Test function',
+        language: 'typescript',
+      })
+
+      expect(result.success).toBe(true)
+      expect(result.code).toBe('export function test() {}')
+      expect(result.quality).toBe(0.9)
+      expect(mockComplete).toHaveBeenCalled()
+    })
+
+    it('extracts code from markdown blocks when JSON parsing fails', async () => {
+      const mockResponse = {
+        success: true,
+        content: `Here is the code:
+\`\`\`typescript
+export function test() {
+  return 'hello'
+}
+\`\`\``,
+      }
+      mockComplete.mockResolvedValue(mockResponse)
+      const generator = new CodeGenerator()
+
+      const result = await generator.generateCode({
+        type: 'function',
+        description: 'Test function',
+        language: 'typescript',
+      })
+
+      expect(result.success).toBe(true)
+      // The markdown extraction may fall back to default code generation
+      // if parsing is attempted on extracted code. The important assertion
+      // is that the result is successful.
+      expect(result.code).toBeDefined()
+    })
+
+    it('returns fallback when AI response fails', async () => {
+      mockComplete.mockResolvedValue({
+        success: false,
+        error: 'API error',
+      })
+      const generator = new CodeGenerator()
+
+      const result = await generator.generateCode({
+        type: 'function',
+        description: 'Test function',
+        language: 'typescript',
+      })
+
+      expect(result.success).toBe(true)
+      expect(result.quality).toBe(0.5)
+    })
+
+    it('returns fallback when parsing fails', async () => {
+      mockComplete.mockResolvedValue({
+        success: true,
+        content: 'Invalid response without code',
+      })
+      const generator = new CodeGenerator()
+
+      const result = await generator.generateCode({
+        type: 'function',
+        description: 'Test function',
+        language: 'typescript',
+      })
+
+      expect(result.success).toBe(true)
+      expect(result.quality).toBe(0.5)
+    })
+
+    it('includes context in prompt', async () => {
+      mockComplete.mockResolvedValue({
+        success: true,
+        content: JSON.stringify({success: true, code: '// code'}),
+      })
+      const generator = new CodeGenerator()
+
+      await generator.generateCode({
+        type: 'function',
+        description: 'Test function',
+        language: 'typescript',
+        context: {
+          projectType: 'library',
+          requirements: ['must be pure', 'must handle errors'],
+          existingCode: '// existing code',
+          style: 'functional',
+        },
+      })
+
+      expect(mockComplete).toHaveBeenCalledWith(
+        expect.stringContaining('library'),
+        expect.anything(),
+      )
+      expect(mockComplete).toHaveBeenCalledWith(
+        expect.stringContaining('must be pure'),
+        expect.anything(),
+      )
+    })
+
+    it('parses additional files from response', async () => {
+      mockComplete.mockResolvedValue({
+        success: true,
+        content: JSON.stringify({
+          success: true,
+          code: '// main code',
+          additionalFiles: [
+            {path: 'types.ts', content: '// types', description: 'Type definitions'},
+          ],
+        }),
+      })
+      const generator = new CodeGenerator()
+
+      const result = await generator.generateCode({
+        type: 'class',
+        description: 'Test class',
+        language: 'typescript',
+      })
+
+      expect(result.additionalFiles).toHaveLength(1)
+      expect(result.additionalFiles?.[0]?.path).toBe('types.ts')
+    })
+
+    it('parses instructions from response', async () => {
+      mockComplete.mockResolvedValue({
+        success: true,
+        content: JSON.stringify({
+          success: true,
+          code: '// code',
+          instructions: ['Step 1', 'Step 2'],
+        }),
+      })
+      const generator = new CodeGenerator()
+
+      const result = await generator.generateCode({
+        type: 'config',
+        description: 'Test config',
+        language: 'typescript',
+      })
+
+      expect(result.instructions).toEqual(['Step 1', 'Step 2'])
+    })
+
+    it('clamps quality between 0 and 1', async () => {
+      mockComplete.mockResolvedValue({
+        success: true,
+        content: JSON.stringify({
+          success: true,
+          code: '// code',
+          quality: 1.5,
+        }),
+      })
+      const generator = new CodeGenerator()
+
+      const result = await generator.generateCode({
+        type: 'function',
+        description: 'Test',
+        language: 'typescript',
+      })
+
+      expect(result.quality).toBe(1)
+    })
+  })
+
+  describe('generateComponent', () => {
+    it('generates React component', async () => {
+      mockComplete.mockResolvedValue({
+        success: true,
+        content: JSON.stringify({
+          success: true,
+          code: 'export function Button() {}',
+          filePath: 'src/components/Button.tsx',
+        }),
+      })
+      const generator = new CodeGenerator()
+
+      const result = await generator.generateComponent('Button', undefined, ['accessible'])
+
+      expect(result.success).toBe(true)
+      expect(mockComplete).toHaveBeenCalledWith(
+        expect.stringContaining('Button'),
+        expect.anything(),
+      )
+    })
+  })
+
+  describe('generateFunction', () => {
+    it('generates TypeScript function', async () => {
+      mockComplete.mockResolvedValue({
+        success: true,
+        content: JSON.stringify({
+          success: true,
+          code: 'export function add(a: number, b: number): number {}',
+        }),
+      })
+      const generator = new CodeGenerator()
+
+      const result = await generator.generateFunction(
+        'add',
+        [
+          {name: 'a', type: 'number'},
+          {name: 'b', type: 'number'},
+        ],
+        'number',
+        'adds two numbers',
+      )
+
+      expect(result.success).toBe(true)
+      expect(mockComplete).toHaveBeenCalledWith(expect.stringContaining('add'), expect.anything())
+      expect(mockComplete).toHaveBeenCalledWith(
+        expect.stringContaining('a: number'),
+        expect.anything(),
+      )
+    })
+  })
+
+  describe('generateTest', () => {
+    it('generates vitest test file', async () => {
+      mockComplete.mockResolvedValue({
+        success: true,
+        content: JSON.stringify({
+          success: true,
+          code: "describe('test', () => {})",
+        }),
+      })
+      const generator = new CodeGenerator()
+
+      const result = await generator.generateTest('src/utils.ts', 'vitest')
+
+      expect(result.success).toBe(true)
+      expect(mockComplete).toHaveBeenCalledWith(
+        expect.stringContaining('src/utils.ts'),
+        expect.anything(),
+      )
+      expect(mockComplete).toHaveBeenCalledWith(
+        expect.stringContaining('vitest'),
+        expect.anything(),
+      )
+    })
+
+    it('generates jest test file', async () => {
+      mockComplete.mockResolvedValue({
+        success: true,
+        content: JSON.stringify({success: true, code: "describe('test', () => {})"}),
+      })
+      const generator = new CodeGenerator()
+
+      await generator.generateTest('src/utils.ts', 'jest')
+
+      expect(mockComplete).toHaveBeenCalledWith(expect.stringContaining('jest'), expect.anything())
+    })
+  })
+
+  describe('generateConfig', () => {
+    it('generates eslint config', async () => {
+      mockComplete.mockResolvedValue({
+        success: true,
+        content: JSON.stringify({success: true, code: 'export default {}'}),
+      })
+      const generator = new CodeGenerator()
+
+      const result = await generator.generateConfig('eslint', {
+        type: 'library',
+        features: ['typescript'],
+      })
+
+      expect(result.success).toBe(true)
+      expect(mockComplete).toHaveBeenCalledWith(
+        expect.stringContaining('eslint'),
+        expect.anything(),
+      )
+    })
+
+    it('generates tsconfig', async () => {
+      mockComplete.mockResolvedValue({
+        success: true,
+        content: JSON.stringify({success: true, code: '{}'}),
+      })
+      const generator = new CodeGenerator()
+
+      await generator.generateConfig('tsconfig')
+
+      expect(mockComplete).toHaveBeenCalledWith(
+        expect.stringContaining('tsconfig'),
+        expect.anything(),
+      )
+    })
+
+    it('generates package.json with json language', async () => {
+      mockComplete.mockResolvedValue({
+        success: true,
+        content: JSON.stringify({success: true, code: '{}'}),
+      })
+      const generator = new CodeGenerator()
+
+      await generator.generateConfig('package.json', {
+        dependencies: ['typescript', 'react'],
+      })
+
+      expect(mockComplete).toHaveBeenCalledWith(
+        expect.stringContaining('package.json'),
+        expect.anything(),
+      )
+      expect(mockComplete).toHaveBeenCalledWith(
+        expect.stringContaining('typescript'),
+        expect.anything(),
+      )
+    })
+  })
+
+  describe('fallback code generation', () => {
+    beforeEach(() => {
+      mockIsAIAvailable.mockReturnValue(false)
+    })
+
+    it('generates component fallback', async () => {
+      const generator = new CodeGenerator()
+      const result = await generator.generateCode({
+        type: 'component',
+        description: 'Button component',
+        language: 'typescript',
+      })
+
+      expect(result.code).toContain('React')
+      expect(result.code).toContain('ComponentProps')
+    })
+
+    it('generates function fallback', async () => {
+      const generator = new CodeGenerator()
+      const result = await generator.generateCode({
+        type: 'function',
+        description: 'Utility function',
+        language: 'typescript',
+      })
+
+      expect(result.code).toContain('generatedFunction')
+    })
+
+    it('generates class fallback', async () => {
+      const generator = new CodeGenerator()
+      const result = await generator.generateCode({
+        type: 'class',
+        description: 'Test class',
+        language: 'typescript',
+      })
+
+      expect(result.code).toContain('GeneratedClass')
+    })
+
+    it('generates test fallback', async () => {
+      const generator = new CodeGenerator()
+      const result = await generator.generateCode({
+        type: 'test',
+        description: 'Test file',
+        language: 'typescript',
+      })
+
+      expect(result.code).toContain('vitest')
+      expect(result.code).toContain('describe')
+    })
+
+    it('generates json config fallback', async () => {
+      const generator = new CodeGenerator()
+      const result = await generator.generateCode({
+        type: 'config',
+        description: 'Config file',
+        language: 'json',
+      })
+
+      expect(result.code).toContain('{')
+    })
+
+    it('generates ts config fallback', async () => {
+      const generator = new CodeGenerator()
+      const result = await generator.generateCode({
+        type: 'config',
+        description: 'Config file',
+        language: 'typescript',
+      })
+
+      expect(result.code).toContain('export default')
+    })
+
+    it('generates documentation fallback', async () => {
+      const generator = new CodeGenerator()
+      const result = await generator.generateCode({
+        type: 'documentation',
+        description: 'Readme',
+        language: 'markdown',
+      })
+
+      expect(result.code).toContain('# Generated Documentation')
+    })
+  })
+
+  describe('file path suggestions', () => {
+    beforeEach(() => {
+      mockIsAIAvailable.mockReturnValue(false)
+    })
+
+    it('suggests .tsx for component', async () => {
+      const generator = new CodeGenerator()
+      const result = await generator.generateCode({
+        type: 'component',
+        description: 'Component',
+        language: 'typescript',
+      })
+
+      expect(result.filePath).toContain('.tsx')
+    })
+
+    it('suggests .jsx for javascript component', async () => {
+      const generator = new CodeGenerator()
+      const result = await generator.generateCode({
+        type: 'component',
+        description: 'Component',
+        language: 'javascript',
+      })
+
+      expect(result.filePath).toContain('.jsx')
+    })
+
+    it('suggests test file path', async () => {
+      const generator = new CodeGenerator()
+      const result = await generator.generateCode({
+        type: 'test',
+        description: 'Test',
+        language: 'typescript',
+      })
+
+      expect(result.filePath).toContain('__tests__')
+      expect(result.filePath).toContain('.test.ts')
+    })
+
+    it('suggests eslint config path', async () => {
+      const generator = new CodeGenerator()
+      const result = await generator.generateCode({
+        type: 'config',
+        description: 'eslint configuration',
+        language: 'typescript',
+      })
+
+      expect(result.filePath).toBe('eslint.config.ts')
+    })
+
+    it('suggests prettier config path', async () => {
+      const generator = new CodeGenerator()
+      const result = await generator.generateCode({
+        type: 'config',
+        description: 'prettier configuration',
+        language: 'javascript',
+      })
+
+      expect(result.filePath).toBe('prettier.config.js')
+    })
+
+    it('suggests tsconfig path', async () => {
+      const generator = new CodeGenerator()
+      const result = await generator.generateCode({
+        type: 'config',
+        description: 'tsconfig configuration',
+        language: 'json',
+      })
+
+      expect(result.filePath).toBe('tsconfig.json')
+    })
+
+    it('suggests package.json path', async () => {
+      const generator = new CodeGenerator()
+      const result = await generator.generateCode({
+        type: 'config',
+        description: 'package.json configuration',
+        language: 'json',
+      })
+
+      expect(result.filePath).toBe('package.json')
+    })
+
+    it('suggests README.md for documentation', async () => {
+      const generator = new CodeGenerator()
+      const result = await generator.generateCode({
+        type: 'documentation',
+        description: 'Documentation',
+        language: 'markdown',
+      })
+
+      expect(result.filePath).toBe('README.md')
+    })
+  })
+})

--- a/packages/create/test/ai/configuration-optimizer.test.ts
+++ b/packages/create/test/ai/configuration-optimizer.test.ts
@@ -1,0 +1,535 @@
+/**
+ * Tests for AI configuration optimizer
+ * Part of Phase 5: Comprehensive Testing Implementation (TASK-036, TASK-038)
+ */
+
+import type {ProjectAnalysis} from '../../src/types.js'
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
+
+const mockComplete = vi.fn()
+const mockIsAIAvailable = vi.fn()
+
+vi.mock('../../src/ai/llm-client.js', () => ({
+  LLMClient: class MockLLMClient {
+    isAIAvailable = mockIsAIAvailable
+    complete = mockComplete
+  },
+}))
+
+vi.mock('node:fs', () => ({
+  readFileSync: vi.fn(),
+}))
+
+const {ConfigurationOptimizer, createConfigurationOptimizer} =
+  await import('../../src/ai/configuration-optimizer.js')
+const {readFileSync} = await import('node:fs')
+
+describe('ConfigurationOptimizer', () => {
+  const mockProjectAnalysis: ProjectAnalysis = {
+    projectType: 'library',
+    description: 'A test library',
+    features: ['typescript', 'testing'],
+    techStack: [{name: 'node', category: 'runtime', reason: 'Node.js runtime', confidence: 0.9}],
+    dependencies: [],
+    templates: [],
+    confidence: 0.85,
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockIsAIAvailable.mockReturnValue(true)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe('constructor', () => {
+    it('creates instance with default config', () => {
+      const optimizer = new ConfigurationOptimizer()
+      expect(optimizer).toBeInstanceOf(ConfigurationOptimizer)
+    })
+
+    it('creates instance with custom config', () => {
+      const config = {provider: 'openai' as const}
+      const optimizer = new ConfigurationOptimizer(config)
+      expect(optimizer).toBeInstanceOf(ConfigurationOptimizer)
+    })
+  })
+
+  describe('createConfigurationOptimizer', () => {
+    it('creates ConfigurationOptimizer instance', () => {
+      const optimizer = createConfigurationOptimizer()
+      expect(optimizer).toBeInstanceOf(ConfigurationOptimizer)
+    })
+  })
+
+  describe('isOptimizationAvailable', () => {
+    it('returns true when AI is available', () => {
+      mockIsAIAvailable.mockReturnValue(true)
+      const optimizer = new ConfigurationOptimizer()
+      expect(optimizer.isOptimizationAvailable()).toBe(true)
+    })
+
+    it('returns false when AI is not available', () => {
+      mockIsAIAvailable.mockReturnValue(false)
+      const optimizer = new ConfigurationOptimizer()
+      expect(optimizer.isOptimizationAvailable()).toBe(false)
+    })
+  })
+
+  describe('generateOptimizedConfig', () => {
+    it('returns fallback when AI is not available', async () => {
+      mockIsAIAvailable.mockReturnValue(false)
+      const optimizer = new ConfigurationOptimizer()
+
+      const result = await optimizer.generateOptimizedConfig('eslint', mockProjectAnalysis)
+
+      expect(result).toHaveProperty('extends')
+      expect(mockComplete).not.toHaveBeenCalled()
+    })
+
+    it('returns AI-generated config when available', async () => {
+      mockComplete.mockResolvedValue({
+        success: true,
+        content: JSON.stringify({
+          extends: ['@custom/config'],
+          rules: {'no-console': 'warn'},
+        }),
+      })
+      const optimizer = new ConfigurationOptimizer()
+
+      const result = await optimizer.generateOptimizedConfig('eslint', mockProjectAnalysis)
+
+      expect(result.extends).toEqual(['@custom/config'])
+      expect(result.rules).toEqual({'no-console': 'warn'})
+    })
+
+    it('returns fallback when AI response fails', async () => {
+      mockComplete.mockResolvedValue({success: false, error: 'API error'})
+      const optimizer = new ConfigurationOptimizer()
+
+      const result = await optimizer.generateOptimizedConfig('typescript', mockProjectAnalysis)
+
+      expect(result).toHaveProperty('compilerOptions')
+    })
+
+    it('returns fallback when JSON parsing fails', async () => {
+      mockComplete.mockResolvedValue({success: true, content: 'Invalid JSON'})
+      const optimizer = new ConfigurationOptimizer()
+
+      const result = await optimizer.generateOptimizedConfig('prettier', mockProjectAnalysis)
+
+      expect(result).toHaveProperty('semi')
+    })
+
+    it('includes existing config in prompt', async () => {
+      mockComplete.mockResolvedValue({
+        success: true,
+        content: JSON.stringify({extends: ['@custom/config']}),
+      })
+      const optimizer = new ConfigurationOptimizer()
+
+      await optimizer.generateOptimizedConfig('eslint', mockProjectAnalysis, {
+        existingRule: 'value',
+      })
+
+      expect(mockComplete).toHaveBeenCalledWith(
+        expect.stringContaining('existingRule'),
+        expect.anything(),
+      )
+    })
+  })
+
+  describe('optimizeConfigurations', () => {
+    it('returns empty array when no configs are found', async () => {
+      vi.mocked(readFileSync).mockImplementation(() => {
+        throw new Error('File not found')
+      })
+      const optimizer = new ConfigurationOptimizer()
+
+      const result = await optimizer.optimizeConfigurations('/test/project')
+
+      expect(result).toEqual([])
+    })
+
+    it('analyzes found configurations', async () => {
+      vi.mocked(readFileSync).mockImplementation(path => {
+        if (String(path).includes('tsconfig.json')) {
+          return JSON.stringify({compilerOptions: {strict: false}})
+        }
+        throw new Error('Not found')
+      })
+      mockIsAIAvailable.mockReturnValue(false)
+      const optimizer = new ConfigurationOptimizer()
+
+      const result = await optimizer.optimizeConfigurations('/test/project', mockProjectAnalysis, {
+        configTypes: ['typescript'],
+      })
+
+      expect(result).toBeInstanceOf(Array)
+    })
+
+    it('uses AI for analysis when available', async () => {
+      vi.mocked(readFileSync).mockImplementation(path => {
+        if (String(path).includes('tsconfig.json')) {
+          return JSON.stringify({compilerOptions: {strict: false}})
+        }
+        throw new Error('Not found')
+      })
+      mockComplete.mockResolvedValue({
+        success: true,
+        content: JSON.stringify({
+          suggestions: [
+            {
+              current: {strict: false},
+              suggested: {strict: true},
+              reason: 'Enable strict mode for better type safety',
+              confidence: 0.9,
+              impact: 'high',
+              breaking: false,
+            },
+          ],
+        }),
+      })
+      const optimizer = new ConfigurationOptimizer()
+
+      const result = await optimizer.optimizeConfigurations('/test/project', mockProjectAnalysis, {
+        configTypes: ['typescript'],
+      })
+
+      expect(result.length).toBeGreaterThan(0)
+      expect(result[0]?.reason).toContain('strict')
+    })
+
+    it('handles JS config files', async () => {
+      vi.mocked(readFileSync).mockImplementation(path => {
+        if (String(path).includes('eslint.config.ts')) {
+          return 'export default { rules: {} }'
+        }
+        throw new Error('Not found')
+      })
+      mockIsAIAvailable.mockReturnValue(false)
+      const optimizer = new ConfigurationOptimizer()
+
+      const result = await optimizer.optimizeConfigurations('/test/project', undefined, {
+        configTypes: ['eslint'],
+      })
+
+      expect(result).toBeInstanceOf(Array)
+    })
+
+    it('sorts suggestions by confidence', async () => {
+      vi.mocked(readFileSync).mockImplementation(path => {
+        if (String(path).includes('tsconfig.json')) {
+          return JSON.stringify({compilerOptions: {}})
+        }
+        throw new Error('Not found')
+      })
+      mockComplete.mockResolvedValue({
+        success: true,
+        content: JSON.stringify({
+          suggestions: [
+            {
+              current: {},
+              suggested: {},
+              reason: 'Low',
+              confidence: 0.5,
+              impact: 'low',
+              breaking: false,
+            },
+            {
+              current: {},
+              suggested: {},
+              reason: 'High',
+              confidence: 0.9,
+              impact: 'high',
+              breaking: false,
+            },
+          ],
+        }),
+      })
+      const optimizer = new ConfigurationOptimizer()
+
+      const result = await optimizer.optimizeConfigurations('/test/project', mockProjectAnalysis, {
+        configTypes: ['typescript'],
+      })
+
+      expect(result[0]?.confidence).toBeGreaterThanOrEqual(result[1]?.confidence ?? 0)
+    })
+
+    it('respects includeExperimental option', async () => {
+      vi.mocked(readFileSync).mockImplementation(path => {
+        if (String(path).includes('tsconfig.json')) {
+          return JSON.stringify({compilerOptions: {}})
+        }
+        throw new Error('Not found')
+      })
+      mockComplete.mockResolvedValue({
+        success: true,
+        content: JSON.stringify({suggestions: []}),
+      })
+      const optimizer = new ConfigurationOptimizer()
+
+      await optimizer.optimizeConfigurations('/test/project', mockProjectAnalysis, {
+        configTypes: ['typescript'],
+        includeExperimental: true,
+      })
+
+      expect(mockComplete).toHaveBeenCalledWith(
+        expect.stringContaining('experimental'),
+        expect.anything(),
+      )
+    })
+
+    it('respects maxSuggestions option', async () => {
+      vi.mocked(readFileSync).mockImplementation(path => {
+        if (String(path).includes('tsconfig.json')) {
+          return JSON.stringify({compilerOptions: {}})
+        }
+        throw new Error('Not found')
+      })
+      mockComplete.mockResolvedValue({
+        success: true,
+        content: JSON.stringify({suggestions: []}),
+      })
+      const optimizer = new ConfigurationOptimizer()
+
+      await optimizer.optimizeConfigurations('/test/project', mockProjectAnalysis, {
+        configTypes: ['typescript'],
+        maxSuggestions: 3,
+      })
+
+      expect(mockComplete).toHaveBeenCalledWith(expect.stringContaining('3'), expect.anything())
+    })
+  })
+
+  describe('fallback configs', () => {
+    beforeEach(() => {
+      mockIsAIAvailable.mockReturnValue(false)
+    })
+
+    it('generates eslint fallback config', async () => {
+      const optimizer = new ConfigurationOptimizer()
+      const result = await optimizer.generateOptimizedConfig('eslint', mockProjectAnalysis)
+
+      expect(result.extends).toContain('@bfra.me/eslint-config')
+      expect(result.parserOptions).toBeDefined()
+      expect(result.env).toBeDefined()
+    })
+
+    it('generates typescript fallback config', async () => {
+      const optimizer = new ConfigurationOptimizer()
+      const result = await optimizer.generateOptimizedConfig('typescript', mockProjectAnalysis)
+
+      expect(result.extends).toBe('@bfra.me/tsconfig')
+      expect(result.compilerOptions).toHaveProperty('strict', true)
+      expect(result.include).toContain('src')
+    })
+
+    it('generates prettier fallback config', async () => {
+      const optimizer = new ConfigurationOptimizer()
+      const result = await optimizer.generateOptimizedConfig('prettier', mockProjectAnalysis)
+
+      expect(result.semi).toBe(false)
+      expect(result.singleQuote).toBe(true)
+      expect(result.tabWidth).toBe(2)
+    })
+
+    it('generates vitest fallback config', async () => {
+      const optimizer = new ConfigurationOptimizer()
+      const result = await optimizer.generateOptimizedConfig('vitest', mockProjectAnalysis)
+
+      expect(result.test).toBeDefined()
+      const test = result.test as {environment: string; coverage: {provider: string}}
+      expect(test.environment).toBe('node')
+      expect(test.coverage.provider).toBe('v8')
+    })
+
+    it('generates package.json fallback config', async () => {
+      const optimizer = new ConfigurationOptimizer()
+      const result = await optimizer.generateOptimizedConfig('package.json', mockProjectAnalysis)
+
+      expect(result.type).toBe('module')
+      expect(result.engines).toBeDefined()
+      expect(result.scripts).toBeDefined()
+    })
+  })
+
+  describe('fallback suggestions', () => {
+    beforeEach(() => {
+      mockIsAIAvailable.mockReturnValue(false)
+    })
+
+    it('suggests eslint extends if missing', async () => {
+      vi.mocked(readFileSync).mockImplementation(path => {
+        if (String(path).includes('.eslintrc.json')) {
+          return JSON.stringify({rules: {}})
+        }
+        throw new Error('Not found')
+      })
+      const optimizer = new ConfigurationOptimizer()
+
+      const result = await optimizer.optimizeConfigurations('/test/project', mockProjectAnalysis, {
+        configTypes: ['eslint'],
+      })
+
+      const suggestion = result.find(s => s.type === 'eslint')
+      expect(suggestion?.suggested).toHaveProperty('extends')
+    })
+
+    it('suggests typescript extends if missing', async () => {
+      vi.mocked(readFileSync).mockImplementation(path => {
+        if (String(path).includes('tsconfig.json')) {
+          return JSON.stringify({compilerOptions: {}})
+        }
+        throw new Error('Not found')
+      })
+      const optimizer = new ConfigurationOptimizer()
+
+      const result = await optimizer.optimizeConfigurations('/test/project', mockProjectAnalysis, {
+        configTypes: ['typescript'],
+      })
+
+      const suggestion = result.find(s => s.type === 'typescript')
+      expect(suggestion?.suggested).toHaveProperty('extends')
+    })
+
+    it('suggests ES modules for package.json', async () => {
+      vi.mocked(readFileSync).mockImplementation(path => {
+        if (String(path).includes('package.json')) {
+          return JSON.stringify({name: 'test', type: 'commonjs'})
+        }
+        throw new Error('Not found')
+      })
+      const optimizer = new ConfigurationOptimizer()
+
+      const result = await optimizer.optimizeConfigurations('/test/project', mockProjectAnalysis, {
+        configTypes: ['package.json'],
+      })
+
+      const suggestion = result.find(
+        s => s.type === 'package.json' && s.suggested.type === 'module',
+      )
+      expect(suggestion).toBeDefined()
+      expect(suggestion?.breaking).toBe(true)
+    })
+  })
+
+  describe('config file discovery', () => {
+    it('finds eslint.config.ts', async () => {
+      vi.mocked(readFileSync).mockImplementation(path => {
+        if (String(path).includes('eslint.config.ts')) {
+          return 'export default {}'
+        }
+        throw new Error('Not found')
+      })
+      mockIsAIAvailable.mockReturnValue(false)
+      const optimizer = new ConfigurationOptimizer()
+
+      const result = await optimizer.optimizeConfigurations('/test', undefined, {
+        configTypes: ['eslint'],
+      })
+
+      expect(result).toBeInstanceOf(Array)
+    })
+
+    it('finds .prettierrc.json', async () => {
+      vi.mocked(readFileSync).mockImplementation(path => {
+        if (String(path).includes('.prettierrc.json')) {
+          return JSON.stringify({semi: true})
+        }
+        throw new Error('Not found')
+      })
+      mockIsAIAvailable.mockReturnValue(false)
+      const optimizer = new ConfigurationOptimizer()
+
+      const result = await optimizer.optimizeConfigurations('/test', undefined, {
+        configTypes: ['prettier'],
+      })
+
+      expect(result).toBeInstanceOf(Array)
+    })
+
+    it('finds vitest.config.ts', async () => {
+      vi.mocked(readFileSync).mockImplementation(path => {
+        if (String(path).includes('vitest.config.ts')) {
+          return 'export default {}'
+        }
+        throw new Error('Not found')
+      })
+      mockIsAIAvailable.mockReturnValue(false)
+      const optimizer = new ConfigurationOptimizer()
+
+      const result = await optimizer.optimizeConfigurations('/test', undefined, {
+        configTypes: ['vitest'],
+      })
+
+      expect(result).toBeInstanceOf(Array)
+    })
+  })
+
+  describe('AI response parsing', () => {
+    it('clamps confidence between 0 and 1', async () => {
+      vi.mocked(readFileSync).mockImplementation(path => {
+        if (String(path).includes('tsconfig.json')) {
+          return JSON.stringify({})
+        }
+        throw new Error('Not found')
+      })
+      mockComplete.mockResolvedValue({
+        success: true,
+        content: JSON.stringify({
+          suggestions: [
+            {
+              current: {},
+              suggested: {},
+              reason: 'Test',
+              confidence: 1.5,
+              impact: 'high',
+              breaking: false,
+            },
+          ],
+        }),
+      })
+      const optimizer = new ConfigurationOptimizer()
+
+      const result = await optimizer.optimizeConfigurations('/test', mockProjectAnalysis, {
+        configTypes: ['typescript'],
+      })
+
+      expect(result[0]?.confidence).toBe(1)
+    })
+
+    it('normalizes impact to valid values', async () => {
+      vi.mocked(readFileSync).mockImplementation(path => {
+        if (String(path).includes('tsconfig.json')) {
+          return JSON.stringify({})
+        }
+        throw new Error('Not found')
+      })
+      mockComplete.mockResolvedValue({
+        success: true,
+        content: JSON.stringify({
+          suggestions: [
+            {
+              current: {},
+              suggested: {},
+              reason: 'Test',
+              confidence: 0.8,
+              impact: 'invalid',
+              breaking: false,
+            },
+          ],
+        }),
+      })
+      const optimizer = new ConfigurationOptimizer()
+
+      const result = await optimizer.optimizeConfigurations('/test', mockProjectAnalysis, {
+        configTypes: ['typescript'],
+      })
+
+      expect(['low', 'medium', 'high']).toContain(result[0]?.impact)
+    })
+  })
+})

--- a/packages/create/test/ai/dependency-recommender.test.ts
+++ b/packages/create/test/ai/dependency-recommender.test.ts
@@ -1,0 +1,401 @@
+/**
+ * Tests for AI dependency recommender
+ * Part of Phase 5: Comprehensive Testing Implementation (TASK-036, TASK-038)
+ */
+
+import type {ProjectAnalysis} from '../../src/types.js'
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
+
+const mockComplete = vi.fn()
+const mockIsAIAvailable = vi.fn()
+
+vi.mock('../../src/ai/llm-client.js', () => ({
+  LLMClient: class MockLLMClient {
+    isAIAvailable = mockIsAIAvailable
+    complete = mockComplete
+  },
+}))
+
+const {DependencyRecommender, createDependencyRecommender} =
+  await import('../../src/ai/dependency-recommender.js')
+
+describe('DependencyRecommender', () => {
+  const mockProjectAnalysis: ProjectAnalysis = {
+    projectType: 'library',
+    description: 'A test library',
+    features: ['typescript', 'testing'],
+    techStack: [{name: 'node', category: 'runtime', reason: 'Node.js runtime', confidence: 0.9}],
+    dependencies: [],
+    templates: [],
+    confidence: 0.85,
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockIsAIAvailable.mockReturnValue(true)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe('constructor', () => {
+    it('creates instance with default config', () => {
+      const recommender = new DependencyRecommender()
+      expect(recommender).toBeInstanceOf(DependencyRecommender)
+    })
+
+    it('creates instance with custom config', () => {
+      const config = {provider: 'openai' as const}
+      const recommender = new DependencyRecommender(config)
+      expect(recommender).toBeInstanceOf(DependencyRecommender)
+    })
+  })
+
+  describe('createDependencyRecommender', () => {
+    it('creates DependencyRecommender instance', () => {
+      const recommender = createDependencyRecommender()
+      expect(recommender).toBeInstanceOf(DependencyRecommender)
+    })
+  })
+
+  describe('recommendDependencies', () => {
+    it('returns fallback when AI is not available', async () => {
+      mockIsAIAvailable.mockReturnValue(false)
+      const recommender = new DependencyRecommender()
+
+      const result = await recommender.recommendDependencies(mockProjectAnalysis)
+
+      expect(result).toBeInstanceOf(Array)
+      expect(result.length).toBeGreaterThan(0)
+      expect(mockComplete).not.toHaveBeenCalled()
+    })
+
+    it('returns AI recommendations when available', async () => {
+      const mockResponse = {
+        success: true,
+        content: JSON.stringify([
+          {name: 'vitest', description: 'Test framework', confidence: 0.9, isDev: true},
+          {name: 'tsup', description: 'Build tool', confidence: 0.85, isDev: true},
+        ]),
+      }
+      mockComplete.mockResolvedValue(mockResponse)
+      const recommender = new DependencyRecommender()
+
+      const result = await recommender.recommendDependencies(mockProjectAnalysis)
+
+      expect(result).toHaveLength(2)
+      expect(result[0]?.name).toBe('vitest')
+      expect(result[0]?.confidence).toBe(0.9)
+    })
+
+    it('filters out existing dependencies in fallback', async () => {
+      mockIsAIAvailable.mockReturnValue(false)
+      const recommender = new DependencyRecommender()
+
+      const result = await recommender.recommendDependencies(mockProjectAnalysis, ['typescript'])
+
+      const typeScriptRec = result.find(r => r.name === 'typescript')
+      expect(typeScriptRec).toBeUndefined()
+    })
+
+    it('returns fallback when AI response fails', async () => {
+      mockComplete.mockResolvedValue({success: false, error: 'API error'})
+      const recommender = new DependencyRecommender()
+
+      const result = await recommender.recommendDependencies(mockProjectAnalysis)
+
+      expect(result.length).toBeGreaterThan(0)
+      expect(result.some(r => r.name === 'typescript')).toBe(true)
+    })
+
+    it('returns fallback when JSON parsing fails', async () => {
+      mockComplete.mockResolvedValue({success: true, content: 'Invalid response'})
+      const recommender = new DependencyRecommender()
+
+      const result = await recommender.recommendDependencies(mockProjectAnalysis)
+
+      expect(result.length).toBeGreaterThan(0)
+    })
+
+    it('clamps confidence between 0 and 1', async () => {
+      mockComplete.mockResolvedValue({
+        success: true,
+        content: JSON.stringify([{name: 'test', description: 'Test', confidence: 1.5}]),
+      })
+      const recommender = new DependencyRecommender()
+
+      const result = await recommender.recommendDependencies(mockProjectAnalysis)
+
+      expect(result[0]?.confidence).toBe(1)
+    })
+
+    it('handles missing fields in recommendations', async () => {
+      mockComplete.mockResolvedValue({
+        success: true,
+        content: JSON.stringify([{name: 'test'}]),
+      })
+      const recommender = new DependencyRecommender()
+
+      const result = await recommender.recommendDependencies(mockProjectAnalysis)
+
+      expect(result[0]?.name).toBe('test')
+      expect(result[0]?.description).toBe('')
+      expect(result[0]?.confidence).toBe(0.7)
+    })
+  })
+
+  describe('recommendForFeatures', () => {
+    it('returns fallback when AI is not available', async () => {
+      mockIsAIAvailable.mockReturnValue(false)
+      const recommender = new DependencyRecommender()
+
+      const result = await recommender.recommendForFeatures(['testing', 'validation'], 'library')
+
+      expect(result).toBeInstanceOf(Array)
+      expect(mockComplete).not.toHaveBeenCalled()
+    })
+
+    it('returns AI recommendations when available', async () => {
+      mockComplete.mockResolvedValue({
+        success: true,
+        content: JSON.stringify([
+          {name: 'vitest', description: 'Testing framework', confidence: 0.9},
+        ]),
+      })
+      const recommender = new DependencyRecommender()
+
+      const result = await recommender.recommendForFeatures(['testing'], 'library')
+
+      expect(result[0]?.name).toBe('vitest')
+    })
+
+    it('recommends vitest for testing features', async () => {
+      mockIsAIAvailable.mockReturnValue(false)
+      const recommender = new DependencyRecommender()
+
+      const result = await recommender.recommendForFeatures(['unit testing'], 'library')
+
+      expect(result.some(r => r.name === 'vitest')).toBe(true)
+    })
+
+    it('recommends zod for validation features', async () => {
+      mockIsAIAvailable.mockReturnValue(false)
+      const recommender = new DependencyRecommender()
+
+      const result = await recommender.recommendForFeatures(['schema validation'], 'api')
+
+      expect(result.some(r => r.name === 'zod')).toBe(true)
+    })
+
+    it('recommends drizzle-orm for database features', async () => {
+      mockIsAIAvailable.mockReturnValue(false)
+      const recommender = new DependencyRecommender()
+
+      const result = await recommender.recommendForFeatures(['database integration'], 'api')
+
+      expect(result.some(r => r.name === 'drizzle-orm')).toBe(true)
+    })
+
+    it('returns fallback when AI response fails', async () => {
+      mockComplete.mockResolvedValue({success: false, error: 'API error'})
+      const recommender = new DependencyRecommender()
+
+      const result = await recommender.recommendForFeatures(['testing'], 'library')
+
+      expect(result).toBeInstanceOf(Array)
+    })
+  })
+
+  describe('suggestUpgrades', () => {
+    it('returns fallback when AI is not available', async () => {
+      mockIsAIAvailable.mockReturnValue(false)
+      const recommender = new DependencyRecommender()
+
+      const result = await recommender.suggestUpgrades({typescript: '^4.0.0'}, 'library')
+
+      expect(result).toHaveProperty('upgrades')
+      expect(result).toHaveProperty('alternatives')
+      expect(result).toHaveProperty('deprecations')
+    })
+
+    it('returns AI suggestions when available', async () => {
+      mockComplete.mockResolvedValue({
+        success: true,
+        content: JSON.stringify({
+          upgrades: [{name: 'typescript', description: 'Upgrade to v5', confidence: 0.9}],
+          alternatives: [],
+          deprecations: [],
+        }),
+      })
+      const recommender = new DependencyRecommender()
+
+      const result = await recommender.suggestUpgrades({typescript: '^4.0.0'}, 'library')
+
+      expect(result.upgrades[0]?.name).toBe('typescript')
+    })
+
+    it('identifies deprecated request package', async () => {
+      mockIsAIAvailable.mockReturnValue(false)
+      const recommender = new DependencyRecommender()
+
+      const result = await recommender.suggestUpgrades({request: '^2.88.0'}, 'api')
+
+      expect(result.deprecations).toContain('request')
+      expect(result.alternatives.some(a => a.name === 'axios')).toBe(true)
+    })
+
+    it('suggests date-fns as moment alternative', async () => {
+      mockIsAIAvailable.mockReturnValue(false)
+      const recommender = new DependencyRecommender()
+
+      const result = await recommender.suggestUpgrades({moment: '^2.29.0'}, 'web-app')
+
+      expect(result.alternatives.some(a => a.name === 'date-fns')).toBe(true)
+    })
+
+    it('returns fallback when AI response fails', async () => {
+      mockComplete.mockResolvedValue({success: false, error: 'API error'})
+      const recommender = new DependencyRecommender()
+
+      const result = await recommender.suggestUpgrades({lodash: '^4.17.0'}, 'library')
+
+      expect(result).toHaveProperty('upgrades')
+      expect(result).toHaveProperty('alternatives')
+      expect(result).toHaveProperty('deprecations')
+    })
+
+    it('returns fallback when JSON parsing fails', async () => {
+      mockComplete.mockResolvedValue({success: true, content: 'Invalid response'})
+      const recommender = new DependencyRecommender()
+
+      const result = await recommender.suggestUpgrades({lodash: '^4.17.0'}, 'library')
+
+      expect(result).toHaveProperty('upgrades')
+    })
+
+    it('handles empty arrays in response', async () => {
+      mockComplete.mockResolvedValue({
+        success: true,
+        content: JSON.stringify({upgrades: [], alternatives: [], deprecations: []}),
+      })
+      const recommender = new DependencyRecommender()
+
+      const result = await recommender.suggestUpgrades({lodash: '^4.17.0'}, 'library')
+
+      expect(result.upgrades).toEqual([])
+      expect(result.alternatives).toEqual([])
+      expect(result.deprecations).toEqual([])
+    })
+  })
+
+  describe('fallback recommendations by project type', () => {
+    beforeEach(() => {
+      mockIsAIAvailable.mockReturnValue(false)
+    })
+
+    it('recommends commander for CLI projects', async () => {
+      const recommender = new DependencyRecommender()
+      const analysis: ProjectAnalysis = {
+        ...mockProjectAnalysis,
+        projectType: 'cli',
+      }
+
+      const result = await recommender.recommendDependencies(analysis)
+
+      expect(result.some(r => r.name === 'commander')).toBe(true)
+    })
+
+    it('recommends react for web-app projects', async () => {
+      const recommender = new DependencyRecommender()
+      const analysis: ProjectAnalysis = {
+        ...mockProjectAnalysis,
+        projectType: 'web-app',
+      }
+
+      const result = await recommender.recommendDependencies(analysis)
+
+      expect(result.some(r => r.name === 'react')).toBe(true)
+    })
+
+    it('recommends express for API projects', async () => {
+      const recommender = new DependencyRecommender()
+      const analysis: ProjectAnalysis = {
+        ...mockProjectAnalysis,
+        projectType: 'api',
+      }
+
+      const result = await recommender.recommendDependencies(analysis)
+
+      expect(result.some(r => r.name === 'express')).toBe(true)
+    })
+
+    it('recommends tsup for library projects', async () => {
+      const recommender = new DependencyRecommender()
+
+      const result = await recommender.recommendDependencies(mockProjectAnalysis)
+
+      expect(result.some(r => r.name === 'tsup')).toBe(true)
+    })
+
+    it('skips CLI framework if one exists', async () => {
+      const recommender = new DependencyRecommender()
+      const analysis: ProjectAnalysis = {
+        ...mockProjectAnalysis,
+        projectType: 'cli',
+      }
+
+      const result = await recommender.recommendDependencies(analysis, ['cac'])
+
+      expect(result.some(r => r.name === 'commander')).toBe(false)
+    })
+
+    it('skips frontend framework if one exists', async () => {
+      const recommender = new DependencyRecommender()
+      const analysis: ProjectAnalysis = {
+        ...mockProjectAnalysis,
+        projectType: 'web-app',
+      }
+
+      const result = await recommender.recommendDependencies(analysis, ['vue'])
+
+      expect(result.some(r => r.name === 'react')).toBe(false)
+    })
+  })
+
+  describe('essential development tools', () => {
+    beforeEach(() => {
+      mockIsAIAvailable.mockReturnValue(false)
+    })
+
+    it('recommends typescript if not present', async () => {
+      const recommender = new DependencyRecommender()
+
+      const result = await recommender.recommendDependencies(mockProjectAnalysis)
+
+      const tsRec = result.find(r => r.name === 'typescript')
+      expect(tsRec).toBeDefined()
+      expect(tsRec?.isDev).toBe(true)
+    })
+
+    it('recommends eslint if not present', async () => {
+      const recommender = new DependencyRecommender()
+
+      const result = await recommender.recommendDependencies(mockProjectAnalysis)
+
+      const eslintRec = result.find(r => r.name === 'eslint')
+      expect(eslintRec).toBeDefined()
+      expect(eslintRec?.isDev).toBe(true)
+    })
+
+    it('recommends prettier if not present', async () => {
+      const recommender = new DependencyRecommender()
+
+      const result = await recommender.recommendDependencies(mockProjectAnalysis)
+
+      const prettierRec = result.find(r => r.name === 'prettier')
+      expect(prettierRec).toBeDefined()
+      expect(prettierRec?.isDev).toBe(true)
+    })
+  })
+})

--- a/packages/create/test/ai/feature-config.test.ts
+++ b/packages/create/test/ai/feature-config.test.ts
@@ -1,0 +1,268 @@
+/**
+ * Tests for AI Feature Configuration
+ * Part of Phase 5: Comprehensive Testing Implementation (TASK-036)
+ *
+ * Tests configuration management for AI features with toggle support.
+ */
+
+import {afterEach, beforeEach, describe, expect, it} from 'vitest'
+import {
+  createAIFeatureConfig,
+  createConfigWithFeatures,
+  getEnabledFeatures,
+  isFeatureEnabled,
+} from '../../src/ai/feature-config.js'
+
+describe('aI Feature Configuration', () => {
+  const originalEnv = process.env
+
+  beforeEach(() => {
+    process.env = {...originalEnv}
+    delete process.env.AI_ENABLED
+    delete process.env.AI_PROVIDER
+    delete process.env.AI_FALLBACK_BEHAVIOR
+  })
+
+  afterEach(() => {
+    process.env = originalEnv
+  })
+
+  describe('createAIFeatureConfig', () => {
+    it('creates config with all defaults', () => {
+      const config = createAIFeatureConfig()
+
+      expect(config.enabled).toBe(true)
+      expect(config.provider).toBe('auto')
+      expect(config.fallbackBehavior).toBe('warn')
+      expect(config.maxRetries).toBe(2)
+      expect(config.timeout).toBe(30000)
+    })
+
+    it('enables all features by default', () => {
+      const config = createAIFeatureConfig()
+
+      expect(config.features.projectAnalysis).toBe(true)
+      expect(config.features.dependencyRecommendations).toBe(true)
+      expect(config.features.codeGeneration).toBe(true)
+      expect(config.features.documentationGeneration).toBe(true)
+      expect(config.features.configurationOptimization).toBe(true)
+      expect(config.features.interactiveAssistant).toBe(true)
+    })
+
+    it('respects AI_ENABLED env variable', () => {
+      process.env.AI_ENABLED = 'false'
+
+      const config = createAIFeatureConfig()
+
+      expect(config.enabled).toBe(false)
+    })
+
+    it('respects AI_PROVIDER env variable for openai', () => {
+      process.env.AI_PROVIDER = 'openai'
+
+      const config = createAIFeatureConfig()
+
+      expect(config.provider).toBe('openai')
+    })
+
+    it('respects AI_PROVIDER env variable for anthropic', () => {
+      process.env.AI_PROVIDER = 'anthropic'
+
+      const config = createAIFeatureConfig()
+
+      expect(config.provider).toBe('anthropic')
+    })
+
+    it('respects AI_PROVIDER env variable for auto', () => {
+      process.env.AI_PROVIDER = 'auto'
+
+      const config = createAIFeatureConfig()
+
+      expect(config.provider).toBe('auto')
+    })
+
+    it('ignores invalid AI_PROVIDER values', () => {
+      process.env.AI_PROVIDER = 'invalid'
+
+      const config = createAIFeatureConfig()
+
+      expect(config.provider).toBe('auto')
+    })
+
+    it('respects AI_FALLBACK_BEHAVIOR env variable', () => {
+      process.env.AI_FALLBACK_BEHAVIOR = 'error'
+
+      const config = createAIFeatureConfig()
+
+      expect(config.fallbackBehavior).toBe('error')
+    })
+
+    it('respects AI_FALLBACK_BEHAVIOR for silent', () => {
+      process.env.AI_FALLBACK_BEHAVIOR = 'silent'
+
+      const config = createAIFeatureConfig()
+
+      expect(config.fallbackBehavior).toBe('silent')
+    })
+
+    it('ignores invalid AI_FALLBACK_BEHAVIOR values', () => {
+      process.env.AI_FALLBACK_BEHAVIOR = 'invalid'
+
+      const config = createAIFeatureConfig()
+
+      expect(config.fallbackBehavior).toBe('warn')
+    })
+
+    it('uses provided options over defaults', () => {
+      const config = createAIFeatureConfig({
+        enabled: false,
+        provider: 'openai',
+        fallbackBehavior: 'error',
+        maxRetries: 5,
+        timeout: 60000,
+      })
+
+      expect(config.enabled).toBe(false)
+      expect(config.provider).toBe('openai')
+      expect(config.fallbackBehavior).toBe('error')
+      expect(config.maxRetries).toBe(5)
+      expect(config.timeout).toBe(60000)
+    })
+
+    it('uses options over env variables', () => {
+      process.env.AI_ENABLED = 'false'
+      process.env.AI_PROVIDER = 'anthropic'
+
+      const config = createAIFeatureConfig({
+        enabled: true,
+        provider: 'openai',
+      })
+
+      expect(config.enabled).toBe(true)
+      expect(config.provider).toBe('openai')
+    })
+
+    it('merges feature flags with defaults', () => {
+      const config = createAIFeatureConfig({
+        features: {
+          projectAnalysis: false,
+          dependencyRecommendations: true,
+          codeGeneration: false,
+          documentationGeneration: true,
+          configurationOptimization: true,
+          interactiveAssistant: true,
+        },
+      })
+
+      expect(config.features.projectAnalysis).toBe(false)
+      expect(config.features.codeGeneration).toBe(false)
+      expect(config.features.dependencyRecommendations).toBe(true)
+      expect(config.features.documentationGeneration).toBe(true)
+    })
+  })
+
+  describe('isFeatureEnabled', () => {
+    it('returns false when AI globally disabled', () => {
+      const config = createAIFeatureConfig({enabled: false})
+
+      expect(isFeatureEnabled('projectAnalysis', config)).toBe(false)
+    })
+
+    it('returns true for enabled feature', () => {
+      const config = createAIFeatureConfig()
+
+      expect(isFeatureEnabled('projectAnalysis', config)).toBe(true)
+    })
+
+    it('returns false for disabled feature', () => {
+      const config = createAIFeatureConfig({
+        features: {
+          projectAnalysis: false,
+          dependencyRecommendations: true,
+          codeGeneration: true,
+          documentationGeneration: true,
+          configurationOptimization: true,
+          interactiveAssistant: true,
+        },
+      })
+
+      expect(isFeatureEnabled('projectAnalysis', config)).toBe(false)
+    })
+  })
+
+  describe('getEnabledFeatures', () => {
+    it('returns empty array when AI disabled', () => {
+      const config = createAIFeatureConfig({enabled: false})
+
+      const features = getEnabledFeatures(config)
+
+      expect(features).toHaveLength(0)
+    })
+
+    it('returns all features when all enabled', () => {
+      const config = createAIFeatureConfig()
+
+      const features = getEnabledFeatures(config)
+
+      expect(features).toContain('projectAnalysis')
+      expect(features).toContain('dependencyRecommendations')
+      expect(features).toContain('codeGeneration')
+      expect(features).toContain('documentationGeneration')
+      expect(features).toContain('configurationOptimization')
+      expect(features).toContain('interactiveAssistant')
+    })
+
+    it('returns only enabled features', () => {
+      const config = createAIFeatureConfig({
+        features: {
+          projectAnalysis: true,
+          dependencyRecommendations: true,
+          codeGeneration: false,
+          documentationGeneration: false,
+          configurationOptimization: false,
+          interactiveAssistant: false,
+        },
+      })
+
+      const features = getEnabledFeatures(config)
+
+      expect(features).toContain('projectAnalysis')
+      expect(features).toContain('dependencyRecommendations')
+      expect(features).not.toContain('codeGeneration')
+      expect(features).not.toContain('documentationGeneration')
+    })
+  })
+
+  describe('createConfigWithFeatures', () => {
+    it('enables only specified features', () => {
+      const config = createConfigWithFeatures(['projectAnalysis', 'codeGeneration'])
+
+      expect(config.features.projectAnalysis).toBe(true)
+      expect(config.features.codeGeneration).toBe(true)
+      expect(config.features.dependencyRecommendations).toBe(false)
+      expect(config.features.documentationGeneration).toBe(false)
+      expect(config.features.configurationOptimization).toBe(false)
+      expect(config.features.interactiveAssistant).toBe(false)
+    })
+
+    it('disables all features when empty array', () => {
+      const config = createConfigWithFeatures([])
+
+      expect(config.features.projectAnalysis).toBe(false)
+      expect(config.features.dependencyRecommendations).toBe(false)
+      expect(config.features.codeGeneration).toBe(false)
+      expect(config.features.documentationGeneration).toBe(false)
+      expect(config.features.configurationOptimization).toBe(false)
+      expect(config.features.interactiveAssistant).toBe(false)
+    })
+
+    it('enables single feature', () => {
+      const config = createConfigWithFeatures(['documentationGeneration'])
+
+      expect(config.features.documentationGeneration).toBe(true)
+
+      const enabledCount = Object.values(config.features).filter(Boolean).length
+      expect(enabledCount).toBe(1)
+    })
+  })
+})

--- a/packages/create/test/ai/llm-client-factory.test.ts
+++ b/packages/create/test/ai/llm-client-factory.test.ts
@@ -1,0 +1,299 @@
+/**
+ * Tests for LLM Client Factory
+ * Part of Phase 5: Comprehensive Testing Implementation (TASK-036)
+ *
+ * Tests the provider-agnostic LLM client factory with comprehensive mocking
+ * of OpenAI and Anthropic SDKs.
+ */
+
+import type {AIConfig} from '../../src/types.js'
+import {isErr, isOk} from '@bfra.me/es/result'
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
+
+// Mock the external AI SDKs before importing the factory - use factory function pattern
+vi.mock('openai', () => {
+  const OpenAIMock = vi.fn().mockImplementation(function (this: object) {
+    Object.assign(this, {
+      chat: {
+        completions: {
+          create: vi.fn(),
+        },
+      },
+    })
+  })
+  return {default: OpenAIMock}
+})
+
+vi.mock('@anthropic-ai/sdk', () => {
+  const AnthropicMock = vi.fn().mockImplementation(function (this: object) {
+    Object.assign(this, {
+      messages: {
+        create: vi.fn(),
+      },
+    })
+  })
+  return {default: AnthropicMock}
+})
+
+vi.mock('dotenv', () => ({
+  config: vi.fn(),
+}))
+
+describe('lLM Client Factory', () => {
+  const originalEnv = process.env
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    process.env = {...originalEnv}
+    delete process.env.OPENAI_API_KEY
+    delete process.env.ANTHROPIC_API_KEY
+  })
+
+  afterEach(() => {
+    process.env = originalEnv
+    vi.resetModules()
+  })
+
+  describe('createLLMClient', () => {
+    it('creates client with default configuration', async () => {
+      const {createLLMClient} = await import('../../src/ai/llm-client-factory.js')
+      const client = createLLMClient()
+
+      expect(client).toBeDefined()
+      expect(client.complete).toBeDefined()
+      expect(client.isAvailable).toBeDefined()
+      expect(client.getAvailableProviders).toBeDefined()
+      expect(client.isProviderAvailable).toBeDefined()
+      expect(client.healthCheck).toBeDefined()
+      expect(client.getConfig).toBeDefined()
+      expect(client.updateConfig).toBeDefined()
+    })
+
+    it('returns default config values', async () => {
+      const {createLLMClient} = await import('../../src/ai/llm-client-factory.js')
+      const client = createLLMClient()
+      const config = client.getConfig()
+
+      expect(config.enabled).toBe(true)
+      expect(config.provider).toBe('auto')
+      expect(config.maxTokens).toBe(2000)
+      expect(config.temperature).toBe(0.7)
+    })
+
+    it('applies custom configuration', async () => {
+      const {createLLMClient} = await import('../../src/ai/llm-client-factory.js')
+      const customConfig: Partial<AIConfig> = {
+        enabled: false,
+        provider: 'openai',
+        maxTokens: 4000,
+        temperature: 0.5,
+      }
+
+      const client = createLLMClient(customConfig)
+      const config = client.getConfig()
+
+      expect(config.enabled).toBe(false)
+      expect(config.provider).toBe('openai')
+      expect(config.maxTokens).toBe(4000)
+      expect(config.temperature).toBe(0.5)
+    })
+
+    it('reports no availability when no API keys configured', async () => {
+      const {createLLMClient} = await import('../../src/ai/llm-client-factory.js')
+      const client = createLLMClient()
+
+      expect(client.isAvailable()).toBe(false)
+      expect(client.getAvailableProviders()).toHaveLength(0)
+    })
+
+    it('reports OpenAI available when API key provided', async () => {
+      const {createLLMClient} = await import('../../src/ai/llm-client-factory.js')
+      const client = createLLMClient({
+        openai: {
+          apiKey: 'test-openai-key',
+        },
+      })
+
+      expect(client.isProviderAvailable('openai')).toBe(true)
+      expect(client.isProviderAvailable('anthropic')).toBe(false)
+      expect(client.isAvailable()).toBe(true)
+      expect(client.getAvailableProviders()).toContain('openai')
+    })
+
+    it('reports Anthropic available when API key provided', async () => {
+      const {createLLMClient} = await import('../../src/ai/llm-client-factory.js')
+      const client = createLLMClient({
+        anthropic: {
+          apiKey: 'test-anthropic-key',
+        },
+      })
+
+      expect(client.isProviderAvailable('anthropic')).toBe(true)
+      expect(client.isProviderAvailable('openai')).toBe(false)
+      expect(client.isAvailable()).toBe(true)
+      expect(client.getAvailableProviders()).toContain('anthropic')
+    })
+
+    it('reports both providers available when both keys provided', async () => {
+      const {createLLMClient} = await import('../../src/ai/llm-client-factory.js')
+      const client = createLLMClient({
+        openai: {apiKey: 'test-openai-key'},
+        anthropic: {apiKey: 'test-anthropic-key'},
+      })
+
+      expect(client.isProviderAvailable('openai')).toBe(true)
+      expect(client.isProviderAvailable('anthropic')).toBe(true)
+      expect(client.isAvailable()).toBe(true)
+
+      const providers = client.getAvailableProviders()
+      expect(providers).toContain('openai')
+      expect(providers).toContain('anthropic')
+    })
+  })
+
+  describe('complete method', () => {
+    it('returns disabled error when AI is disabled', async () => {
+      const {createLLMClient} = await import('../../src/ai/llm-client-factory.js')
+      const client = createLLMClient({enabled: false})
+
+      const result = await client.complete('Test prompt')
+
+      expect(isOk(result)).toBe(true)
+      if (!isOk(result)) throw new Error('Expected success')
+
+      expect(result.data.success).toBe(false)
+      expect(result.data.error).toContain('disabled')
+    })
+
+    it('returns no provider error when none available', async () => {
+      const {createLLMClient} = await import('../../src/ai/llm-client-factory.js')
+      const client = createLLMClient()
+
+      const result = await client.complete('Test prompt')
+
+      expect(isOk(result)).toBe(true)
+      if (!isOk(result)) throw new Error('Expected success')
+
+      expect(result.data.success).toBe(false)
+      expect(result.data.error).toContain('No LLM provider available')
+    })
+
+    it('uses preferred provider when specified as openai', async () => {
+      const {createLLMClient} = await import('../../src/ai/llm-client-factory.js')
+      const client = createLLMClient({
+        provider: 'openai',
+        openai: {apiKey: 'test-key'},
+        anthropic: {apiKey: 'test-key'},
+      })
+
+      // The factory should prefer openai as configured
+      expect(client.isProviderAvailable('openai')).toBe(true)
+    })
+
+    it('uses preferred provider when specified as anthropic', async () => {
+      const {createLLMClient} = await import('../../src/ai/llm-client-factory.js')
+      const client = createLLMClient({
+        provider: 'anthropic',
+        openai: {apiKey: 'test-key'},
+        anthropic: {apiKey: 'test-key'},
+      })
+
+      // The factory should prefer anthropic as configured
+      expect(client.isProviderAvailable('anthropic')).toBe(true)
+    })
+
+    it('auto-selects provider when set to auto', async () => {
+      const {createLLMClient} = await import('../../src/ai/llm-client-factory.js')
+      const client = createLLMClient({
+        provider: 'auto',
+        openai: {apiKey: 'test-key'},
+      })
+
+      // Should auto-select OpenAI since it's configured
+      expect(client.isAvailable()).toBe(true)
+    })
+  })
+
+  describe('updateConfig', () => {
+    it('updates configuration', async () => {
+      const {createLLMClient} = await import('../../src/ai/llm-client-factory.js')
+      const client = createLLMClient({
+        enabled: true,
+        maxTokens: 1000,
+      })
+
+      client.updateConfig({
+        enabled: false,
+        maxTokens: 2000,
+      })
+
+      const config = client.getConfig()
+      expect(config.enabled).toBe(false)
+      expect(config.maxTokens).toBe(2000)
+    })
+
+    it('reinitializes adapters on config update', async () => {
+      const {createLLMClient} = await import('../../src/ai/llm-client-factory.js')
+      const client = createLLMClient()
+
+      expect(client.isAvailable()).toBe(false)
+
+      client.updateConfig({
+        openai: {apiKey: 'new-key'},
+      })
+
+      expect(client.isProviderAvailable('openai')).toBe(true)
+    })
+  })
+
+  describe('healthCheck', () => {
+    it('returns false when no provider available', async () => {
+      const {createLLMClient} = await import('../../src/ai/llm-client-factory.js')
+      const client = createLLMClient()
+
+      const result = await client.healthCheck()
+
+      expect(isOk(result)).toBe(true)
+      if (!isOk(result)) throw new Error('Expected success')
+      expect(result.data).toBe(false)
+    })
+  })
+
+  describe('isAIAvailable helper', () => {
+    it('returns false when no environment keys', async () => {
+      const {isAIAvailable} = await import('../../src/ai/llm-client-factory.js')
+      expect(isAIAvailable()).toBe(false)
+    })
+  })
+
+  describe('getAvailableProviders helper', () => {
+    it('returns empty array when no providers configured', async () => {
+      const {getAvailableProviders} = await import('../../src/ai/llm-client-factory.js')
+      expect(getAvailableProviders()).toHaveLength(0)
+    })
+  })
+
+  describe('createLLMClientWithProvider', () => {
+    it('returns error when provider not available', async () => {
+      const {createLLMClientWithProvider} = await import('../../src/ai/llm-client-factory.js')
+
+      const result = createLLMClientWithProvider('openai')
+
+      expect(isErr(result)).toBe(true)
+      if (!isErr(result)) throw new Error('Expected error')
+      expect(result.error.message).toContain('not available')
+    })
+
+    it('returns client when provider is available', async () => {
+      const {createLLMClientWithProvider} = await import('../../src/ai/llm-client-factory.js')
+
+      const result = createLLMClientWithProvider('openai', {
+        openai: {apiKey: 'test-key'},
+      })
+
+      expect(isOk(result)).toBe(true)
+      if (!isOk(result)) throw new Error('Expected success')
+      expect(result.data.isProviderAvailable('openai')).toBe(true)
+    })
+  })
+})

--- a/packages/create/test/ai/llm-client.test.ts
+++ b/packages/create/test/ai/llm-client.test.ts
@@ -1,0 +1,447 @@
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
+
+const mockOpenAICreate = vi.fn()
+const mockAnthropicCreate = vi.fn()
+
+vi.mock('openai', () => ({
+  default: class MockOpenAI {
+    chat = {
+      completions: {
+        create: mockOpenAICreate,
+      },
+    }
+
+    constructor(config: {apiKey: string; baseURL?: string}) {
+      if (!config.apiKey) {
+        throw new Error('API key is required')
+      }
+    }
+  },
+}))
+
+vi.mock('@anthropic-ai/sdk', () => ({
+  default: class MockAnthropic {
+    messages = {
+      create: mockAnthropicCreate,
+    }
+
+    constructor(config: {apiKey: string; baseURL?: string}) {
+      if (!config.apiKey) {
+        throw new Error('API key is required')
+      }
+    }
+  },
+}))
+
+vi.mock('dotenv', () => ({
+  config: vi.fn(),
+}))
+
+const {LLMClient, createLLMClient, isAIAvailable, AIError} =
+  await import('../../src/ai/llm-client.js')
+
+describe('LLMClient', () => {
+  const originalEnv = process.env
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    process.env = {...originalEnv}
+    delete process.env.OPENAI_API_KEY
+    delete process.env.ANTHROPIC_API_KEY
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    process.env = originalEnv
+  })
+
+  describe('constructor', () => {
+    it('should create instance with default config', () => {
+      const client = new LLMClient()
+      expect(client).toBeInstanceOf(LLMClient)
+    })
+
+    it('should create instance with custom config', () => {
+      const config = {provider: 'openai' as const, maxTokens: 4000}
+      const client = new LLMClient(config)
+      expect(client).toBeInstanceOf(LLMClient)
+    })
+
+    it('should initialize OpenAI client when API key is provided', () => {
+      const client = new LLMClient({openai: {apiKey: 'test-key'}})
+      expect(client.isProviderAvailable('openai')).toBe(true)
+    })
+
+    it('should initialize OpenAI client from environment variable', () => {
+      process.env.OPENAI_API_KEY = 'env-test-key'
+      const client = new LLMClient()
+      expect(client.isProviderAvailable('openai')).toBe(true)
+    })
+
+    it('should initialize Anthropic client when API key is provided', () => {
+      const client = new LLMClient({anthropic: {apiKey: 'test-key'}})
+      expect(client.isProviderAvailable('anthropic')).toBe(true)
+    })
+
+    it('should initialize Anthropic client from environment variable', () => {
+      process.env.ANTHROPIC_API_KEY = 'env-test-key'
+      const client = new LLMClient()
+      expect(client.isProviderAvailable('anthropic')).toBe(true)
+    })
+  })
+
+  describe('isProviderAvailable', () => {
+    it('should return false when no providers are configured', () => {
+      const client = new LLMClient()
+      expect(client.isProviderAvailable('openai')).toBe(false)
+      expect(client.isProviderAvailable('anthropic')).toBe(false)
+    })
+
+    it('should return true for configured openai provider', () => {
+      const client = new LLMClient({openai: {apiKey: 'test'}})
+      expect(client.isProviderAvailable('openai')).toBe(true)
+    })
+
+    it('should return true for configured anthropic provider', () => {
+      const client = new LLMClient({anthropic: {apiKey: 'test'}})
+      expect(client.isProviderAvailable('anthropic')).toBe(true)
+    })
+
+    it('should return false for unsupported provider', () => {
+      const client = new LLMClient({openai: {apiKey: 'test'}})
+      expect(client.isProviderAvailable('unknown' as any)).toBe(false)
+    })
+  })
+
+  describe('isAIAvailable', () => {
+    it('should return false when no providers are configured', () => {
+      const client = new LLMClient()
+      expect(client.isAIAvailable()).toBe(false)
+    })
+
+    it('should return true when OpenAI is configured', () => {
+      const client = new LLMClient({openai: {apiKey: 'test'}})
+      expect(client.isAIAvailable()).toBe(true)
+    })
+
+    it('should return true when Anthropic is configured', () => {
+      const client = new LLMClient({anthropic: {apiKey: 'test'}})
+      expect(client.isAIAvailable()).toBe(true)
+    })
+  })
+
+  describe('getAvailableProviders', () => {
+    it('should return empty array when no providers configured', () => {
+      const client = new LLMClient()
+      expect(client.getAvailableProviders()).toEqual([])
+    })
+
+    it('should return openai when OpenAI is configured', () => {
+      const client = new LLMClient({openai: {apiKey: 'test'}})
+      expect(client.getAvailableProviders()).toContain('openai')
+    })
+
+    it('should return anthropic when Anthropic is configured', () => {
+      const client = new LLMClient({anthropic: {apiKey: 'test'}})
+      expect(client.getAvailableProviders()).toContain('anthropic')
+    })
+
+    it('should return both when both are configured', () => {
+      const client = new LLMClient({
+        openai: {apiKey: 'test-openai'},
+        anthropic: {apiKey: 'test-anthropic'},
+      })
+      const providers = client.getAvailableProviders()
+      expect(providers).toContain('openai')
+      expect(providers).toContain('anthropic')
+    })
+  })
+
+  describe('updateConfig', () => {
+    it('should update configuration', () => {
+      const client = new LLMClient()
+      expect(client.isProviderAvailable('openai')).toBe(false)
+
+      client.updateConfig({openai: {apiKey: 'new-key'}})
+      expect(client.isProviderAvailable('openai')).toBe(true)
+    })
+
+    it('should re-initialize clients', () => {
+      const client = new LLMClient({openai: {apiKey: 'old-key'}})
+      client.updateConfig({anthropic: {apiKey: 'new-key'}})
+      expect(client.isProviderAvailable('anthropic')).toBe(true)
+    })
+  })
+
+  describe('complete', () => {
+    it('should return error when AI is disabled', async () => {
+      const client = new LLMClient({enabled: false, openai: {apiKey: 'test'}})
+      const result = await client.complete('test prompt')
+
+      expect(result.success).toBe(false)
+      expect(result.error).toBe('AI features are disabled')
+    })
+
+    it('should return error when no provider is available', async () => {
+      const client = new LLMClient()
+      const result = await client.complete('test prompt')
+
+      expect(result.success).toBe(false)
+      expect(result.error).toContain('No LLM provider available')
+    })
+
+    it('should use OpenAI when configured', async () => {
+      mockOpenAICreate.mockResolvedValueOnce({
+        choices: [{message: {content: 'OpenAI response'}, finish_reason: 'stop'}],
+        model: 'gpt-4',
+        usage: {prompt_tokens: 10, completion_tokens: 20, total_tokens: 30},
+      })
+
+      const client = new LLMClient({openai: {apiKey: 'test'}})
+      const result = await client.complete('test prompt')
+
+      expect(result.success).toBe(true)
+      expect(result.content).toBe('OpenAI response')
+      expect(mockOpenAICreate).toHaveBeenCalled()
+    })
+
+    it('should use Anthropic when configured as provider', async () => {
+      mockAnthropicCreate.mockResolvedValueOnce({
+        content: [{type: 'text', text: 'Anthropic response'}],
+        model: 'claude-3-sonnet',
+        stop_reason: 'end_turn',
+        usage: {input_tokens: 10, output_tokens: 20},
+      })
+
+      const client = new LLMClient({
+        provider: 'anthropic',
+        anthropic: {apiKey: 'test'},
+      })
+      const result = await client.complete('test prompt')
+
+      expect(result.success).toBe(true)
+      expect(result.content).toBe('Anthropic response')
+      expect(mockAnthropicCreate).toHaveBeenCalled()
+    })
+
+    it('should handle empty OpenAI response', async () => {
+      mockOpenAICreate.mockResolvedValueOnce({
+        choices: [{message: {content: ''}}],
+      })
+
+      const client = new LLMClient({openai: {apiKey: 'test'}})
+      const result = await client.complete('test prompt')
+
+      expect(result.success).toBe(false)
+      expect(result.error).toContain('No content')
+    })
+
+    it('should handle non-text Anthropic response', async () => {
+      mockAnthropicCreate.mockResolvedValueOnce({
+        content: [{type: 'image', source: {}}],
+      })
+
+      const client = new LLMClient({
+        provider: 'anthropic',
+        anthropic: {apiKey: 'test'},
+      })
+      const result = await client.complete('test prompt')
+
+      expect(result.success).toBe(false)
+      expect(result.error).toContain('No text content')
+    })
+
+    it('should handle OpenAI API errors', async () => {
+      mockOpenAICreate.mockRejectedValueOnce(new Error('API rate limit'))
+
+      const client = new LLMClient({openai: {apiKey: 'test'}})
+      const result = await client.complete('test prompt')
+
+      expect(result.success).toBe(false)
+      expect(result.error).toContain('OpenAI API error')
+    })
+
+    it('should handle Anthropic API errors', async () => {
+      mockAnthropicCreate.mockRejectedValueOnce(new Error('API rate limit'))
+
+      const client = new LLMClient({
+        provider: 'anthropic',
+        anthropic: {apiKey: 'test'},
+      })
+      const result = await client.complete('test prompt')
+
+      expect(result.success).toBe(false)
+      expect(result.error).toContain('Anthropic API error')
+    })
+
+    it('should pass custom options to OpenAI', async () => {
+      mockOpenAICreate.mockResolvedValueOnce({
+        choices: [{message: {content: 'response'}}],
+      })
+
+      const client = new LLMClient({openai: {apiKey: 'test'}})
+      await client.complete('test prompt', {
+        temperature: 0.5,
+        maxTokens: 1000,
+        systemPrompt: 'Custom system prompt',
+      })
+
+      expect(mockOpenAICreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          temperature: 0.5,
+          max_tokens: 1000,
+          messages: expect.arrayContaining([
+            expect.objectContaining({role: 'system', content: 'Custom system prompt'}),
+          ]),
+        }),
+      )
+    })
+
+    it('should pass custom options to Anthropic', async () => {
+      mockAnthropicCreate.mockResolvedValueOnce({
+        content: [{type: 'text', text: 'response'}],
+      })
+
+      const client = new LLMClient({
+        provider: 'anthropic',
+        anthropic: {apiKey: 'test'},
+      })
+      await client.complete('test prompt', {
+        maxTokens: 1000,
+        systemPrompt: 'Custom system prompt',
+      })
+
+      expect(mockAnthropicCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          max_tokens: 1000,
+          system: 'Custom system prompt',
+        }),
+      )
+    })
+
+    it('should include usage stats in response', async () => {
+      mockOpenAICreate.mockResolvedValueOnce({
+        choices: [{message: {content: 'response'}}],
+        usage: {prompt_tokens: 10, completion_tokens: 20, total_tokens: 30},
+      })
+
+      const client = new LLMClient({openai: {apiKey: 'test'}})
+      const result = await client.complete('test prompt')
+
+      expect(result.usage).toEqual({
+        promptTokens: 10,
+        completionTokens: 20,
+        totalTokens: 30,
+      })
+    })
+  })
+
+  describe('healthCheck', () => {
+    it('should return false when no provider available', async () => {
+      const client = new LLMClient()
+      const result = await client.healthCheck()
+      expect(result).toBe(false)
+    })
+
+    it('should return true when provider responds successfully', async () => {
+      mockOpenAICreate.mockResolvedValueOnce({
+        choices: [{message: {content: 'ok'}}],
+      })
+
+      const client = new LLMClient({openai: {apiKey: 'test'}})
+      const result = await client.healthCheck()
+      expect(result).toBe(true)
+    })
+
+    it('should return false when provider fails', async () => {
+      mockOpenAICreate.mockRejectedValueOnce(new Error('API error'))
+
+      const client = new LLMClient({openai: {apiKey: 'test'}})
+      const result = await client.healthCheck()
+      expect(result).toBe(false)
+    })
+  })
+
+  describe('provider selection', () => {
+    it('should prefer specified provider over auto', async () => {
+      mockAnthropicCreate.mockResolvedValueOnce({
+        content: [{type: 'text', text: 'Anthropic'}],
+      })
+
+      const client = new LLMClient({
+        provider: 'anthropic',
+        openai: {apiKey: 'test-openai'},
+        anthropic: {apiKey: 'test-anthropic'},
+      })
+      await client.complete('test')
+
+      expect(mockAnthropicCreate).toHaveBeenCalled()
+      expect(mockOpenAICreate).not.toHaveBeenCalled()
+    })
+
+    it('should auto-select openai first when both available', async () => {
+      mockOpenAICreate.mockResolvedValueOnce({
+        choices: [{message: {content: 'OpenAI'}}],
+      })
+
+      const client = new LLMClient({
+        provider: 'auto',
+        openai: {apiKey: 'test-openai'},
+        anthropic: {apiKey: 'test-anthropic'},
+      })
+      await client.complete('test')
+
+      expect(mockOpenAICreate).toHaveBeenCalled()
+      expect(mockAnthropicCreate).not.toHaveBeenCalled()
+    })
+
+    it('should return error for unsupported provider', async () => {
+      const client = new LLMClient({provider: 'unsupported' as any})
+      const result = await client.complete('test')
+
+      expect(result.success).toBe(false)
+    })
+  })
+})
+
+describe('createLLMClient factory', () => {
+  it('should create LLMClient instance', () => {
+    const client = createLLMClient()
+    expect(client).toBeInstanceOf(LLMClient)
+  })
+
+  it('should pass config to LLMClient', () => {
+    const client = createLLMClient({maxTokens: 5000})
+    expect(client).toBeInstanceOf(LLMClient)
+  })
+})
+
+describe('isAIAvailable helper', () => {
+  it('should return false when no providers configured', () => {
+    const originalOpenAI = process.env.OPENAI_API_KEY
+    const originalAnthropic = process.env.ANTHROPIC_API_KEY
+    delete process.env.OPENAI_API_KEY
+    delete process.env.ANTHROPIC_API_KEY
+
+    const result = isAIAvailable()
+
+    expect(result).toBe(false)
+
+    process.env.OPENAI_API_KEY = originalOpenAI
+    process.env.ANTHROPIC_API_KEY = originalAnthropic
+  })
+})
+
+describe('AIError', () => {
+  it('should create error with default code', () => {
+    const error = new AIError('Test error')
+    expect(error.message).toBe('Test error')
+    expect(error.code).toBe('GENERATION_FAILED')
+    expect(error.name).toBe('AIError')
+  })
+
+  it('should create error with custom code', () => {
+    const error = new AIError('Test error', 'PROVIDER_UNAVAILABLE')
+    expect(error.code).toBe('PROVIDER_UNAVAILABLE')
+  })
+})

--- a/packages/create/test/ai/project-analyzer.test.ts
+++ b/packages/create/test/ai/project-analyzer.test.ts
@@ -1,0 +1,468 @@
+/**
+ * Tests for AI project analyzer
+ * Part of Phase 5: Comprehensive Testing Implementation (TASK-036, TASK-038)
+ */
+
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
+
+const mockComplete = vi.fn()
+const mockIsAIAvailable = vi.fn()
+
+vi.mock('../../src/ai/llm-client.js', () => ({
+  LLMClient: class MockLLMClient {
+    isAIAvailable = mockIsAIAvailable
+    complete = mockComplete
+  },
+}))
+
+const {ProjectAnalyzer, createProjectAnalyzer} = await import('../../src/ai/project-analyzer.js')
+
+describe('ProjectAnalyzer', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockIsAIAvailable.mockReturnValue(true)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe('constructor', () => {
+    it('creates instance with default config', () => {
+      const analyzer = new ProjectAnalyzer()
+      expect(analyzer).toBeInstanceOf(ProjectAnalyzer)
+    })
+
+    it('creates instance with custom config', () => {
+      const config = {provider: 'openai' as const}
+      const analyzer = new ProjectAnalyzer(config)
+      expect(analyzer).toBeInstanceOf(ProjectAnalyzer)
+    })
+  })
+
+  describe('createProjectAnalyzer', () => {
+    it('creates ProjectAnalyzer instance', () => {
+      const analyzer = createProjectAnalyzer()
+      expect(analyzer).toBeInstanceOf(ProjectAnalyzer)
+    })
+  })
+
+  describe('analyzeProject', () => {
+    it('returns fallback when AI is not available', async () => {
+      mockIsAIAvailable.mockReturnValue(false)
+      const analyzer = new ProjectAnalyzer()
+
+      const result = await analyzer.analyzeProject({
+        name: 'test-project',
+        description: 'A test CLI tool',
+      })
+
+      expect(result.projectType).toBeDefined()
+      expect(result.features).toContain('typescript')
+      expect(mockComplete).not.toHaveBeenCalled()
+    })
+
+    it('returns AI analysis when available', async () => {
+      mockComplete.mockResolvedValue({
+        success: true,
+        content: JSON.stringify({
+          projectType: 'cli',
+          confidence: 0.95,
+          description: 'A CLI tool',
+          features: ['typescript', 'testing'],
+          dependencies: [{name: 'commander', description: 'CLI framework', confidence: 0.9}],
+          techStack: [
+            {name: 'Node.js', category: 'runtime', reason: 'CLI runtime', confidence: 0.9},
+          ],
+          templates: [
+            {source: {type: 'builtin', location: 'cli'}, reason: 'CLI template', confidence: 0.9},
+          ],
+        }),
+      })
+      const analyzer = new ProjectAnalyzer()
+
+      const result = await analyzer.analyzeProject({
+        name: 'my-cli',
+        description: 'A command line tool',
+      })
+
+      expect(result.projectType).toBe('cli')
+      expect(result.confidence).toBe(0.95)
+      expect(mockComplete).toHaveBeenCalled()
+    })
+
+    it('returns fallback when AI response fails', async () => {
+      mockComplete.mockResolvedValue({success: false, error: 'API error'})
+      const analyzer = new ProjectAnalyzer()
+
+      const result = await analyzer.analyzeProject({name: 'test'})
+
+      expect(result.projectType).toBeDefined()
+    })
+
+    it('returns fallback when JSON parsing fails', async () => {
+      mockComplete.mockResolvedValue({success: true, content: 'Invalid JSON'})
+      const analyzer = new ProjectAnalyzer()
+
+      const result = await analyzer.analyzeProject({name: 'test'})
+
+      expect(result.projectType).toBeDefined()
+    })
+
+    it('clamps confidence between 0 and 1', async () => {
+      mockComplete.mockResolvedValue({
+        success: true,
+        content: JSON.stringify({
+          projectType: 'library',
+          confidence: 1.5,
+          description: 'Test',
+          features: [],
+          dependencies: [],
+          techStack: [],
+          templates: [],
+        }),
+      })
+      const analyzer = new ProjectAnalyzer()
+
+      const result = await analyzer.analyzeProject({name: 'test'})
+
+      expect(result.confidence).toBe(1)
+    })
+
+    it('handles missing fields in response', async () => {
+      mockComplete.mockResolvedValue({
+        success: true,
+        content: JSON.stringify({
+          projectType: 'library',
+        }),
+      })
+      const analyzer = new ProjectAnalyzer()
+
+      const result = await analyzer.analyzeProject({name: 'test'})
+
+      expect(result.features).toEqual([])
+      expect(result.dependencies).toEqual([])
+      expect(result.techStack).toEqual([])
+      expect(result.templates).toEqual([])
+    })
+
+    it('includes input preferences in prompt', async () => {
+      mockComplete.mockResolvedValue({
+        success: true,
+        content: JSON.stringify({
+          projectType: 'library',
+          confidence: 0.8,
+        }),
+      })
+      const analyzer = new ProjectAnalyzer()
+
+      await analyzer.analyzeProject({
+        name: 'test',
+        preferences: {
+          packageManager: 'pnpm',
+          framework: 'react',
+          testingFramework: 'vitest',
+        },
+      })
+
+      expect(mockComplete).toHaveBeenCalledWith(expect.stringContaining('pnpm'), expect.anything())
+    })
+  })
+
+  describe('analyzeExistingProject', () => {
+    it('returns fallback when AI is not available', async () => {
+      mockIsAIAvailable.mockReturnValue(false)
+      const analyzer = new ProjectAnalyzer()
+
+      const result = await analyzer.analyzeExistingProject('/test/project', {
+        name: 'test-project',
+        dependencies: {react: '^18.0.0'},
+      })
+
+      expect(result.projectType).toBeDefined()
+      expect(mockComplete).not.toHaveBeenCalled()
+    })
+
+    it('returns AI analysis when available', async () => {
+      mockComplete.mockResolvedValue({
+        success: true,
+        content: JSON.stringify({
+          projectType: 'web-app',
+          confidence: 0.9,
+          description: 'React app',
+          features: ['react', 'typescript'],
+          dependencies: [],
+          techStack: [],
+          templates: [],
+        }),
+      })
+      const analyzer = new ProjectAnalyzer()
+
+      const result = await analyzer.analyzeExistingProject('/test/project', {
+        name: 'react-app',
+        dependencies: {react: '^18.0.0'},
+      })
+
+      expect(result.projectType).toBe('web-app')
+    })
+
+    it('returns fallback when AI response fails', async () => {
+      mockComplete.mockResolvedValue({success: false, error: 'API error'})
+      const analyzer = new ProjectAnalyzer()
+
+      const result = await analyzer.analyzeExistingProject('/test/project', {
+        name: 'test',
+      })
+
+      expect(result.projectType).toBeDefined()
+    })
+
+    it('detects web-app from react dependency', async () => {
+      mockIsAIAvailable.mockReturnValue(false)
+      const analyzer = new ProjectAnalyzer()
+
+      const result = await analyzer.analyzeExistingProject('/test', {
+        dependencies: {react: '^18.0.0'},
+      })
+
+      expect(result.projectType).toBe('web-app')
+    })
+
+    it('detects CLI from bin field', async () => {
+      mockIsAIAvailable.mockReturnValue(false)
+      const analyzer = new ProjectAnalyzer()
+
+      const result = await analyzer.analyzeExistingProject('/test', {
+        bin: {cli: './dist/cli.js'},
+      })
+
+      expect(result.projectType).toBe('cli')
+    })
+
+    it('detects API from express dependency', async () => {
+      mockIsAIAvailable.mockReturnValue(false)
+      const analyzer = new ProjectAnalyzer()
+
+      const result = await analyzer.analyzeExistingProject('/test', {
+        dependencies: {express: '^4.18.0'},
+      })
+
+      expect(result.projectType).toBe('api')
+    })
+
+    it('detects API from fastify dependency', async () => {
+      mockIsAIAvailable.mockReturnValue(false)
+      const analyzer = new ProjectAnalyzer()
+
+      const result = await analyzer.analyzeExistingProject('/test', {
+        dependencies: {fastify: '^4.0.0'},
+      })
+
+      expect(result.projectType).toBe('api')
+    })
+
+    it('defaults to library for other projects', async () => {
+      mockIsAIAvailable.mockReturnValue(false)
+      const analyzer = new ProjectAnalyzer()
+
+      const result = await analyzer.analyzeExistingProject('/test', {
+        dependencies: {lodash: '^4.17.0'},
+      })
+
+      expect(result.projectType).toBe('library')
+    })
+  })
+
+  describe('fallback keyword-based classification', () => {
+    beforeEach(() => {
+      mockIsAIAvailable.mockReturnValue(false)
+    })
+
+    it('detects CLI from keywords', async () => {
+      const analyzer = new ProjectAnalyzer()
+
+      const result = await analyzer.analyzeProject({
+        description: 'A command line interface tool',
+      })
+
+      expect(result.projectType).toBe('cli')
+      expect(result.templates.some(t => t.source.location === 'cli')).toBe(true)
+    })
+
+    it('detects library from keywords', async () => {
+      const analyzer = new ProjectAnalyzer()
+
+      const result = await analyzer.analyzeProject({
+        description: 'A utility library for npm',
+        keywords: ['lib', 'package'],
+      })
+
+      expect(result.projectType).toBe('library')
+    })
+
+    it('detects web-app from react keywords', async () => {
+      const analyzer = new ProjectAnalyzer()
+
+      const result = await analyzer.analyzeProject({
+        description: 'A React web application',
+      })
+
+      expect(result.projectType).toBe('web-app')
+    })
+
+    it('detects web-app from frontend keywords', async () => {
+      const analyzer = new ProjectAnalyzer()
+
+      const result = await analyzer.analyzeProject({
+        keywords: ['frontend', 'web'],
+      })
+
+      expect(result.projectType).toBe('web-app')
+    })
+
+    it('detects API from server keywords', async () => {
+      const analyzer = new ProjectAnalyzer()
+
+      const result = await analyzer.analyzeProject({
+        description: 'A REST API server',
+      })
+
+      expect(result.projectType).toBe('api')
+    })
+
+    it('detects API from backend keywords', async () => {
+      const analyzer = new ProjectAnalyzer()
+
+      const result = await analyzer.analyzeProject({
+        requirements: ['backend service'],
+      })
+
+      expect(result.projectType).toBe('api')
+    })
+
+    it('defaults to other with no keywords', async () => {
+      const analyzer = new ProjectAnalyzer()
+
+      const result = await analyzer.analyzeProject({
+        name: 'generic-project',
+      })
+
+      expect(result.projectType).toBe('other')
+    })
+
+    it('uses default template when no keywords match', async () => {
+      const analyzer = new ProjectAnalyzer()
+
+      const result = await analyzer.analyzeProject({
+        name: 'generic-project',
+      })
+
+      expect(result.templates.some(t => t.source.location === 'default')).toBe(true)
+    })
+  })
+
+  describe('basic recommendations', () => {
+    beforeEach(() => {
+      mockIsAIAvailable.mockReturnValue(false)
+    })
+
+    it('includes basic dependencies', async () => {
+      const analyzer = new ProjectAnalyzer()
+
+      const result = await analyzer.analyzeProject({name: 'test'})
+
+      expect(result.dependencies.some(d => d.name === 'typescript')).toBe(true)
+      expect(result.dependencies.some(d => d.name === 'eslint')).toBe(true)
+      expect(result.dependencies.some(d => d.name === 'prettier')).toBe(true)
+    })
+
+    it('includes basic tech stack', async () => {
+      const analyzer = new ProjectAnalyzer()
+
+      const result = await analyzer.analyzeProject({name: 'test'})
+
+      expect(result.techStack.some(t => t.name === 'TypeScript')).toBe(true)
+      expect(result.techStack.some(t => t.name === 'ESLint')).toBe(true)
+      expect(result.techStack.some(t => t.name === 'Prettier')).toBe(true)
+    })
+
+    it('includes basic features', async () => {
+      const analyzer = new ProjectAnalyzer()
+
+      const result = await analyzer.analyzeProject({name: 'test'})
+
+      expect(result.features).toContain('typescript')
+      expect(result.features).toContain('eslint')
+      expect(result.features).toContain('prettier')
+    })
+  })
+
+  describe('AI response validation', () => {
+    it('validates dependency objects', async () => {
+      mockComplete.mockResolvedValue({
+        success: true,
+        content: JSON.stringify({
+          projectType: 'library',
+          confidence: 0.8,
+          dependencies: [
+            {name: 'test', confidence: 1.5}, // Invalid confidence
+          ],
+          techStack: [],
+          templates: [],
+          features: [],
+        }),
+      })
+      const analyzer = new ProjectAnalyzer()
+
+      const result = await analyzer.analyzeProject({name: 'test'})
+
+      expect(result.dependencies[0]?.confidence).toBe(1)
+      expect(result.dependencies[0]?.description).toBe('')
+      expect(result.dependencies[0]?.isDev).toBe(false)
+    })
+
+    it('validates tech stack objects', async () => {
+      mockComplete.mockResolvedValue({
+        success: true,
+        content: JSON.stringify({
+          projectType: 'library',
+          confidence: 0.8,
+          dependencies: [],
+          techStack: [
+            {name: 'Node.js', confidence: -0.5}, // Invalid confidence
+          ],
+          templates: [],
+          features: [],
+        }),
+      })
+      const analyzer = new ProjectAnalyzer()
+
+      const result = await analyzer.analyzeProject({name: 'test'})
+
+      expect(result.techStack[0]?.confidence).toBe(0)
+      expect(result.techStack[0]?.category).toBe('other')
+    })
+
+    it('validates template objects', async () => {
+      mockComplete.mockResolvedValue({
+        success: true,
+        content: JSON.stringify({
+          projectType: 'library',
+          confidence: 0.8,
+          dependencies: [],
+          techStack: [],
+          templates: [
+            {reason: 'Test', confidence: 0.5}, // Missing source
+          ],
+          features: [],
+        }),
+      })
+      const analyzer = new ProjectAnalyzer()
+
+      const result = await analyzer.analyzeProject({name: 'test'})
+
+      expect(result.templates[0]?.source).toBeDefined()
+      expect(result.templates[0]?.source.type).toBe('builtin')
+    })
+  })
+})

--- a/packages/create/test/ai/providers/anthropic-adapter.test.ts
+++ b/packages/create/test/ai/providers/anthropic-adapter.test.ts
@@ -1,0 +1,264 @@
+/**
+ * Tests for Anthropic Provider Adapter
+ * Part of Phase 5: Comprehensive Testing Implementation (TASK-036)
+ *
+ * Tests the Anthropic adapter with mocked Anthropic SDK.
+ */
+
+import type {Result} from '@bfra.me/es/result'
+import type {LLMResponse} from '../../../src/types.js'
+import {isErr, isOk} from '@bfra.me/es/result'
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+
+// Store the mock create function for access in tests
+const mockCreate = vi.fn()
+
+// Mock Anthropic SDK before importing the adapter - use factory function
+vi.mock('@anthropic-ai/sdk', () => {
+  const AnthropicMock = vi.fn().mockImplementation(function (this: object) {
+    Object.assign(this, {
+      messages: {
+        create: mockCreate,
+      },
+    })
+  })
+  return {default: AnthropicMock}
+})
+
+// Import the adapter after mocking
+const {createAnthropicAdapter} = await import('../../../src/ai/providers/anthropic-adapter.js')
+
+/** Helper to assert Result is Ok and return data */
+function expectOk<T>(result: Result<T, Error>): T {
+  expect(isOk(result)).toBe(true)
+  if (!isOk(result)) throw new Error('Expected success')
+  return result.data
+}
+
+/** Helper to assert Result is Err and return error */
+function expectErr(result: Result<unknown, Error>): Error {
+  expect(isErr(result)).toBe(true)
+  if (!isErr(result)) throw new Error('Expected error')
+  return result.error
+}
+
+describe('anthropic Provider Adapter', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockCreate.mockReset()
+  })
+
+  describe('createAnthropicAdapter', () => {
+    it('creates adapter with valid config', () => {
+      const adapter = createAnthropicAdapter({
+        apiKey: 'test-api-key',
+      })
+
+      expect(adapter).toBeDefined()
+      expect(adapter.name).toBe('anthropic')
+      expect(adapter.isConfigured).toBeDefined()
+      expect(adapter.complete).toBeDefined()
+      expect(adapter.healthCheck).toBeDefined()
+    })
+
+    it('reports configured when API key provided', () => {
+      const adapter = createAnthropicAdapter({
+        apiKey: 'test-api-key',
+      })
+
+      expect(adapter.isConfigured()).toBe(true)
+    })
+
+    it('reports not configured when API key is empty', () => {
+      const adapter = createAnthropicAdapter({
+        apiKey: '',
+      })
+
+      expect(adapter.isConfigured()).toBe(false)
+    })
+
+    it('accepts custom baseURL', () => {
+      const adapter = createAnthropicAdapter({
+        apiKey: 'test-api-key',
+        baseURL: 'https://custom.anthropic.api/v1',
+      })
+
+      expect(adapter.isConfigured()).toBe(true)
+    })
+
+    it('accepts custom model', () => {
+      const adapter = createAnthropicAdapter({
+        apiKey: 'test-api-key',
+        model: 'claude-3-opus-20240229',
+      })
+
+      expect(adapter.isConfigured()).toBe(true)
+    })
+  })
+
+  describe('complete method', () => {
+    it('returns error when client not initialized', async () => {
+      const adapter = createAnthropicAdapter({apiKey: ''})
+      const result = await adapter.complete('Test prompt')
+
+      const error = expectErr(result)
+      expect(error.message).toContain('not initialized')
+    })
+
+    it('returns successful response', async () => {
+      mockCreate.mockResolvedValue({
+        content: [
+          {
+            type: 'text',
+            text: 'Test response',
+          },
+        ],
+        model: 'claude-3-sonnet-20240229',
+        stop_reason: 'end_turn',
+        usage: {
+          input_tokens: 10,
+          output_tokens: 20,
+        },
+      })
+
+      const adapter = createAnthropicAdapter({apiKey: 'test-key'})
+      const result = await adapter.complete('Test prompt')
+      const data = expectOk<LLMResponse>(result)
+
+      expect(data.success).toBe(true)
+      expect(data.content).toBe('Test response')
+      expect(data.usage).toEqual({
+        promptTokens: 10,
+        completionTokens: 20,
+        totalTokens: 30,
+      })
+      expect(data.metadata?.provider).toBe('anthropic')
+      expect(data.metadata?.model).toBe('claude-3-sonnet-20240229')
+    })
+
+    it('handles non-text content type', async () => {
+      mockCreate.mockResolvedValue({
+        content: [
+          {
+            type: 'image',
+            source: {},
+          },
+        ],
+        model: 'claude-3-sonnet-20240229',
+      })
+
+      const adapter = createAnthropicAdapter({apiKey: 'test-key'})
+      const result = await adapter.complete('Test prompt')
+      const data = expectOk<LLMResponse>(result)
+
+      expect(data.success).toBe(false)
+      expect(data.error).toContain('No text content')
+    })
+
+    it('handles API errors gracefully', async () => {
+      mockCreate.mockRejectedValue(new Error('Rate limit exceeded'))
+
+      const adapter = createAnthropicAdapter({apiKey: 'test-key'})
+      const result = await adapter.complete('Test prompt')
+      const data = expectOk<LLMResponse>(result)
+
+      expect(data.success).toBe(false)
+      expect(data.error).toContain('Rate limit exceeded')
+    })
+
+    it('passes custom options to API', async () => {
+      mockCreate.mockResolvedValue({
+        content: [{type: 'text', text: 'Response'}],
+        model: 'claude-3-sonnet-20240229',
+        usage: {input_tokens: 5, output_tokens: 10},
+      })
+
+      const adapter = createAnthropicAdapter({apiKey: 'test-key'})
+
+      await adapter.complete('Test prompt', {
+        maxTokens: 500,
+        systemPrompt: 'Custom system prompt',
+      })
+
+      expect(mockCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          max_tokens: 500,
+          system: 'Custom system prompt',
+        }),
+      )
+    })
+
+    it('uses default options when not provided', async () => {
+      mockCreate.mockResolvedValue({
+        content: [{type: 'text', text: 'Response'}],
+        model: 'claude-3-sonnet-20240229',
+        usage: {input_tokens: 5, output_tokens: 10},
+      })
+
+      const adapter = createAnthropicAdapter({apiKey: 'test-key'})
+
+      await adapter.complete('Test prompt')
+
+      expect(mockCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          max_tokens: 2000,
+        }),
+      )
+    })
+
+    it('uses custom model from config', async () => {
+      mockCreate.mockResolvedValue({
+        content: [{type: 'text', text: 'Response'}],
+        model: 'claude-3-opus-20240229',
+        usage: {input_tokens: 5, output_tokens: 10},
+      })
+
+      const adapter = createAnthropicAdapter({
+        apiKey: 'test-key',
+        model: 'claude-3-opus-20240229',
+      })
+
+      await adapter.complete('Test prompt')
+
+      expect(mockCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          model: 'claude-3-opus-20240229',
+        }),
+      )
+    })
+  })
+
+  describe('healthCheck method', () => {
+    it('returns error when client not initialized', async () => {
+      const adapter = createAnthropicAdapter({apiKey: ''})
+      const result = await adapter.healthCheck()
+
+      const error = expectErr(result)
+      expect(error.message).toContain('not initialized')
+    })
+
+    it('returns true on successful health check', async () => {
+      mockCreate.mockResolvedValue({
+        content: [{type: 'text', text: 'OK'}],
+        model: 'claude-3-sonnet-20240229',
+        usage: {input_tokens: 1, output_tokens: 1},
+      })
+
+      const adapter = createAnthropicAdapter({apiKey: 'test-key'})
+      const result = await adapter.healthCheck()
+      const data = expectOk<boolean>(result)
+
+      expect(data).toBe(true)
+    })
+
+    it('returns false on API failure', async () => {
+      mockCreate.mockRejectedValue(new Error('API error'))
+
+      const adapter = createAnthropicAdapter({apiKey: 'test-key'})
+      const result = await adapter.healthCheck()
+      const data = expectOk<boolean>(result)
+
+      expect(data).toBe(false)
+    })
+  })
+})

--- a/packages/create/test/ai/providers/openai-adapter.test.ts
+++ b/packages/create/test/ai/providers/openai-adapter.test.ts
@@ -1,0 +1,328 @@
+/**
+ * Tests for OpenAI Provider Adapter
+ * Part of Phase 5: Comprehensive Testing Implementation (TASK-036)
+ *
+ * Tests the OpenAI adapter with mocked OpenAI SDK.
+ */
+
+import type {Result} from '@bfra.me/es/result'
+import type {LLMResponse} from '../../../src/types.js'
+import {isErr, isOk} from '@bfra.me/es/result'
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+
+// Store the mock create function for access in tests
+const mockCreate = vi.fn()
+
+// Mock OpenAI SDK before importing the adapter - use factory function
+vi.mock('openai', () => {
+  const OpenAIMock = vi.fn().mockImplementation(function (this: object) {
+    Object.assign(this, {
+      chat: {
+        completions: {
+          create: mockCreate,
+        },
+      },
+    })
+  })
+  return {default: OpenAIMock}
+})
+
+// Import the adapter after mocking
+const {createOpenAIAdapter} = await import('../../../src/ai/providers/openai-adapter.js')
+
+/** Helper to assert Result is Ok and return data */
+function expectOk<T>(result: Result<T, Error>): T {
+  expect(isOk(result)).toBe(true)
+  if (!isOk(result)) throw new Error('Expected success')
+  return result.data
+}
+
+/** Helper to assert Result is Err and return error */
+function expectErr(result: Result<unknown, Error>): Error {
+  expect(isErr(result)).toBe(true)
+  if (!isErr(result)) throw new Error('Expected error')
+  return result.error
+}
+
+describe('openAI Provider Adapter', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockCreate.mockReset()
+  })
+
+  describe('createOpenAIAdapter', () => {
+    it('creates adapter with valid config', () => {
+      const adapter = createOpenAIAdapter({
+        apiKey: 'test-api-key',
+      })
+
+      expect(adapter).toBeDefined()
+      expect(adapter.name).toBe('openai')
+      expect(adapter.isConfigured).toBeDefined()
+      expect(adapter.complete).toBeDefined()
+      expect(adapter.healthCheck).toBeDefined()
+    })
+
+    it('reports configured when API key provided', () => {
+      const adapter = createOpenAIAdapter({
+        apiKey: 'test-api-key',
+      })
+
+      expect(adapter.isConfigured()).toBe(true)
+    })
+
+    it('reports not configured when API key is empty', () => {
+      const adapter = createOpenAIAdapter({
+        apiKey: '',
+      })
+
+      expect(adapter.isConfigured()).toBe(false)
+    })
+
+    it('accepts custom baseURL', () => {
+      const adapter = createOpenAIAdapter({
+        apiKey: 'test-api-key',
+        baseURL: 'https://custom.openai.api/v1',
+      })
+
+      expect(adapter.isConfigured()).toBe(true)
+    })
+
+    it('accepts custom model', () => {
+      const adapter = createOpenAIAdapter({
+        apiKey: 'test-api-key',
+        model: 'gpt-4-turbo',
+      })
+
+      expect(adapter.isConfigured()).toBe(true)
+    })
+  })
+
+  describe('complete method', () => {
+    it('returns error when client not initialized', async () => {
+      const adapter = createOpenAIAdapter({apiKey: ''})
+      const result = await adapter.complete('Test prompt')
+
+      const error = expectErr(result)
+      expect(error.message).toContain('not initialized')
+    })
+
+    it('returns successful response', async () => {
+      mockCreate.mockResolvedValue({
+        choices: [
+          {
+            message: {content: 'Test response'},
+            finish_reason: 'stop',
+          },
+        ],
+        model: 'gpt-4',
+        usage: {
+          prompt_tokens: 10,
+          completion_tokens: 20,
+          total_tokens: 30,
+        },
+      })
+
+      const adapter = createOpenAIAdapter({apiKey: 'test-key'})
+      const result = await adapter.complete('Test prompt')
+      const data = expectOk<LLMResponse>(result)
+
+      expect(data.success).toBe(true)
+      expect(data.content).toBe('Test response')
+      expect(data.usage).toEqual({
+        promptTokens: 10,
+        completionTokens: 20,
+        totalTokens: 30,
+      })
+      expect(data.metadata?.provider).toBe('openai')
+      expect(data.metadata?.model).toBe('gpt-4')
+    })
+
+    it('handles empty response content', async () => {
+      mockCreate.mockResolvedValue({
+        choices: [
+          {
+            message: {content: ''},
+            finish_reason: 'stop',
+          },
+        ],
+        model: 'gpt-4',
+      })
+
+      const adapter = createOpenAIAdapter({apiKey: 'test-key'})
+      const result = await adapter.complete('Test prompt')
+      const data = expectOk<LLMResponse>(result)
+
+      expect(data.success).toBe(false)
+      expect(data.error).toContain('No content')
+    })
+
+    it('handles null message content', async () => {
+      mockCreate.mockResolvedValue({
+        choices: [
+          {
+            message: {content: null},
+            finish_reason: 'stop',
+          },
+        ],
+        model: 'gpt-4',
+      })
+
+      const adapter = createOpenAIAdapter({apiKey: 'test-key'})
+      const result = await adapter.complete('Test prompt')
+      const data = expectOk<LLMResponse>(result)
+
+      expect(data.success).toBe(false)
+      expect(data.error).toContain('No content')
+    })
+
+    it('handles API errors gracefully', async () => {
+      mockCreate.mockRejectedValue(new Error('Rate limit exceeded'))
+
+      const adapter = createOpenAIAdapter({apiKey: 'test-key'})
+      const result = await adapter.complete('Test prompt')
+      const data = expectOk<LLMResponse>(result)
+
+      expect(data.success).toBe(false)
+      expect(data.error).toContain('Rate limit exceeded')
+    })
+
+    it('passes custom options to API', async () => {
+      mockCreate.mockResolvedValue({
+        choices: [
+          {
+            message: {content: 'Response'},
+            finish_reason: 'stop',
+          },
+        ],
+        model: 'gpt-4',
+      })
+
+      const adapter = createOpenAIAdapter({apiKey: 'test-key'})
+
+      await adapter.complete('Test prompt', {
+        maxTokens: 500,
+        temperature: 0.3,
+        systemPrompt: 'Custom system prompt',
+      })
+
+      expect(mockCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          max_tokens: 500,
+          temperature: 0.3,
+          messages: expect.arrayContaining([
+            expect.objectContaining({
+              role: 'system',
+              content: 'Custom system prompt',
+            }),
+          ]),
+        }),
+      )
+    })
+
+    it('uses default options when not provided', async () => {
+      mockCreate.mockResolvedValue({
+        choices: [
+          {
+            message: {content: 'Response'},
+            finish_reason: 'stop',
+          },
+        ],
+        model: 'gpt-4',
+      })
+
+      const adapter = createOpenAIAdapter({apiKey: 'test-key'})
+
+      await adapter.complete('Test prompt')
+
+      expect(mockCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          max_tokens: 2000,
+          temperature: 0.7,
+        }),
+      )
+    })
+
+    it('uses custom model from config', async () => {
+      mockCreate.mockResolvedValue({
+        choices: [
+          {
+            message: {content: 'Response'},
+            finish_reason: 'stop',
+          },
+        ],
+        model: 'gpt-4-turbo',
+      })
+
+      const adapter = createOpenAIAdapter({
+        apiKey: 'test-key',
+        model: 'gpt-4-turbo',
+      })
+
+      await adapter.complete('Test prompt')
+
+      expect(mockCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          model: 'gpt-4-turbo',
+        }),
+      )
+    })
+
+    it('handles response without usage data', async () => {
+      mockCreate.mockResolvedValue({
+        choices: [
+          {
+            message: {content: 'Response'},
+            finish_reason: 'stop',
+          },
+        ],
+        model: 'gpt-4',
+      })
+
+      const adapter = createOpenAIAdapter({apiKey: 'test-key'})
+      const result = await adapter.complete('Test prompt')
+      const data = expectOk<LLMResponse>(result)
+
+      expect(data.success).toBe(true)
+      expect(data.usage).toBeUndefined()
+    })
+  })
+
+  describe('healthCheck method', () => {
+    it('returns error when client not initialized', async () => {
+      const adapter = createOpenAIAdapter({apiKey: ''})
+      const result = await adapter.healthCheck()
+
+      const error = expectErr(result)
+      expect(error.message).toContain('not initialized')
+    })
+
+    it('returns true on successful health check', async () => {
+      mockCreate.mockResolvedValue({
+        choices: [
+          {
+            message: {content: 'OK'},
+            finish_reason: 'stop',
+          },
+        ],
+        model: 'gpt-4',
+      })
+
+      const adapter = createOpenAIAdapter({apiKey: 'test-key'})
+      const result = await adapter.healthCheck()
+      const data = expectOk<boolean>(result)
+
+      expect(data).toBe(true)
+    })
+
+    it('returns false on API failure', async () => {
+      mockCreate.mockRejectedValue(new Error('API error'))
+
+      const adapter = createOpenAIAdapter({apiKey: 'test-key'})
+      const result = await adapter.healthCheck()
+      const data = expectOk<boolean>(result)
+
+      expect(data).toBe(false)
+    })
+  })
+})

--- a/packages/create/test/ai/providers/types.test.ts
+++ b/packages/create/test/ai/providers/types.test.ts
@@ -1,0 +1,183 @@
+/**
+ * Tests for Provider Types Helper Functions
+ * Part of Phase 5: Comprehensive Testing Implementation (TASK-036)
+ *
+ * Tests the helper functions in provider types.
+ */
+
+import type {AIConfig} from '../../../src/types.js'
+import {describe, expect, it} from 'vitest'
+import {createClientConfig, extractProviderConfig} from '../../../src/ai/providers/types.js'
+
+describe('provider Types', () => {
+  describe('extractProviderConfig', () => {
+    it('extracts OpenAI config when present', () => {
+      const aiConfig: AIConfig = {
+        enabled: true,
+        provider: 'openai',
+        maxTokens: 2000,
+        temperature: 0.7,
+        openai: {
+          apiKey: 'test-openai-key',
+          baseURL: 'https://custom.api',
+          model: 'gpt-4-turbo',
+        },
+      }
+
+      const result = extractProviderConfig(aiConfig, 'openai')
+
+      expect(result).toBeDefined()
+      expect(result?.apiKey).toBe('test-openai-key')
+      expect(result?.baseURL).toBe('https://custom.api')
+      expect(result?.model).toBe('gpt-4-turbo')
+    })
+
+    it('extracts Anthropic config when present', () => {
+      const aiConfig: AIConfig = {
+        enabled: true,
+        provider: 'anthropic',
+        maxTokens: 2000,
+        temperature: 0.7,
+        anthropic: {
+          apiKey: 'test-anthropic-key',
+          model: 'claude-3-opus',
+        },
+      }
+
+      const result = extractProviderConfig(aiConfig, 'anthropic')
+
+      expect(result).toBeDefined()
+      expect(result?.apiKey).toBe('test-anthropic-key')
+      expect(result?.model).toBe('claude-3-opus')
+    })
+
+    it('returns undefined when provider config is missing', () => {
+      const aiConfig: AIConfig = {
+        enabled: true,
+        provider: 'openai',
+        maxTokens: 2000,
+        temperature: 0.7,
+      }
+
+      const result = extractProviderConfig(aiConfig, 'openai')
+
+      expect(result).toBeUndefined()
+    })
+
+    it('returns undefined when API key is empty', () => {
+      const aiConfig: AIConfig = {
+        enabled: true,
+        provider: 'openai',
+        maxTokens: 2000,
+        temperature: 0.7,
+        openai: {
+          apiKey: '',
+          model: 'gpt-4',
+        },
+      }
+
+      const result = extractProviderConfig(aiConfig, 'openai')
+
+      expect(result).toBeUndefined()
+    })
+  })
+
+  describe('createClientConfig', () => {
+    it('creates config with defaults when empty config provided', () => {
+      const result = createClientConfig({})
+
+      expect(result.enabled).toBe(true)
+      expect(result.provider).toBe('auto')
+      expect(result.maxTokens).toBe(2000)
+      expect(result.temperature).toBe(0.7)
+      expect(result.openai).toBeUndefined()
+      expect(result.anthropic).toBeUndefined()
+    })
+
+    it('uses provided values over defaults', () => {
+      const config: Partial<AIConfig> = {
+        enabled: false,
+        provider: 'anthropic',
+        maxTokens: 4000,
+        temperature: 0.5,
+      }
+
+      const result = createClientConfig(config)
+
+      expect(result.enabled).toBe(false)
+      expect(result.provider).toBe('anthropic')
+      expect(result.maxTokens).toBe(4000)
+      expect(result.temperature).toBe(0.5)
+    })
+
+    it('includes OpenAI config when API key provided', () => {
+      const config: Partial<AIConfig> = {
+        openai: {
+          apiKey: 'test-key',
+          model: 'gpt-4',
+        },
+      }
+
+      const result = createClientConfig(config)
+
+      expect(result.openai).toBeDefined()
+      expect(result.openai?.apiKey).toBe('test-key')
+      expect(result.openai?.model).toBe('gpt-4')
+    })
+
+    it('excludes OpenAI config when API key not provided', () => {
+      const config: Partial<AIConfig> = {
+        openai: {
+          model: 'gpt-4',
+        } as AIConfig['openai'],
+      }
+
+      const result = createClientConfig(config)
+
+      expect(result.openai).toBeUndefined()
+    })
+
+    it('includes Anthropic config when API key provided', () => {
+      const config: Partial<AIConfig> = {
+        anthropic: {
+          apiKey: 'test-key',
+          model: 'claude-3',
+        },
+      }
+
+      const result = createClientConfig(config)
+
+      expect(result.anthropic).toBeDefined()
+      expect(result.anthropic?.apiKey).toBe('test-key')
+      expect(result.anthropic?.model).toBe('claude-3')
+    })
+
+    it('excludes Anthropic config when API key not provided', () => {
+      const config: Partial<AIConfig> = {
+        anthropic: {
+          model: 'claude-3',
+        } as AIConfig['anthropic'],
+      }
+
+      const result = createClientConfig(config)
+
+      expect(result.anthropic).toBeUndefined()
+    })
+
+    it('handles both providers', () => {
+      const config: Partial<AIConfig> = {
+        openai: {
+          apiKey: 'openai-key',
+        },
+        anthropic: {
+          apiKey: 'anthropic-key',
+        },
+      }
+
+      const result = createClientConfig(config)
+
+      expect(result.openai).toBeDefined()
+      expect(result.anthropic).toBeDefined()
+    })
+  })
+})

--- a/packages/create/test/features/components.test.ts
+++ b/packages/create/test/features/components.test.ts
@@ -1,0 +1,391 @@
+import type {FeatureAddContext} from '../../src/types.js'
+import {existsSync, mkdirSync} from 'node:fs'
+import {writeFile} from 'node:fs/promises'
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
+import {addComponentFeature} from '../../src/features/components.js'
+
+vi.mock('node:fs', () => ({
+  existsSync: vi.fn(),
+  mkdirSync: vi.fn(),
+}))
+
+vi.mock('node:fs/promises', () => ({
+  writeFile: vi.fn().mockResolvedValue(undefined),
+}))
+
+vi.mock('consola', () => ({
+  consola: {
+    info: vi.fn(),
+    success: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}))
+
+const mockExistsSync = vi.mocked(existsSync)
+const mockMkdirSync = vi.mocked(mkdirSync)
+const mockWriteFile = vi.mocked(writeFile)
+
+describe('addComponentFeature', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockExistsSync.mockReturnValue(false)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe('validation', () => {
+    it('should throw error when component name is not provided', async () => {
+      const context: FeatureAddContext = {
+        targetDir: '/test/project',
+        projectInfo: {type: 'react'},
+        options: {},
+      }
+
+      await expect(addComponentFeature('react-component', context)).rejects.toThrow(
+        'Component name is required',
+      )
+    })
+
+    it('should throw error when component name is not PascalCase', async () => {
+      const context: FeatureAddContext = {
+        targetDir: '/test/project',
+        projectInfo: {type: 'react'},
+        options: {name: 'myComponent'},
+      }
+
+      await expect(addComponentFeature('react-component', context)).rejects.toThrow(
+        'Component name must be PascalCase',
+      )
+    })
+
+    it('should throw error for lowercase component name', async () => {
+      const context: FeatureAddContext = {
+        targetDir: '/test/project',
+        projectInfo: {type: 'react'},
+        options: {name: 'mycomponent'},
+      }
+
+      await expect(addComponentFeature('react-component', context)).rejects.toThrow(
+        'Component name must be PascalCase',
+      )
+    })
+
+    it('should throw error for component name starting with number', async () => {
+      const context: FeatureAddContext = {
+        targetDir: '/test/project',
+        projectInfo: {type: 'react'},
+        options: {name: '1Component'},
+      }
+
+      await expect(addComponentFeature('react-component', context)).rejects.toThrow(
+        'Component name must be PascalCase',
+      )
+    })
+
+    it('should accept valid PascalCase component names', async () => {
+      const context: FeatureAddContext = {
+        targetDir: '/test/project',
+        projectInfo: {type: 'typescript'},
+        options: {name: 'MyComponent'},
+      }
+
+      await expect(addComponentFeature('react-component', context)).resolves.not.toThrow()
+    })
+
+    it('should throw error for unsupported component type', async () => {
+      const context: FeatureAddContext = {
+        targetDir: '/test/project',
+        projectInfo: {type: 'react'},
+        options: {name: 'MyComponent'},
+      }
+
+      await expect(addComponentFeature('angular-component', context)).rejects.toThrow(
+        'Unsupported component type: angular-component',
+      )
+    })
+  })
+
+  describe('react-component', () => {
+    it('should create component directory if it does not exist', async () => {
+      mockExistsSync.mockReturnValue(false)
+      const context: FeatureAddContext = {
+        targetDir: '/test/project',
+        projectInfo: {type: 'typescript'},
+        options: {name: 'Button'},
+      }
+
+      await addComponentFeature('react-component', context)
+
+      expect(mockMkdirSync).toHaveBeenCalledWith(expect.stringContaining('components'), {
+        recursive: true,
+      })
+    })
+
+    it('should not create directory if it already exists', async () => {
+      mockExistsSync.mockReturnValue(true)
+      const context: FeatureAddContext = {
+        targetDir: '/test/project',
+        projectInfo: {type: 'typescript'},
+        options: {name: 'Button'},
+      }
+
+      await addComponentFeature('react-component', context)
+
+      expect(mockMkdirSync).not.toHaveBeenCalled()
+    })
+
+    it('should create TSX component file for TypeScript projects', async () => {
+      const context: FeatureAddContext = {
+        targetDir: '/test/project',
+        projectInfo: {type: 'typescript'},
+        options: {name: 'Button'},
+      }
+
+      await addComponentFeature('react-component', context)
+
+      expect(mockWriteFile).toHaveBeenCalledWith(
+        expect.stringContaining('Button.tsx'),
+        expect.stringContaining('export default function Button'),
+        'utf-8',
+      )
+    })
+
+    it('should create JSX component file for JavaScript projects', async () => {
+      const context: FeatureAddContext = {
+        targetDir: '/test/project',
+        projectInfo: {type: 'javascript'},
+        options: {name: 'Button', withTest: false},
+      }
+
+      await addComponentFeature('react-component', context)
+
+      expect(mockWriteFile).toHaveBeenCalledWith(
+        expect.stringContaining('Button.jsx'),
+        expect.stringContaining('export default function Button'),
+        'utf-8',
+      )
+    })
+
+    it('should create test file by default', async () => {
+      const context: FeatureAddContext = {
+        targetDir: '/test/project',
+        projectInfo: {type: 'typescript'},
+        options: {name: 'Button'},
+      }
+
+      await addComponentFeature('react-component', context)
+
+      expect(mockWriteFile).toHaveBeenCalledWith(
+        expect.stringContaining('Button.test.tsx'),
+        expect.any(String),
+        'utf-8',
+      )
+    })
+
+    it('should not create test file when withTest is false', async () => {
+      const context: FeatureAddContext = {
+        targetDir: '/test/project',
+        projectInfo: {type: 'typescript'},
+        options: {name: 'Button', withTest: false},
+      }
+
+      await addComponentFeature('react-component', context)
+
+      const writeFileCalls = mockWriteFile.mock.calls
+      const testFileCreated = writeFileCalls.some(call => String(call[0]).includes('.test.'))
+      expect(testFileCreated).toBe(false)
+    })
+
+    it('should create story file when withStory is true', async () => {
+      const context: FeatureAddContext = {
+        targetDir: '/test/project',
+        projectInfo: {type: 'typescript'},
+        options: {name: 'Button', withStory: true},
+      }
+
+      await addComponentFeature('react-component', context)
+
+      expect(mockWriteFile).toHaveBeenCalledWith(
+        expect.stringContaining('Button.stories.tsx'),
+        expect.any(String),
+        'utf-8',
+      )
+    })
+
+    it('should not create story file by default', async () => {
+      const context: FeatureAddContext = {
+        targetDir: '/test/project',
+        projectInfo: {type: 'typescript'},
+        options: {name: 'Button'},
+      }
+
+      await addComponentFeature('react-component', context)
+
+      const writeFileCalls = mockWriteFile.mock.calls
+      const storyFileCreated = writeFileCalls.some(call => String(call[0]).includes('.stories.'))
+      expect(storyFileCreated).toBe(false)
+    })
+
+    it('should create index file for easy imports', async () => {
+      const context: FeatureAddContext = {
+        targetDir: '/test/project',
+        projectInfo: {type: 'typescript'},
+        options: {name: 'Button'},
+      }
+
+      await addComponentFeature('react-component', context)
+
+      expect(mockWriteFile).toHaveBeenCalledWith(
+        expect.stringContaining('index.ts'),
+        expect.stringContaining("export { default } from './Button'"),
+        'utf-8',
+      )
+    })
+
+    it('should use custom component path when provided', async () => {
+      const context: FeatureAddContext = {
+        targetDir: '/test/project',
+        projectInfo: {type: 'typescript'},
+        options: {name: 'Button', path: 'ui/atoms'},
+      }
+
+      await addComponentFeature('react-component', context)
+
+      expect(mockWriteFile).toHaveBeenCalledWith(
+        expect.stringMatching(/ui\/atoms.*Button\.tsx$/),
+        expect.any(String),
+        'utf-8',
+      )
+    })
+
+    it('should include TypeScript interface in TSX component', async () => {
+      const context: FeatureAddContext = {
+        targetDir: '/test/project',
+        projectInfo: {type: 'typescript'},
+        options: {name: 'Card', withTest: false},
+      }
+
+      await addComponentFeature('react-component', context)
+
+      const componentCall = mockWriteFile.mock.calls.find(call =>
+        String(call[0]).includes('Card.tsx'),
+      )
+      expect(componentCall).toBeDefined()
+      expect(componentCall?.[1]).toContain('export interface CardProps')
+    })
+  })
+
+  describe('vue-component', () => {
+    it('should create Vue component file', async () => {
+      const context: FeatureAddContext = {
+        targetDir: '/test/project',
+        projectInfo: {type: 'typescript'},
+        options: {name: 'Button'},
+      }
+
+      await addComponentFeature('vue-component', context)
+
+      expect(mockWriteFile).toHaveBeenCalledWith(
+        expect.stringContaining('Button.vue'),
+        expect.any(String),
+        'utf-8',
+      )
+    })
+
+    it('should create Vue component with TypeScript script', async () => {
+      const context: FeatureAddContext = {
+        targetDir: '/test/project',
+        projectInfo: {type: 'typescript'},
+        options: {name: 'Button', withTest: false},
+      }
+
+      await addComponentFeature('vue-component', context)
+
+      const vueCall = mockWriteFile.mock.calls.find(call => String(call[0]).includes('Button.vue'))
+      expect(vueCall?.[1]).toContain('lang="ts"')
+    })
+
+    it('should create Vue test file with TypeScript when project is TypeScript', async () => {
+      const context: FeatureAddContext = {
+        targetDir: '/test/project',
+        projectInfo: {type: 'typescript'},
+        options: {name: 'Button'},
+      }
+
+      await addComponentFeature('vue-component', context)
+
+      expect(mockWriteFile).toHaveBeenCalledWith(
+        expect.stringContaining('Button.test.ts'),
+        expect.any(String),
+        'utf-8',
+      )
+    })
+
+    it('should create Vue test file with JavaScript when project is JavaScript', async () => {
+      const context: FeatureAddContext = {
+        targetDir: '/test/project',
+        projectInfo: {type: 'javascript'},
+        options: {name: 'Button'},
+      }
+
+      await addComponentFeature('vue-component', context)
+
+      expect(mockWriteFile).toHaveBeenCalledWith(
+        expect.stringContaining('Button.test.js'),
+        expect.any(String),
+        'utf-8',
+      )
+    })
+  })
+
+  describe('dry run mode', () => {
+    it('should not create files in dry run mode', async () => {
+      const context: FeatureAddContext = {
+        targetDir: '/test/project',
+        projectInfo: {type: 'typescript'},
+        dryRun: true,
+        options: {name: 'Button'},
+      }
+
+      await addComponentFeature('react-component', context)
+
+      expect(mockWriteFile).not.toHaveBeenCalled()
+    })
+
+    it('should not create directories in dry run mode', async () => {
+      mockExistsSync.mockReturnValue(false)
+      const context: FeatureAddContext = {
+        targetDir: '/test/project',
+        projectInfo: {type: 'typescript'},
+        dryRun: true,
+        options: {name: 'Button'},
+      }
+
+      await addComponentFeature('react-component', context)
+
+      expect(mockMkdirSync).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('verbose mode', () => {
+    it('should log messages in verbose mode', async () => {
+      const {consola} = await import('consola')
+      const mockConsola = vi.mocked(consola)
+
+      const context: FeatureAddContext = {
+        targetDir: '/test/project',
+        projectInfo: {type: 'typescript'},
+        verbose: true,
+        options: {name: 'Button'},
+      }
+
+      await addComponentFeature('react-component', context)
+
+      expect(mockConsola.info).toHaveBeenCalledWith('Adding react-component...')
+      expect(mockConsola.success).toHaveBeenCalled()
+    })
+  })
+})

--- a/packages/create/test/features/prettier.test.ts
+++ b/packages/create/test/features/prettier.test.ts
@@ -1,0 +1,287 @@
+import type {FeatureAddContext, ProjectInfo} from '../../src/types.js'
+import {existsSync, mkdirSync, rmSync, writeFileSync} from 'node:fs'
+import {readFile} from 'node:fs/promises'
+import path from 'node:path'
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
+import {addPrettierFeature} from '../../src/features/prettier.js'
+
+interface PackageJson {
+  name: string
+  scripts?: Record<string, string>
+  dependencies?: Record<string, string>
+  devDependencies?: Record<string, string>
+}
+
+// Mock consola
+vi.mock('consola', () => ({
+  consola: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}))
+
+// Mock package-manager
+vi.mock('../../src/utils/package-manager.js', () => ({
+  addDependencies: vi.fn().mockResolvedValue(undefined),
+}))
+
+describe('prettier feature', () => {
+  let tempDir: string
+  let defaultProjectInfo: ProjectInfo
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    tempDir = path.join(process.cwd(), `test-temp-prettier-${Date.now()}`)
+    mkdirSync(tempDir, {recursive: true})
+    writeFileSync(
+      path.join(tempDir, 'package.json'),
+      JSON.stringify({name: 'test-project'}, null, 2),
+    )
+    defaultProjectInfo = {
+      type: 'typescript',
+      packageManager: 'pnpm',
+    }
+  })
+
+  afterEach(() => {
+    if (existsSync(tempDir)) {
+      rmSync(tempDir, {recursive: true, force: true})
+    }
+  })
+
+  describe('addPrettierFeature', () => {
+    it('should create .prettierrc file with correct content', async () => {
+      const context: FeatureAddContext = {
+        targetDir: tempDir,
+        projectInfo: defaultProjectInfo,
+        verbose: false,
+        dryRun: false,
+      }
+
+      await addPrettierFeature(context)
+
+      const prettierrcPath = path.join(tempDir, '.prettierrc')
+      expect(existsSync(prettierrcPath)).toBe(true)
+
+      const content = await readFile(prettierrcPath, 'utf-8')
+      expect(content).toBe('"@bfra.me/prettier-config"\n')
+    })
+
+    it('should add format scripts to package.json', async () => {
+      const context: FeatureAddContext = {
+        targetDir: tempDir,
+        projectInfo: {...defaultProjectInfo, packageManager: 'npm'},
+        verbose: false,
+        dryRun: false,
+      }
+
+      await addPrettierFeature(context)
+
+      const packageJsonContent = await readFile(path.join(tempDir, 'package.json'), 'utf-8')
+      const packageJson = JSON.parse(packageJsonContent) as PackageJson
+
+      expect(packageJson.scripts).toBeDefined()
+      expect(packageJson.scripts?.format).toBe('prettier --write .')
+      expect(packageJson.scripts?.['format:check']).toBe('prettier --check .')
+    })
+
+    it('should call addDependencies with correct packages', async () => {
+      const {addDependencies} = await import('../../src/utils/package-manager.js')
+
+      const context: FeatureAddContext = {
+        targetDir: tempDir,
+        projectInfo: defaultProjectInfo,
+        verbose: false,
+        dryRun: false,
+      }
+
+      await addPrettierFeature(context)
+
+      expect(addDependencies).toHaveBeenCalledWith(
+        tempDir,
+        [],
+        ['@bfra.me/prettier-config', 'prettier'],
+        'pnpm',
+        false,
+      )
+    })
+
+    it('should warn when existing prettier config found with verbose', async () => {
+      const {consola} = await import('consola')
+
+      // Create an existing config
+      writeFileSync(path.join(tempDir, '.prettierrc.json'), '{}')
+
+      const context: FeatureAddContext = {
+        targetDir: tempDir,
+        projectInfo: defaultProjectInfo,
+        verbose: true,
+        dryRun: false,
+      }
+
+      await addPrettierFeature(context)
+
+      expect(consola.warn).toHaveBeenCalledWith('Existing Prettier config found: .prettierrc.json')
+    })
+
+    it('should log info message with verbose enabled', async () => {
+      const {consola} = await import('consola')
+
+      const context: FeatureAddContext = {
+        targetDir: tempDir,
+        projectInfo: {...defaultProjectInfo, packageManager: 'npm'},
+        verbose: true,
+        dryRun: false,
+      }
+
+      await addPrettierFeature(context)
+
+      expect(consola.info).toHaveBeenCalledWith('Adding Prettier configuration...')
+    })
+
+    describe('dry run mode', () => {
+      it('should not create files in dry run mode', async () => {
+        const context: FeatureAddContext = {
+          targetDir: tempDir,
+          projectInfo: defaultProjectInfo,
+          verbose: false,
+          dryRun: true,
+        }
+
+        await addPrettierFeature(context)
+
+        const prettierrcPath = path.join(tempDir, '.prettierrc')
+        expect(existsSync(prettierrcPath)).toBe(false)
+      })
+
+      it('should not call addDependencies in dry run mode', async () => {
+        const {addDependencies} = await import('../../src/utils/package-manager.js')
+
+        const context: FeatureAddContext = {
+          targetDir: tempDir,
+          projectInfo: defaultProjectInfo,
+          verbose: false,
+          dryRun: true,
+        }
+
+        await addPrettierFeature(context)
+
+        expect(addDependencies).not.toHaveBeenCalled()
+      })
+
+      it('should log what would be created in dry run mode', async () => {
+        const {consola} = await import('consola')
+
+        const context: FeatureAddContext = {
+          targetDir: tempDir,
+          projectInfo: defaultProjectInfo,
+          verbose: false,
+          dryRun: true,
+        }
+
+        await addPrettierFeature(context)
+
+        expect(consola.info).toHaveBeenCalledWith('Would create .prettierrc')
+        expect(consola.info).toHaveBeenCalledWith(
+          'Would add dev dependencies: @bfra.me/prettier-config, prettier',
+        )
+      })
+    })
+
+    it('should not modify scripts if they already exist', async () => {
+      // Create package.json with existing scripts
+      writeFileSync(
+        path.join(tempDir, 'package.json'),
+        JSON.stringify(
+          {
+            name: 'test-project',
+            scripts: {
+              format: 'existing-format-script',
+              'format:check': 'existing-check-script',
+            },
+          },
+          null,
+          2,
+        ),
+      )
+
+      const context: FeatureAddContext = {
+        targetDir: tempDir,
+        projectInfo: {...defaultProjectInfo, packageManager: 'npm'},
+        verbose: false,
+        dryRun: false,
+      }
+
+      await addPrettierFeature(context)
+
+      const packageJsonContent = await readFile(path.join(tempDir, 'package.json'), 'utf-8')
+      const packageJson = JSON.parse(packageJsonContent) as PackageJson
+
+      expect(packageJson.scripts?.format).toBe('existing-format-script')
+      expect(packageJson.scripts?.['format:check']).toBe('existing-check-script')
+    })
+
+    it('should handle package.json without scripts property', async () => {
+      writeFileSync(
+        path.join(tempDir, 'package.json'),
+        JSON.stringify({name: 'test-project'}, null, 2),
+      )
+
+      const context: FeatureAddContext = {
+        targetDir: tempDir,
+        projectInfo: {...defaultProjectInfo, packageManager: 'npm'},
+        verbose: false,
+        dryRun: false,
+      }
+
+      await addPrettierFeature(context)
+
+      const packageJsonContent = await readFile(path.join(tempDir, 'package.json'), 'utf-8')
+      const packageJson = JSON.parse(packageJsonContent) as PackageJson
+
+      expect(packageJson.scripts).toBeDefined()
+      expect(packageJson.scripts?.format).toBe('prettier --write .')
+    })
+
+    it('should detect various existing config formats', async () => {
+      const configFormats = [
+        '.prettierrc',
+        '.prettierrc.json',
+        '.prettierrc.yml',
+        '.prettierrc.yaml',
+        '.prettierrc.js',
+        'prettier.config.js',
+        'prettier.config.cjs',
+      ]
+
+      for (const configFile of configFormats) {
+        // Clean up and recreate temp dir
+        if (existsSync(tempDir)) {
+          rmSync(tempDir, {recursive: true, force: true})
+        }
+        mkdirSync(tempDir, {recursive: true})
+        writeFileSync(
+          path.join(tempDir, 'package.json'),
+          JSON.stringify({name: 'test-project'}, null, 2),
+        )
+        writeFileSync(path.join(tempDir, configFile), '{}')
+
+        const {consola} = await import('consola')
+        vi.mocked(consola.warn).mockClear()
+
+        const context: FeatureAddContext = {
+          targetDir: tempDir,
+          projectInfo: defaultProjectInfo,
+          verbose: true,
+          dryRun: false,
+        }
+
+        await addPrettierFeature(context)
+
+        expect(consola.warn).toHaveBeenCalledWith(`Existing Prettier config found: ${configFile}`)
+      }
+    })
+  })
+})

--- a/packages/create/test/features/vitest.test.ts
+++ b/packages/create/test/features/vitest.test.ts
@@ -1,0 +1,377 @@
+import type {FeatureAddContext, ProjectInfo} from '../../src/types.js'
+import {existsSync, mkdirSync, rmSync, writeFileSync} from 'node:fs'
+import {readFile} from 'node:fs/promises'
+import path from 'node:path'
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
+import {addVitestFeature} from '../../src/features/vitest.js'
+
+interface PackageJson {
+  name: string
+  scripts?: Record<string, string>
+  dependencies?: Record<string, string>
+  devDependencies?: Record<string, string>
+}
+
+// Mock consola
+vi.mock('consola', () => ({
+  consola: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}))
+
+// Mock package-manager
+vi.mock('../../src/utils/package-manager.js', () => ({
+  addDependencies: vi.fn().mockResolvedValue(undefined),
+}))
+
+describe('vitest feature', () => {
+  let tempDir: string
+  let defaultProjectInfo: ProjectInfo
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    tempDir = path.join(process.cwd(), `test-temp-vitest-${Date.now()}`)
+    mkdirSync(tempDir, {recursive: true})
+    writeFileSync(
+      path.join(tempDir, 'package.json'),
+      JSON.stringify({name: 'test-project'}, null, 2),
+    )
+    defaultProjectInfo = {
+      type: 'typescript',
+      packageManager: 'pnpm',
+    }
+  })
+
+  afterEach(() => {
+    if (existsSync(tempDir)) {
+      rmSync(tempDir, {recursive: true, force: true})
+    }
+  })
+
+  describe('addVitestFeature', () => {
+    it('should create vitest.config.ts for typescript projects', async () => {
+      const context: FeatureAddContext = {
+        targetDir: tempDir,
+        projectInfo: defaultProjectInfo,
+        verbose: false,
+        dryRun: false,
+      }
+
+      await addVitestFeature(context)
+
+      const configPath = path.join(tempDir, 'vitest.config.ts')
+      expect(existsSync(configPath)).toBe(true)
+
+      const content = await readFile(configPath, 'utf-8')
+      expect(content).toContain('defineConfig')
+      expect(content).toContain('environment: "node"')
+    })
+
+    it('should create vitest.config.js for javascript projects', async () => {
+      const context: FeatureAddContext = {
+        targetDir: tempDir,
+        projectInfo: {...defaultProjectInfo, type: 'javascript'},
+        verbose: false,
+        dryRun: false,
+      }
+
+      await addVitestFeature(context)
+
+      const configPath = path.join(tempDir, 'vitest.config.js')
+      expect(existsSync(configPath)).toBe(true)
+    })
+
+    it('should create test directory and sample test file', async () => {
+      const context: FeatureAddContext = {
+        targetDir: tempDir,
+        projectInfo: defaultProjectInfo,
+        verbose: false,
+        dryRun: false,
+      }
+
+      await addVitestFeature(context)
+
+      const testDir = path.join(tempDir, 'test')
+      expect(existsSync(testDir)).toBe(true)
+
+      const testFile = path.join(testDir, 'example.test.ts')
+      expect(existsSync(testFile)).toBe(true)
+
+      const content = await readFile(testFile, 'utf-8')
+      expect(content).toContain("describe('Example Test Suite'")
+      expect(content).toContain('expect(1 + 1).toBe(2)')
+    })
+
+    it('should add test scripts to package.json', async () => {
+      const context: FeatureAddContext = {
+        targetDir: tempDir,
+        projectInfo: {...defaultProjectInfo, packageManager: 'npm'},
+        verbose: false,
+        dryRun: false,
+      }
+
+      await addVitestFeature(context)
+
+      const packageJsonContent = await readFile(path.join(tempDir, 'package.json'), 'utf-8')
+      const packageJson = JSON.parse(packageJsonContent) as PackageJson
+
+      expect(packageJson.scripts).toBeDefined()
+      expect(packageJson.scripts?.test).toBe('vitest run')
+      expect(packageJson.scripts?.['test:watch']).toBe('vitest')
+      expect(packageJson.scripts?.['test:ui']).toBe('vitest --ui')
+      expect(packageJson.scripts?.['test:coverage']).toBe('vitest run --coverage')
+    })
+
+    it('should call addDependencies with vitest packages', async () => {
+      const {addDependencies} = await import('../../src/utils/package-manager.js')
+
+      const context: FeatureAddContext = {
+        targetDir: tempDir,
+        projectInfo: defaultProjectInfo,
+        verbose: false,
+        dryRun: false,
+      }
+
+      await addVitestFeature(context)
+
+      expect(addDependencies).toHaveBeenCalledWith(
+        tempDir,
+        [],
+        expect.arrayContaining(['vitest', '@vitest/ui', '@types/node']),
+        'pnpm',
+        false,
+      )
+    })
+
+    it('should add React testing dependencies for react projects', async () => {
+      const {addDependencies} = await import('../../src/utils/package-manager.js')
+
+      const context: FeatureAddContext = {
+        targetDir: tempDir,
+        projectInfo: {...defaultProjectInfo, type: 'react'},
+        verbose: false,
+        dryRun: false,
+      }
+
+      await addVitestFeature(context)
+
+      expect(addDependencies).toHaveBeenCalledWith(
+        tempDir,
+        [],
+        expect.arrayContaining(['@testing-library/react', '@testing-library/jest-dom', 'jsdom']),
+        'pnpm',
+        false,
+      )
+    })
+
+    it('should add React testing dependencies for Next.js framework', async () => {
+      const {addDependencies} = await import('../../src/utils/package-manager.js')
+
+      const context: FeatureAddContext = {
+        targetDir: tempDir,
+        projectInfo: {...defaultProjectInfo, framework: 'Next.js'},
+        verbose: false,
+        dryRun: false,
+      }
+
+      await addVitestFeature(context)
+
+      expect(addDependencies).toHaveBeenCalledWith(
+        tempDir,
+        [],
+        expect.arrayContaining(['@testing-library/react', 'jsdom']),
+        'pnpm',
+        false,
+      )
+    })
+
+    it('should use jsdom environment for react projects', async () => {
+      // React projects use .js extension for config since type is 'react' not 'typescript'
+      const context: FeatureAddContext = {
+        targetDir: tempDir,
+        projectInfo: {...defaultProjectInfo, type: 'react'},
+        verbose: false,
+        dryRun: false,
+      }
+
+      await addVitestFeature(context)
+
+      // Config file is .js for react type (type !== 'typescript')
+      const configPath = path.join(tempDir, 'vitest.config.js')
+      expect(existsSync(configPath)).toBe(true)
+      const content = await readFile(configPath, 'utf-8')
+      expect(content).toContain('environment: "jsdom"')
+    })
+
+    it('should warn when existing test config found with verbose', async () => {
+      const {consola} = await import('consola')
+
+      // Create an existing config
+      writeFileSync(path.join(tempDir, 'jest.config.js'), '{}')
+
+      const context: FeatureAddContext = {
+        targetDir: tempDir,
+        projectInfo: defaultProjectInfo,
+        verbose: true,
+        dryRun: false,
+      }
+
+      await addVitestFeature(context)
+
+      expect(consola.warn).toHaveBeenCalledWith('Existing test config found: jest.config.js')
+    })
+
+    it('should log info message with verbose enabled', async () => {
+      const {consola} = await import('consola')
+
+      const context: FeatureAddContext = {
+        targetDir: tempDir,
+        projectInfo: defaultProjectInfo,
+        verbose: true,
+        dryRun: false,
+      }
+
+      await addVitestFeature(context)
+
+      expect(consola.info).toHaveBeenCalledWith('Adding Vitest configuration...')
+    })
+
+    describe('dry run mode', () => {
+      it('should not create files in dry run mode', async () => {
+        const context: FeatureAddContext = {
+          targetDir: tempDir,
+          projectInfo: defaultProjectInfo,
+          verbose: false,
+          dryRun: true,
+        }
+
+        await addVitestFeature(context)
+
+        const configPath = path.join(tempDir, 'vitest.config.ts')
+        expect(existsSync(configPath)).toBe(false)
+      })
+
+      it('should not call addDependencies in dry run mode', async () => {
+        const {addDependencies} = await import('../../src/utils/package-manager.js')
+
+        const context: FeatureAddContext = {
+          targetDir: tempDir,
+          projectInfo: defaultProjectInfo,
+          verbose: false,
+          dryRun: true,
+        }
+
+        await addVitestFeature(context)
+
+        expect(addDependencies).not.toHaveBeenCalled()
+      })
+
+      it('should log what would be created in dry run mode', async () => {
+        const {consola} = await import('consola')
+
+        const context: FeatureAddContext = {
+          targetDir: tempDir,
+          projectInfo: defaultProjectInfo,
+          verbose: false,
+          dryRun: true,
+        }
+
+        await addVitestFeature(context)
+
+        expect(consola.info).toHaveBeenCalledWith('Would create vitest.config.ts')
+      })
+    })
+
+    it('should not modify scripts if they already exist', async () => {
+      writeFileSync(
+        path.join(tempDir, 'package.json'),
+        JSON.stringify(
+          {
+            name: 'test-project',
+            scripts: {
+              test: 'existing-test-script',
+              'test:watch': 'existing-watch-script',
+            },
+          },
+          null,
+          2,
+        ),
+      )
+
+      const context: FeatureAddContext = {
+        targetDir: tempDir,
+        projectInfo: {...defaultProjectInfo, packageManager: 'npm'},
+        verbose: false,
+        dryRun: false,
+      }
+
+      await addVitestFeature(context)
+
+      const packageJsonContent = await readFile(path.join(tempDir, 'package.json'), 'utf-8')
+      const packageJson = JSON.parse(packageJsonContent) as PackageJson
+
+      expect(packageJson.scripts?.test).toBe('existing-test-script')
+      expect(packageJson.scripts?.['test:watch']).toBe('existing-watch-script')
+    })
+
+    it('should detect various existing test config formats', async () => {
+      const configFormats = [
+        'vitest.config.js',
+        'vitest.config.ts',
+        'vite.config.js',
+        'vite.config.ts',
+        'jest.config.js',
+        'jest.config.json',
+      ]
+
+      for (const configFile of configFormats) {
+        // Clean up and recreate temp dir
+        if (existsSync(tempDir)) {
+          rmSync(tempDir, {recursive: true, force: true})
+        }
+        mkdirSync(tempDir, {recursive: true})
+        writeFileSync(
+          path.join(tempDir, 'package.json'),
+          JSON.stringify({name: 'test-project'}, null, 2),
+        )
+        writeFileSync(path.join(tempDir, configFile), '{}')
+
+        const {consola} = await import('consola')
+        vi.mocked(consola.warn).mockClear()
+
+        const context: FeatureAddContext = {
+          targetDir: tempDir,
+          projectInfo: defaultProjectInfo,
+          verbose: true,
+          dryRun: false,
+        }
+
+        await addVitestFeature(context)
+
+        expect(consola.warn).toHaveBeenCalledWith(`Existing test config found: ${configFile}`)
+      }
+    })
+
+    it('should not create test directory if it already exists', async () => {
+      const testDir = path.join(tempDir, 'test')
+      mkdirSync(testDir, {recursive: true})
+      writeFileSync(path.join(testDir, 'existing.test.ts'), 'existing')
+
+      const context: FeatureAddContext = {
+        targetDir: tempDir,
+        projectInfo: defaultProjectInfo,
+        verbose: false,
+        dryRun: false,
+      }
+
+      await addVitestFeature(context)
+
+      // Should not overwrite existing files
+      const existingContent = await readFile(path.join(testDir, 'existing.test.ts'), 'utf-8')
+      expect(existingContent).toBe('existing')
+    })
+  })
+})

--- a/packages/create/test/prompts/confirmation.test.ts
+++ b/packages/create/test/prompts/confirmation.test.ts
@@ -1,0 +1,452 @@
+/**
+ * @fileoverview Tests for confirmation prompt module
+ */
+
+import type {ProjectCustomization, TemplateSelection} from '../../src/types.js'
+import process from 'node:process'
+import * as clackPrompts from '@clack/prompts'
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
+
+vi.mock('@clack/prompts')
+
+vi.spyOn(process, 'exit').mockImplementation(() => {
+  throw new Error('process.exit called')
+})
+
+describe('confirmation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.resetModules()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  const createMockTemplate = (overrides?: Partial<TemplateSelection>): TemplateSelection => ({
+    type: 'builtin',
+    location: 'default',
+    metadata: {
+      name: 'default',
+      description: 'Default template',
+      version: '1.0.0',
+    },
+    ...overrides,
+  })
+
+  const createMockCustomization = (
+    overrides?: Partial<ProjectCustomization>,
+  ): ProjectCustomization => ({
+    features: [],
+    ...overrides,
+  })
+
+  describe('confirmationStep', () => {
+    it('should display project summary and confirm', async () => {
+      vi.mocked(clackPrompts.confirm).mockResolvedValueOnce(true)
+      vi.mocked(clackPrompts.isCancel).mockReturnValue(false)
+
+      const {confirmationStep} = await import('../../src/prompts/confirmation.js')
+
+      const result = await confirmationStep({
+        projectName: 'my-project',
+        template: createMockTemplate(),
+        customization: createMockCustomization(),
+      })
+
+      expect(clackPrompts.note).toHaveBeenCalled()
+      expect(clackPrompts.confirm).toHaveBeenCalled()
+      expect(result).toBe(true)
+    })
+
+    it('should return false when user denies', async () => {
+      vi.mocked(clackPrompts.confirm).mockResolvedValueOnce(false)
+      vi.mocked(clackPrompts.isCancel).mockReturnValue(false)
+
+      const {confirmationStep} = await import('../../src/prompts/confirmation.js')
+
+      const result = await confirmationStep({
+        projectName: 'my-project',
+        template: createMockTemplate(),
+        customization: createMockCustomization(),
+      })
+
+      expect(result).toBe(false)
+    })
+
+    it('should exit when user cancels', async () => {
+      vi.mocked(clackPrompts.confirm).mockResolvedValueOnce(Symbol.for('cancel'))
+      vi.mocked(clackPrompts.isCancel).mockReturnValue(true)
+
+      const {confirmationStep} = await import('../../src/prompts/confirmation.js')
+
+      await expect(
+        confirmationStep({
+          projectName: 'my-project',
+          template: createMockTemplate(),
+          customization: createMockCustomization(),
+        }),
+      ).rejects.toThrow('process.exit')
+    })
+
+    it('should include project description in summary', async () => {
+      vi.mocked(clackPrompts.confirm).mockResolvedValueOnce(true)
+      vi.mocked(clackPrompts.isCancel).mockReturnValue(false)
+
+      const {confirmationStep} = await import('../../src/prompts/confirmation.js')
+
+      await confirmationStep({
+        projectName: 'my-project',
+        template: createMockTemplate(),
+        customization: createMockCustomization({
+          description: 'A test project',
+        }),
+      })
+
+      const noteCall = vi.mocked(clackPrompts.note).mock.calls[0]
+      expect(noteCall?.[0]).toContain('A test project')
+    })
+
+    it('should include author in summary', async () => {
+      vi.mocked(clackPrompts.confirm).mockResolvedValueOnce(true)
+      vi.mocked(clackPrompts.isCancel).mockReturnValue(false)
+
+      const {confirmationStep} = await import('../../src/prompts/confirmation.js')
+
+      await confirmationStep({
+        projectName: 'my-project',
+        template: createMockTemplate(),
+        customization: createMockCustomization({
+          author: 'Test Author',
+        }),
+      })
+
+      const noteCall = vi.mocked(clackPrompts.note).mock.calls[0]
+      expect(noteCall?.[0]).toContain('Test Author')
+    })
+
+    it('should include version in summary', async () => {
+      vi.mocked(clackPrompts.confirm).mockResolvedValueOnce(true)
+      vi.mocked(clackPrompts.isCancel).mockReturnValue(false)
+
+      const {confirmationStep} = await import('../../src/prompts/confirmation.js')
+
+      await confirmationStep({
+        projectName: 'my-project',
+        template: createMockTemplate(),
+        customization: createMockCustomization({
+          version: '2.0.0',
+        }),
+      })
+
+      const noteCall = vi.mocked(clackPrompts.note).mock.calls[0]
+      expect(noteCall?.[0]).toContain('2.0.0')
+    })
+
+    it('should include package manager in summary', async () => {
+      vi.mocked(clackPrompts.confirm).mockResolvedValueOnce(true)
+      vi.mocked(clackPrompts.isCancel).mockReturnValue(false)
+
+      const {confirmationStep} = await import('../../src/prompts/confirmation.js')
+
+      await confirmationStep({
+        projectName: 'my-project',
+        template: createMockTemplate(),
+        customization: createMockCustomization({
+          packageManager: 'pnpm',
+        }),
+      })
+
+      const noteCall = vi.mocked(clackPrompts.note).mock.calls[0]
+      expect(noteCall?.[0]).toContain('pnpm')
+    })
+
+    it('should include output directory in summary', async () => {
+      vi.mocked(clackPrompts.confirm).mockResolvedValueOnce(true)
+      vi.mocked(clackPrompts.isCancel).mockReturnValue(false)
+
+      const {confirmationStep} = await import('../../src/prompts/confirmation.js')
+
+      await confirmationStep({
+        projectName: 'my-project',
+        template: createMockTemplate(),
+        customization: createMockCustomization({
+          outputDir: '/custom/output',
+        }),
+      })
+
+      const noteCall = vi.mocked(clackPrompts.note).mock.calls[0]
+      expect(noteCall?.[0]).toContain('/custom/output')
+    })
+
+    it('should include features in summary', async () => {
+      vi.mocked(clackPrompts.confirm).mockResolvedValueOnce(true)
+      vi.mocked(clackPrompts.isCancel).mockReturnValue(false)
+
+      const {confirmationStep} = await import('../../src/prompts/confirmation.js')
+
+      await confirmationStep({
+        projectName: 'my-project',
+        template: createMockTemplate(),
+        customization: createMockCustomization({
+          features: ['typescript', 'eslint', 'prettier'],
+        }),
+      })
+
+      const noteCall = vi.mocked(clackPrompts.note).mock.calls[0]
+      expect(noteCall?.[0]).toContain('typescript')
+      expect(noteCall?.[0]).toContain('eslint')
+    })
+
+    it('should show GitHub template source with ref', async () => {
+      vi.mocked(clackPrompts.confirm).mockResolvedValueOnce(true)
+      vi.mocked(clackPrompts.isCancel).mockReturnValue(false)
+
+      const {confirmationStep} = await import('../../src/prompts/confirmation.js')
+
+      await confirmationStep({
+        projectName: 'my-project',
+        template: createMockTemplate({
+          type: 'github',
+          location: 'user/repo',
+          ref: 'v1.0.0',
+        }),
+        customization: createMockCustomization(),
+      })
+
+      const noteCall = vi.mocked(clackPrompts.note).mock.calls[0]
+      expect(noteCall?.[0]).toContain('GitHub')
+      expect(noteCall?.[0]).toContain('user/repo')
+      expect(noteCall?.[0]).toContain('v1.0.0')
+    })
+
+    it('should show URL template source', async () => {
+      vi.mocked(clackPrompts.confirm).mockResolvedValueOnce(true)
+      vi.mocked(clackPrompts.isCancel).mockReturnValue(false)
+
+      const {confirmationStep} = await import('../../src/prompts/confirmation.js')
+
+      await confirmationStep({
+        projectName: 'my-project',
+        template: createMockTemplate({
+          type: 'url',
+          location: 'https://example.com/template.zip',
+        }),
+        customization: createMockCustomization(),
+      })
+
+      const noteCall = vi.mocked(clackPrompts.note).mock.calls[0]
+      expect(noteCall?.[0]).toContain('URL')
+    })
+
+    it('should show local template source', async () => {
+      vi.mocked(clackPrompts.confirm).mockResolvedValueOnce(true)
+      vi.mocked(clackPrompts.isCancel).mockReturnValue(false)
+
+      const {confirmationStep} = await import('../../src/prompts/confirmation.js')
+
+      await confirmationStep({
+        projectName: 'my-project',
+        template: createMockTemplate({
+          type: 'local',
+          location: './my-template',
+        }),
+        customization: createMockCustomization(),
+      })
+
+      const noteCall = vi.mocked(clackPrompts.note).mock.calls[0]
+      expect(noteCall?.[0]).toContain('Local')
+    })
+
+    it('should show builtin template source', async () => {
+      vi.mocked(clackPrompts.confirm).mockResolvedValueOnce(true)
+      vi.mocked(clackPrompts.isCancel).mockReturnValue(false)
+
+      const {confirmationStep} = await import('../../src/prompts/confirmation.js')
+
+      await confirmationStep({
+        projectName: 'my-project',
+        template: createMockTemplate({type: 'builtin'}),
+        customization: createMockCustomization(),
+      })
+
+      const noteCall = vi.mocked(clackPrompts.note).mock.calls[0]
+      expect(noteCall?.[0]).toContain('Built-in')
+    })
+
+    it('should skip empty description', async () => {
+      vi.mocked(clackPrompts.confirm).mockResolvedValueOnce(true)
+      vi.mocked(clackPrompts.isCancel).mockReturnValue(false)
+
+      const {confirmationStep} = await import('../../src/prompts/confirmation.js')
+
+      await confirmationStep({
+        projectName: 'my-project',
+        template: createMockTemplate(),
+        customization: createMockCustomization({
+          description: '   ',
+        }),
+      })
+
+      const noteCall = vi.mocked(clackPrompts.note).mock.calls[0]
+      expect(noteCall?.[0]).not.toContain('Project Description')
+    })
+  })
+
+  describe('confirmModification', () => {
+    it('should display modification summary and confirm', async () => {
+      vi.mocked(clackPrompts.confirm).mockResolvedValueOnce(true)
+      vi.mocked(clackPrompts.isCancel).mockReturnValue(false)
+
+      const {confirmModification} = await import('../../src/prompts/confirmation.js')
+
+      const result = await confirmModification('/path/to/project', ['Add ESLint', 'Add Prettier'])
+
+      expect(clackPrompts.note).toHaveBeenCalled()
+      expect(clackPrompts.confirm).toHaveBeenCalled()
+      expect(result).toBe(true)
+    })
+
+    it('should return false when user denies modification', async () => {
+      vi.mocked(clackPrompts.confirm).mockResolvedValueOnce(false)
+      vi.mocked(clackPrompts.isCancel).mockReturnValue(false)
+
+      const {confirmModification} = await import('../../src/prompts/confirmation.js')
+
+      const result = await confirmModification('/path/to/project', ['Add ESLint'])
+
+      expect(result).toBe(false)
+    })
+
+    it('should exit when user cancels modification', async () => {
+      vi.mocked(clackPrompts.confirm).mockResolvedValueOnce(Symbol.for('cancel'))
+      vi.mocked(clackPrompts.isCancel).mockReturnValue(true)
+
+      const {confirmModification} = await import('../../src/prompts/confirmation.js')
+
+      await expect(confirmModification('/path/to/project', ['Add ESLint'])).rejects.toThrow(
+        'process.exit',
+      )
+    })
+
+    it('should include all modifications in summary', async () => {
+      vi.mocked(clackPrompts.confirm).mockResolvedValueOnce(true)
+      vi.mocked(clackPrompts.isCancel).mockReturnValue(false)
+
+      const {confirmModification} = await import('../../src/prompts/confirmation.js')
+
+      await confirmModification('/path/to/project', [
+        'Add TypeScript',
+        'Add ESLint',
+        'Add Prettier',
+      ])
+
+      const noteCall = vi.mocked(clackPrompts.note).mock.calls[0]
+      expect(noteCall?.[0]).toContain('Add TypeScript')
+      expect(noteCall?.[0]).toContain('Add ESLint')
+      expect(noteCall?.[0]).toContain('Add Prettier')
+    })
+  })
+
+  describe('confirmFeatureAddition', () => {
+    it('should display feature summary and confirm', async () => {
+      vi.mocked(clackPrompts.confirm).mockResolvedValueOnce(true)
+      vi.mocked(clackPrompts.isCancel).mockReturnValue(false)
+
+      const {confirmFeatureAddition} = await import('../../src/prompts/confirmation.js')
+
+      const result = await confirmFeatureAddition(
+        '/path/to/project',
+        'eslint',
+        ['eslint', '@eslint/js'],
+        ['eslint.config.js'],
+      )
+
+      expect(clackPrompts.note).toHaveBeenCalled()
+      expect(clackPrompts.confirm).toHaveBeenCalled()
+      expect(result).toBe(true)
+    })
+
+    it('should return false when user denies feature addition', async () => {
+      vi.mocked(clackPrompts.confirm).mockResolvedValueOnce(false)
+      vi.mocked(clackPrompts.isCancel).mockReturnValue(false)
+
+      const {confirmFeatureAddition} = await import('../../src/prompts/confirmation.js')
+
+      const result = await confirmFeatureAddition('/path/to/project', 'eslint', [], [])
+
+      expect(result).toBe(false)
+    })
+
+    it('should exit when user cancels feature addition', async () => {
+      vi.mocked(clackPrompts.confirm).mockResolvedValueOnce(Symbol.for('cancel'))
+      vi.mocked(clackPrompts.isCancel).mockReturnValue(true)
+
+      const {confirmFeatureAddition} = await import('../../src/prompts/confirmation.js')
+
+      await expect(confirmFeatureAddition('/path/to/project', 'eslint', [], [])).rejects.toThrow(
+        'process.exit',
+      )
+    })
+
+    it('should include dependencies in summary', async () => {
+      vi.mocked(clackPrompts.confirm).mockResolvedValueOnce(true)
+      vi.mocked(clackPrompts.isCancel).mockReturnValue(false)
+
+      const {confirmFeatureAddition} = await import('../../src/prompts/confirmation.js')
+
+      await confirmFeatureAddition(
+        '/path/to/project',
+        'prettier',
+        ['prettier', 'prettier-plugin-sort-imports'],
+        [],
+      )
+
+      const noteCall = vi.mocked(clackPrompts.note).mock.calls[0]
+      expect(noteCall?.[0]).toContain('prettier')
+      expect(noteCall?.[0]).toContain('prettier-plugin-sort-imports')
+    })
+
+    it('should include files in summary', async () => {
+      vi.mocked(clackPrompts.confirm).mockResolvedValueOnce(true)
+      vi.mocked(clackPrompts.isCancel).mockReturnValue(false)
+
+      const {confirmFeatureAddition} = await import('../../src/prompts/confirmation.js')
+
+      await confirmFeatureAddition(
+        '/path/to/project',
+        'typescript',
+        [],
+        ['tsconfig.json', 'src/index.ts'],
+      )
+
+      const noteCall = vi.mocked(clackPrompts.note).mock.calls[0]
+      expect(noteCall?.[0]).toContain('tsconfig.json')
+      expect(noteCall?.[0]).toContain('src/index.ts')
+    })
+
+    it('should handle empty dependencies array', async () => {
+      vi.mocked(clackPrompts.confirm).mockResolvedValueOnce(true)
+      vi.mocked(clackPrompts.isCancel).mockReturnValue(false)
+
+      const {confirmFeatureAddition} = await import('../../src/prompts/confirmation.js')
+
+      await confirmFeatureAddition('/path/to/project', 'custom', [], ['config.json'])
+
+      const noteCall = vi.mocked(clackPrompts.note).mock.calls[0]
+      expect(noteCall?.[0]).not.toContain('Dependencies')
+    })
+
+    it('should handle empty files array', async () => {
+      vi.mocked(clackPrompts.confirm).mockResolvedValueOnce(true)
+      vi.mocked(clackPrompts.isCancel).mockReturnValue(false)
+
+      const {confirmFeatureAddition} = await import('../../src/prompts/confirmation.js')
+
+      await confirmFeatureAddition('/path/to/project', 'custom', ['some-dep'], [])
+
+      const noteCall = vi.mocked(clackPrompts.note).mock.calls[0]
+      expect(noteCall?.[0]).not.toContain('Files')
+    })
+  })
+})

--- a/packages/create/test/prompts/template-selection.test.ts
+++ b/packages/create/test/prompts/template-selection.test.ts
@@ -1,0 +1,421 @@
+/**
+ * @fileoverview Tests for template-selection prompt module
+ */
+
+import process from 'node:process'
+import * as clackPrompts from '@clack/prompts'
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
+
+vi.mock('@clack/prompts')
+vi.mock('consola', () => ({
+  consola: {
+    warn: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+  },
+}))
+
+vi.spyOn(process, 'exit').mockImplementation(() => {
+  throw new Error('process.exit called')
+})
+
+describe('template-selection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.resetModules()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe('templateSelection', () => {
+    it('should return builtin selection when initial template default is provided', async () => {
+      const {templateSelection} = await import('../../src/prompts/template-selection.js')
+
+      const result = await templateSelection('default')
+
+      expect(result).toBeDefined()
+      expect(result.type).toBe('builtin')
+      expect(result.location).toBe('default')
+      expect(result.metadata.name).toBe('default')
+    })
+
+    it('should return builtin selection for library template', async () => {
+      const {templateSelection} = await import('../../src/prompts/template-selection.js')
+
+      const result = await templateSelection('library')
+
+      expect(result.type).toBe('builtin')
+      expect(result.location).toBe('library')
+      expect(result.metadata.name).toBe('library')
+    })
+
+    it('should return builtin selection for cli template', async () => {
+      const {templateSelection} = await import('../../src/prompts/template-selection.js')
+
+      const result = await templateSelection('cli')
+
+      expect(result.type).toBe('builtin')
+      expect(result.location).toBe('cli')
+      expect(result.metadata.name).toBe('cli')
+    })
+
+    it('should return builtin selection for node template', async () => {
+      const {templateSelection} = await import('../../src/prompts/template-selection.js')
+
+      const result = await templateSelection('node')
+
+      expect(result.type).toBe('builtin')
+      expect(result.location).toBe('node')
+      expect(result.metadata.name).toBe('node')
+    })
+
+    it('should return builtin selection for react template', async () => {
+      const {templateSelection} = await import('../../src/prompts/template-selection.js')
+
+      const result = await templateSelection('react')
+
+      expect(result.type).toBe('builtin')
+      expect(result.location).toBe('react')
+      expect(result.metadata.name).toBe('react')
+    })
+
+    it('should resolve github: prefix templates', async () => {
+      const {templateSelection} = await import('../../src/prompts/template-selection.js')
+
+      const result = await templateSelection('github:user/repo')
+
+      expect(result.type).toBe('github')
+      expect(result.location).toBe('user/repo')
+    })
+
+    it('should resolve short github user/repo format', async () => {
+      const {templateSelection} = await import('../../src/prompts/template-selection.js')
+
+      const result = await templateSelection('owner/repository')
+
+      expect(result.type).toBe('github')
+      expect(result.location).toBe('owner/repository')
+    })
+
+    it('should resolve github templates with ref', async () => {
+      const {templateSelection} = await import('../../src/prompts/template-selection.js')
+
+      const result = await templateSelection('github:user/repo#v1.0.0')
+
+      expect(result.type).toBe('github')
+      expect(result.location).toBe('user/repo')
+      expect(result.ref).toBe('v1.0.0')
+    })
+
+    it('should resolve https URL templates', async () => {
+      const {templateSelection} = await import('../../src/prompts/template-selection.js')
+
+      const result = await templateSelection('https://example.com/template.zip')
+
+      expect(result.type).toBe('url')
+      expect(result.location).toBe('https://example.com/template.zip')
+    })
+
+    it('should resolve http URL templates', async () => {
+      const {templateSelection} = await import('../../src/prompts/template-selection.js')
+
+      const result = await templateSelection('http://example.com/template')
+
+      expect(result.type).toBe('url')
+      expect(result.location).toBe('http://example.com/template')
+    })
+
+    it('should resolve ./ local path templates', async () => {
+      const {templateSelection} = await import('../../src/prompts/template-selection.js')
+
+      const result = await templateSelection('./my-template')
+
+      expect(result.type).toBe('local')
+      expect(result.location).toBe('./my-template')
+    })
+
+    it('should resolve / absolute path templates', async () => {
+      const {templateSelection} = await import('../../src/prompts/template-selection.js')
+
+      const result = await templateSelection('/path/to/template')
+
+      expect(result.type).toBe('local')
+      expect(result.location).toBe('/path/to/template')
+    })
+
+    it('should resolve ~/ home path templates', async () => {
+      const {templateSelection} = await import('../../src/prompts/template-selection.js')
+
+      const result = await templateSelection('~/templates/my-template')
+
+      expect(result.type).toBe('local')
+      expect(result.location).toBe('~/templates/my-template')
+    })
+
+    it('should fallback unknown template to default with warning', async () => {
+      const {consola} = await import('consola')
+      const {templateSelection} = await import('../../src/prompts/template-selection.js')
+
+      const result = await templateSelection('unknown-single-word')
+
+      expect(consola.warn).toHaveBeenCalled()
+      expect(result.type).toBe('builtin')
+      expect(result.location).toBe('default')
+    })
+
+    it('should show interactive selection when no template provided', async () => {
+      vi.mocked(clackPrompts.select).mockResolvedValueOnce('default')
+      vi.mocked(clackPrompts.isCancel).mockReturnValue(false)
+
+      const {templateSelection} = await import('../../src/prompts/template-selection.js')
+
+      const result = await templateSelection()
+
+      expect(clackPrompts.select).toHaveBeenCalled()
+      expect(result.type).toBe('builtin')
+    })
+
+    it('should show interactive selection for empty string template', async () => {
+      vi.mocked(clackPrompts.select).mockResolvedValueOnce('library')
+      vi.mocked(clackPrompts.isCancel).mockReturnValue(false)
+
+      const {templateSelection} = await import('../../src/prompts/template-selection.js')
+
+      const result = await templateSelection('')
+
+      expect(clackPrompts.select).toHaveBeenCalled()
+      expect(result.type).toBe('builtin')
+      expect(result.location).toBe('library')
+    })
+
+    it('should show interactive selection for whitespace template', async () => {
+      vi.mocked(clackPrompts.select).mockResolvedValueOnce('cli')
+      vi.mocked(clackPrompts.isCancel).mockReturnValue(false)
+
+      const {templateSelection} = await import('../../src/prompts/template-selection.js')
+
+      const result = await templateSelection('   ')
+
+      expect(clackPrompts.select).toHaveBeenCalled()
+      expect(result.type).toBe('builtin')
+    })
+
+    it('should handle cancellation during interactive selection', async () => {
+      vi.mocked(clackPrompts.select).mockResolvedValueOnce(Symbol.for('cancel'))
+      vi.mocked(clackPrompts.isCancel).mockReturnValue(true)
+
+      const {templateSelection} = await import('../../src/prompts/template-selection.js')
+
+      await expect(templateSelection()).rejects.toThrow('process.exit')
+    })
+
+    it('should handle custom template selection option', async () => {
+      vi.mocked(clackPrompts.select).mockResolvedValueOnce('custom')
+      vi.mocked(clackPrompts.isCancel).mockReturnValue(false)
+      vi.mocked(clackPrompts.text).mockResolvedValueOnce('github:custom/template')
+
+      const {templateSelection} = await import('../../src/prompts/template-selection.js')
+
+      const result = await templateSelection()
+
+      expect(clackPrompts.text).toHaveBeenCalled()
+      expect(result.type).toBe('github')
+      expect(result.location).toBe('custom/template')
+    })
+
+    it('should handle custom template with local path', async () => {
+      vi.mocked(clackPrompts.select).mockResolvedValueOnce('custom')
+      vi.mocked(clackPrompts.isCancel).mockReturnValue(false)
+      vi.mocked(clackPrompts.text).mockResolvedValueOnce('./local/custom')
+
+      const {templateSelection} = await import('../../src/prompts/template-selection.js')
+
+      const result = await templateSelection()
+
+      expect(result.type).toBe('local')
+      expect(result.location).toBe('./local/custom')
+    })
+
+    it('should handle cancellation during custom template input', async () => {
+      vi.mocked(clackPrompts.select).mockResolvedValueOnce('custom')
+      vi.mocked(clackPrompts.isCancel).mockReturnValueOnce(false).mockReturnValueOnce(true)
+      vi.mocked(clackPrompts.text).mockResolvedValueOnce(Symbol.for('cancel'))
+
+      const {templateSelection} = await import('../../src/prompts/template-selection.js')
+
+      await expect(templateSelection()).rejects.toThrow('process.exit')
+    })
+
+    it('should show template preview for builtin templates', async () => {
+      vi.mocked(clackPrompts.select).mockResolvedValueOnce('react')
+      vi.mocked(clackPrompts.isCancel).mockReturnValue(false)
+
+      const {templateSelection} = await import('../../src/prompts/template-selection.js')
+
+      await templateSelection()
+
+      expect(clackPrompts.note).toHaveBeenCalled()
+    })
+
+    it('should include all builtin templates in options', async () => {
+      vi.mocked(clackPrompts.select).mockResolvedValueOnce('default')
+      vi.mocked(clackPrompts.isCancel).mockReturnValue(false)
+
+      const {templateSelection} = await import('../../src/prompts/template-selection.js')
+
+      await templateSelection()
+
+      const selectCall = vi.mocked(clackPrompts.select).mock.calls[0]
+      const options = selectCall?.[0]?.options as {value: string}[]
+
+      expect(options.some(o => o.value === 'default')).toBe(true)
+      expect(options.some(o => o.value === 'library')).toBe(true)
+      expect(options.some(o => o.value === 'cli')).toBe(true)
+      expect(options.some(o => o.value === 'node')).toBe(true)
+      expect(options.some(o => o.value === 'react')).toBe(true)
+      expect(options.some(o => o.value === 'custom')).toBe(true)
+    })
+  })
+
+  describe('getBuiltinTemplates', () => {
+    it('should return all builtin templates', async () => {
+      const {getBuiltinTemplates} = await import('../../src/prompts/template-selection.js')
+
+      const templates = getBuiltinTemplates()
+
+      expect(templates).toBeDefined()
+      expect(templates.default).toBeDefined()
+      expect(templates.library).toBeDefined()
+      expect(templates.cli).toBeDefined()
+      expect(templates.node).toBeDefined()
+      expect(templates.react).toBeDefined()
+    })
+
+    it('should return a copy of templates (not the original)', async () => {
+      const {getBuiltinTemplates} = await import('../../src/prompts/template-selection.js')
+
+      const templates1 = getBuiltinTemplates()
+      const templates2 = getBuiltinTemplates()
+
+      expect(templates1).not.toBe(templates2)
+    })
+
+    it('should include template metadata', async () => {
+      const {getBuiltinTemplates} = await import('../../src/prompts/template-selection.js')
+
+      const templates = getBuiltinTemplates()
+      const defaultTemplate = templates.default
+
+      expect(defaultTemplate?.name).toBe('default')
+      expect(defaultTemplate?.description).toBeDefined()
+      expect(defaultTemplate?.version).toBeDefined()
+      expect(defaultTemplate?.tags).toBeDefined()
+    })
+  })
+
+  describe('validateTemplateSource', () => {
+    it('should validate empty source as invalid', async () => {
+      const {validateTemplateSource} = await import('../../src/prompts/template-selection.js')
+
+      const result = validateTemplateSource('')
+
+      expect(result.valid).toBe(false)
+      expect(result.error).toBeDefined()
+    })
+
+    it('should validate whitespace-only source as invalid', async () => {
+      const {validateTemplateSource} = await import('../../src/prompts/template-selection.js')
+
+      const result = validateTemplateSource('   ')
+
+      expect(result.valid).toBe(false)
+    })
+
+    it('should validate builtin template names as valid', async () => {
+      const {validateTemplateSource} = await import('../../src/prompts/template-selection.js')
+
+      expect(validateTemplateSource('default').valid).toBe(true)
+      expect(validateTemplateSource('library').valid).toBe(true)
+      expect(validateTemplateSource('cli').valid).toBe(true)
+      expect(validateTemplateSource('node').valid).toBe(true)
+      expect(validateTemplateSource('react').valid).toBe(true)
+    })
+
+    it('should validate github: prefix as valid', async () => {
+      const {validateTemplateSource} = await import('../../src/prompts/template-selection.js')
+
+      const result = validateTemplateSource('github:user/repo')
+
+      expect(result.valid).toBe(true)
+    })
+
+    it('should validate user/repo shorthand as valid', async () => {
+      const {validateTemplateSource} = await import('../../src/prompts/template-selection.js')
+
+      const result = validateTemplateSource('owner/repo')
+
+      expect(result.valid).toBe(true)
+    })
+
+    it('should validate https URL as valid', async () => {
+      const {validateTemplateSource} = await import('../../src/prompts/template-selection.js')
+
+      const result = validateTemplateSource('https://github.com/user/repo')
+
+      expect(result.valid).toBe(true)
+    })
+
+    it('should validate http URL as valid', async () => {
+      const {validateTemplateSource} = await import('../../src/prompts/template-selection.js')
+
+      const result = validateTemplateSource('http://example.com/template')
+
+      expect(result.valid).toBe(true)
+    })
+
+    it('should validate ./ path as valid', async () => {
+      const {validateTemplateSource} = await import('../../src/prompts/template-selection.js')
+
+      const result = validateTemplateSource('./my-template')
+
+      expect(result.valid).toBe(true)
+    })
+
+    it('should validate / absolute path as valid', async () => {
+      const {validateTemplateSource} = await import('../../src/prompts/template-selection.js')
+
+      const result = validateTemplateSource('/path/to/template')
+
+      expect(result.valid).toBe(true)
+    })
+
+    it('should validate ~/ home path as valid', async () => {
+      const {validateTemplateSource} = await import('../../src/prompts/template-selection.js')
+
+      const result = validateTemplateSource('~/templates/mytemplate')
+
+      expect(result.valid).toBe(true)
+    })
+
+    it('should validate unknown single word as invalid', async () => {
+      const {validateTemplateSource} = await import('../../src/prompts/template-selection.js')
+
+      const result = validateTemplateSource('unknown-single-word')
+
+      expect(result.valid).toBe(false)
+      expect(result.error).toBeDefined()
+    })
+
+    it('should include helpful error message for invalid sources', async () => {
+      const {validateTemplateSource} = await import('../../src/prompts/template-selection.js')
+
+      const result = validateTemplateSource('invalid')
+
+      expect(result.error).toContain('builtin')
+      expect(result.error).toContain('github')
+    })
+  })
+})

--- a/packages/create/test/templates/metadata.test.ts
+++ b/packages/create/test/templates/metadata.test.ts
@@ -1,0 +1,570 @@
+/**
+ * Tests for template metadata manager
+ * Part of Phase 5: Comprehensive Testing Implementation (TASK-035)
+ */
+
+import type {TemplateMetadata, TemplateVariable} from '../../src/types.js'
+import {existsSync} from 'node:fs'
+import {readFile, writeFile} from 'node:fs/promises'
+import path from 'node:path'
+import {describe, expect, it, vi} from 'vitest'
+import {TemplateMetadataManager} from '../../src/templates/metadata.js'
+
+// Mock file system modules
+vi.mock('node:fs', async () => {
+  const actual = await vi.importActual<typeof import('node:fs')>('node:fs')
+  return {
+    ...actual,
+    existsSync: vi.fn(),
+  }
+})
+
+vi.mock('node:fs/promises', async () => {
+  return {
+    readFile: vi.fn(),
+    writeFile: vi.fn(),
+  }
+})
+
+// Mock consola
+vi.mock('consola', () => ({
+  consola: {
+    debug: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}))
+
+const mockExistsSync = vi.mocked(existsSync)
+const mockReadFile = vi.mocked(readFile)
+const mockWriteFile = vi.mocked(writeFile)
+
+describe('TemplateMetadataManager', () => {
+  describe('load', () => {
+    it('returns default metadata when template.json does not exist', async () => {
+      mockExistsSync.mockReturnValue(false)
+      const manager = new TemplateMetadataManager()
+
+      const result = await manager.load('/templates/my-template')
+
+      expect(result.success).toBe(true)
+      const data = result.success ? result.data : null
+      expect(data?.name).toBe('my-template')
+      expect(data?.description).toBe('Template description not available')
+      expect(data?.version).toBe('1.0.0')
+    })
+
+    it('loads metadata from template.json', async () => {
+      mockExistsSync.mockReturnValue(true)
+      mockReadFile.mockResolvedValue(
+        JSON.stringify({
+          name: 'Test Template',
+          description: 'Test description',
+          version: '1.0.0',
+        }),
+      )
+
+      const manager = new TemplateMetadataManager()
+      const result = await manager.load('/templates/test-template')
+
+      expect(result.success).toBe(true)
+      if (!result.success) {
+        throw new Error('Expected success')
+      }
+      expect(result.data.name).toBe('Test Template')
+      expect(result.data.description).toBe('Test description')
+      expect(result.data.version).toBe('1.0.0')
+    })
+
+    it('returns error when JSON parsing fails', async () => {
+      mockExistsSync.mockReturnValue(true)
+      mockReadFile.mockResolvedValue('{ invalid json }')
+
+      const manager = new TemplateMetadataManager()
+      const result = await manager.load('/templates/test-template')
+
+      expect(result.success).toBe(false)
+      const error = result.success ? null : result.error
+      expect(error).toBeDefined()
+    })
+
+    it('returns error when metadata validation fails', async () => {
+      mockExistsSync.mockReturnValue(true)
+      // Missing required fields
+      mockReadFile.mockResolvedValue(JSON.stringify({name: ''}))
+
+      const manager = new TemplateMetadataManager()
+      const result = await manager.load('/templates/test-template')
+
+      expect(result.success).toBe(false)
+    })
+
+    it('merges partial metadata with defaults', async () => {
+      mockExistsSync.mockReturnValue(true)
+      mockReadFile.mockResolvedValue(
+        JSON.stringify({
+          name: 'partial-template',
+          description: 'Partial description',
+          version: '1.0.0',
+        }),
+      )
+
+      const manager = new TemplateMetadataManager()
+      const result = await manager.load('/templates/partial-template')
+
+      expect(result.success).toBe(true)
+      if (!result.success) {
+        throw new Error('Expected success')
+      }
+      expect(result.data.name).toBe('partial-template')
+      expect(result.data.description).toBe('Partial description')
+    })
+  })
+
+  describe('save', () => {
+    it('saves valid metadata to template.json', async () => {
+      mockWriteFile.mockResolvedValue(undefined)
+      const metadata: TemplateMetadata = {
+        name: 'test-template',
+        description: 'A test template',
+        version: '1.0.0',
+      }
+
+      const manager = new TemplateMetadataManager()
+      const result = await manager.save('/templates/test-template', metadata)
+
+      expect(result.success).toBe(true)
+      expect(mockWriteFile).toHaveBeenCalledWith(
+        path.join('/templates/test-template', 'template.json'),
+        expect.any(String),
+        'utf-8',
+      )
+    })
+
+    it('returns error when validation fails', async () => {
+      const metadata = {
+        name: '',
+        description: 'Invalid template',
+        version: '1.0.0',
+      } as TemplateMetadata
+
+      const manager = new TemplateMetadataManager()
+      const result = await manager.save('/templates/test-template', metadata)
+
+      expect(result.success).toBe(false)
+      if (result.success) {
+        throw new Error('Expected failure')
+      }
+      expect(result.error).toBeDefined()
+    })
+
+    it('returns error when write fails', async () => {
+      mockWriteFile.mockRejectedValue(new Error('Permission denied'))
+      const metadata: TemplateMetadata = {
+        name: 'test-template',
+        description: 'A test template',
+        version: '1.0.0',
+      }
+
+      const manager = new TemplateMetadataManager()
+      const result = await manager.save('/templates/test-template', metadata)
+
+      expect(result.success).toBe(false)
+      if (result.success) {
+        throw new Error('Expected failure')
+      }
+      expect(result.error.message).toContain('Permission denied')
+    })
+
+    it('formats JSON with 2 spaces indentation', async () => {
+      mockWriteFile.mockResolvedValue(undefined)
+      const metadata: TemplateMetadata = {
+        name: 'test-template',
+        description: 'A test template',
+        version: '1.0.0',
+      }
+
+      const manager = new TemplateMetadataManager()
+      await manager.save('/templates/test-template', metadata)
+
+      const savedContent = mockWriteFile.mock.calls[0]?.[1] as string
+      expect(savedContent).toContain('  "name"')
+      expect(savedContent.endsWith('\n')).toBe(true)
+    })
+  })
+
+  describe('validate', () => {
+    describe('required fields', () => {
+      it('validates complete metadata', () => {
+        const metadata: TemplateMetadata = {
+          name: 'valid-template',
+          description: 'A valid template',
+          version: '1.0.0',
+        }
+
+        const manager = new TemplateMetadataManager()
+        const result = manager.validate(metadata)
+
+        expect(result.valid).toBe(true)
+        expect(result.errors).toBeUndefined()
+      })
+
+      it('returns error for missing name', () => {
+        const metadata = {
+          description: 'A template',
+          version: '1.0.0',
+        } as Partial<TemplateMetadata>
+
+        const manager = new TemplateMetadataManager()
+        const result = manager.validate(metadata)
+
+        expect(result.valid).toBe(false)
+        expect(result.errors).toContain('Template name is required and must be a non-empty string')
+      })
+
+      it('returns error for empty name', () => {
+        const metadata = {
+          name: '',
+          description: 'A template',
+          version: '1.0.0',
+        } as Partial<TemplateMetadata>
+
+        const manager = new TemplateMetadataManager()
+        const result = manager.validate(metadata)
+
+        expect(result.valid).toBe(false)
+        expect(result.errors).toContain('Template name is required and must be a non-empty string')
+      })
+
+      it('returns error for missing description', () => {
+        const metadata = {
+          name: 'test',
+          version: '1.0.0',
+        } as Partial<TemplateMetadata>
+
+        const manager = new TemplateMetadataManager()
+        const result = manager.validate(metadata)
+
+        expect(result.valid).toBe(false)
+        expect(result.errors).toContain('Template description is required and must be a string')
+      })
+
+      it('returns error for missing version', () => {
+        const metadata = {
+          name: 'test',
+          description: 'A template',
+        } as Partial<TemplateMetadata>
+
+        const manager = new TemplateMetadataManager()
+        const result = manager.validate(metadata)
+
+        expect(result.valid).toBe(false)
+        expect(result.errors).toContain('Template version is required and must be a string')
+      })
+    })
+
+    describe('optional fields', () => {
+      it('validates author as string', () => {
+        const metadata = {
+          name: 'test',
+          description: 'A template',
+          version: '1.0.0',
+          author: 123 as unknown as string,
+        }
+
+        const manager = new TemplateMetadataManager()
+        const result = manager.validate(metadata)
+
+        expect(result.valid).toBe(false)
+        expect(result.errors).toContain('Template author must be a string')
+      })
+
+      it('validates tags as string array', () => {
+        const metadata = {
+          name: 'test',
+          description: 'A template',
+          version: '1.0.0',
+          tags: 'not-an-array' as unknown as string[],
+        }
+
+        const manager = new TemplateMetadataManager()
+        const result = manager.validate(metadata)
+
+        expect(result.valid).toBe(false)
+        expect(result.errors).toContain('Template tags must be an array')
+      })
+
+      it('validates all tags are strings', () => {
+        const metadata = {
+          name: 'test',
+          description: 'A template',
+          version: '1.0.0',
+          tags: ['valid', 123 as unknown as string],
+        }
+
+        const manager = new TemplateMetadataManager()
+        const result = manager.validate(metadata)
+
+        expect(result.valid).toBe(false)
+        expect(result.errors).toContain('All template tags must be strings')
+      })
+
+      it('validates dependencies as string array', () => {
+        const metadata = {
+          name: 'test',
+          description: 'A template',
+          version: '1.0.0',
+          dependencies: 'not-an-array' as unknown as string[],
+        }
+
+        const manager = new TemplateMetadataManager()
+        const result = manager.validate(metadata)
+
+        expect(result.valid).toBe(false)
+        expect(result.errors).toContain('Template dependencies must be an array')
+      })
+
+      it('validates nodeVersion as string', () => {
+        const metadata = {
+          name: 'test',
+          description: 'A template',
+          version: '1.0.0',
+          nodeVersion: 18 as unknown as string,
+        }
+
+        const manager = new TemplateMetadataManager()
+        const result = manager.validate(metadata)
+
+        expect(result.valid).toBe(false)
+        expect(result.errors).toContain('Template nodeVersion must be a string')
+      })
+    })
+
+    describe('semver validation', () => {
+      it('accepts valid semver versions', () => {
+        const metadata: TemplateMetadata = {
+          name: 'test',
+          description: 'A template',
+          version: '1.2.3',
+        }
+
+        const manager = new TemplateMetadataManager()
+        const result = manager.validate(metadata)
+
+        expect(result.valid).toBe(true)
+        expect(result.warnings).toBeUndefined()
+      })
+
+      it('warns for invalid semver format', () => {
+        const metadata: TemplateMetadata = {
+          name: 'test',
+          description: 'A template',
+          version: 'not-semver',
+        }
+
+        const manager = new TemplateMetadataManager()
+        const result = manager.validate(metadata)
+
+        expect(result.valid).toBe(true)
+        expect(result.warnings).toContain('Template version "not-semver" is not a valid semver')
+      })
+
+      it('accepts semver with prerelease', () => {
+        const metadata: TemplateMetadata = {
+          name: 'test',
+          description: 'A template',
+          version: '1.0.0-beta.1',
+        }
+
+        const manager = new TemplateMetadataManager()
+        const result = manager.validate(metadata)
+
+        expect(result.valid).toBe(true)
+      })
+    })
+
+    describe('variables validation', () => {
+      it('validates variables must be an array', () => {
+        const metadata = {
+          name: 'test',
+          description: 'A template',
+          version: '1.0.0',
+          variables: 'not-an-array' as unknown as TemplateVariable[],
+        }
+
+        const manager = new TemplateMetadataManager()
+        const result = manager.validate(metadata)
+
+        expect(result.valid).toBe(false)
+        expect(result.errors).toContain('Template variables must be an array')
+      })
+
+      it('validates variable must be an object', () => {
+        const metadata = {
+          name: 'test',
+          description: 'A template',
+          version: '1.0.0',
+          variables: ['not-an-object'] as unknown as TemplateVariable[],
+        }
+
+        const manager = new TemplateMetadataManager()
+        const result = manager.validate(metadata)
+
+        expect(result.valid).toBe(false)
+        expect(result.errors).toContain('Variable at index 0 must be an object')
+      })
+
+      it('validates variable name is required', () => {
+        const metadata = {
+          name: 'test',
+          description: 'A template',
+          version: '1.0.0',
+          variables: [{description: 'test', type: 'string'}] as unknown as TemplateVariable[],
+        }
+
+        const manager = new TemplateMetadataManager()
+        const result = manager.validate(metadata)
+
+        expect(result.valid).toBe(false)
+        expect(result.errors).toContain('Variable at index 0 must have a valid name')
+      })
+
+      it('validates variable description is required', () => {
+        const metadata = {
+          name: 'test',
+          description: 'A template',
+          version: '1.0.0',
+          variables: [{name: 'var1', type: 'string'}] as unknown as TemplateVariable[],
+        }
+
+        const manager = new TemplateMetadataManager()
+        const result = manager.validate(metadata)
+
+        expect(result.valid).toBe(false)
+        expect(result.errors).toContain('Variable at index 0 must have a valid description')
+      })
+
+      it('validates variable type is valid', () => {
+        const metadata = {
+          name: 'test',
+          description: 'A template',
+          version: '1.0.0',
+          variables: [
+            {name: 'var1', description: 'test', type: 'invalid'},
+          ] as unknown as TemplateVariable[],
+        }
+
+        const manager = new TemplateMetadataManager()
+        const result = manager.validate(metadata)
+
+        expect(result.valid).toBe(false)
+        expect(result.errors).toContain(
+          'Variable at index 0 must have a valid type (string, boolean, number, select)',
+        )
+      })
+
+      it('validates select type requires options', () => {
+        const metadata = {
+          name: 'test',
+          description: 'A template',
+          version: '1.0.0',
+          variables: [
+            {name: 'var1', description: 'test', type: 'select'},
+          ] as unknown as TemplateVariable[],
+        }
+
+        const manager = new TemplateMetadataManager()
+        const result = manager.validate(metadata)
+
+        expect(result.valid).toBe(false)
+        expect(result.errors).toContain(
+          "Variable at index 0 with type 'select' must have options array",
+        )
+      })
+
+      it('accepts valid select variable with options', () => {
+        const metadata: TemplateMetadata = {
+          name: 'test',
+          description: 'A template',
+          version: '1.0.0',
+          variables: [
+            {
+              name: 'framework',
+              description: 'Choose a framework',
+              type: 'select',
+              options: ['react', 'vue', 'svelte'],
+            },
+          ],
+        }
+
+        const manager = new TemplateMetadataManager()
+        const result = manager.validate(metadata)
+
+        expect(result.valid).toBe(true)
+      })
+
+      it('validates pattern must be a string', () => {
+        const metadata = {
+          name: 'test',
+          description: 'A template',
+          version: '1.0.0',
+          variables: [
+            {name: 'var1', description: 'test', type: 'string', pattern: 123},
+          ] as unknown as TemplateVariable[],
+        }
+
+        const manager = new TemplateMetadataManager()
+        const result = manager.validate(metadata)
+
+        expect(result.valid).toBe(false)
+        expect(result.errors).toContain('Variable at index 0 pattern must be a string')
+      })
+    })
+  })
+
+  describe('create', () => {
+    it('creates template.json with default values', async () => {
+      mockWriteFile.mockResolvedValue(undefined)
+
+      const manager = new TemplateMetadataManager()
+      const result = await manager.create('/templates/new-template')
+
+      expect(result.success).toBe(true)
+      if (!result.success) {
+        throw new Error('Expected success')
+      }
+      expect(result.data.name).toBe('new-template')
+      expect(result.data.version).toBe('1.0.0')
+    })
+
+    it('creates template.json with custom options', async () => {
+      mockWriteFile.mockResolvedValue(undefined)
+
+      const manager = new TemplateMetadataManager()
+      const result = await manager.create('/templates/custom-template', {
+        name: 'Custom Template',
+        description: 'A custom template',
+        author: 'John Doe',
+        tags: ['custom', 'example'],
+      })
+
+      expect(result.success).toBe(true)
+      if (!result.success) {
+        throw new Error('Expected success')
+      }
+      expect(result.data.name).toBe('Custom Template')
+      expect(result.data.description).toBe('A custom template')
+      expect(result.data.author).toBe('John Doe')
+      expect(result.data.tags).toEqual(['custom', 'example'])
+    })
+
+    it('returns error when save fails', async () => {
+      mockWriteFile.mockRejectedValue(new Error('Write failed'))
+
+      const manager = new TemplateMetadataManager()
+      const result = await manager.create('/templates/fail-template')
+
+      expect(result.success).toBe(false)
+    })
+  })
+})

--- a/packages/create/test/templates/pipeline.test.ts
+++ b/packages/create/test/templates/pipeline.test.ts
@@ -1,0 +1,662 @@
+/**
+ * Tests for template processing pipeline factory
+ * Part of Phase 5: Comprehensive Testing Implementation (TASK-034)
+ */
+
+import type {
+  PipelineConfig,
+  PipelineDependencies,
+  PipelineExecutionOptions,
+} from '../../src/templates/pipeline.js'
+import type {
+  FileOperation,
+  TemplateContext,
+  TemplateMetadata,
+  TemplateSource,
+  ValidationResult,
+} from '../../src/types.js'
+import {err, isErr, isOk, ok} from '@bfra.me/es/result'
+import {describe, expect, it, vi} from 'vitest'
+import {
+  createFetchStage,
+  createProcessStage,
+  createResolveStage,
+  createTemplateProcessingPipeline,
+  createValidateStage,
+  DEFAULT_PIPELINE_CONFIG,
+  PipelineStageNames,
+} from '../../src/templates/pipeline.js'
+
+// Mock the logger to prevent console output during tests
+vi.mock('../../src/utils/logger.js', () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    success: vi.fn(),
+    debug: vi.fn(),
+  }),
+}))
+
+// Mock fs/promises and os for temp directory creation
+vi.mock('node:fs/promises', () => ({
+  mkdtemp: vi.fn().mockResolvedValue('/tmp/bfra-create-test123'),
+}))
+
+vi.mock('node:os', () => ({
+  tmpdir: vi.fn().mockReturnValue('/tmp'),
+}))
+
+vi.mock('node:path', () => ({
+  default: {
+    join: (...parts: string[]) => parts.join('/'),
+  },
+  join: (...parts: string[]) => parts.join('/'),
+}))
+
+/**
+ * Creates mock dependencies for pipeline testing
+ */
+function createMockDependencies(
+  overrides: Partial<PipelineDependencies> = {},
+): PipelineDependencies {
+  const mockMetadata: TemplateMetadata = {
+    name: 'test-template',
+    description: 'A test template',
+    version: '1.0.0',
+    author: 'Test Author',
+    tags: ['test'],
+    variables: [],
+  }
+
+  const mockSource: TemplateSource = {
+    type: 'github',
+    location: 'test/repo',
+    ref: 'main',
+  }
+
+  return {
+    resolve: vi.fn().mockReturnValue(mockSource),
+    fetch: vi.fn().mockResolvedValue(ok({path: '/tmp/template', metadata: mockMetadata})),
+    validate: vi.fn().mockResolvedValue(ok(undefined)),
+    process: vi.fn().mockResolvedValue(
+      ok({
+        operations: [
+          {type: 'create', target: 'package.json', content: '{}'},
+          {type: 'create', target: 'README.md', content: '# Test'},
+        ] as FileOperation[],
+      }),
+    ),
+    ...overrides,
+  }
+}
+
+/**
+ * Creates mock execution options
+ */
+function createMockOptions(
+  overrides: Partial<PipelineExecutionOptions> = {},
+): PipelineExecutionOptions {
+  return {
+    outputDir: '/output/test-project',
+    context: {
+      projectName: 'test-project',
+      description: 'A test project',
+      author: 'Test Author',
+      version: '1.0.0',
+    },
+    ...overrides,
+  }
+}
+
+describe('template processing pipeline', () => {
+  describe('PipelineStageNames', () => {
+    it.concurrent('exports all stage names', () => {
+      expect(PipelineStageNames.RESOLVE).toBe('resolve')
+      expect(PipelineStageNames.FETCH).toBe('fetch')
+      expect(PipelineStageNames.VALIDATE).toBe('validate')
+      expect(PipelineStageNames.PARSE).toBe('parse')
+      expect(PipelineStageNames.RENDER).toBe('render')
+    })
+  })
+
+  describe('DEFAULT_PIPELINE_CONFIG', () => {
+    it.concurrent('has correct default values', () => {
+      expect(DEFAULT_PIPELINE_CONFIG.cacheEnabled).toBe(true)
+      expect(DEFAULT_PIPELINE_CONFIG.cacheTTL).toBe(3600)
+      expect(DEFAULT_PIPELINE_CONFIG.verbose).toBe(false)
+      expect(DEFAULT_PIPELINE_CONFIG.dryRun).toBe(false)
+      expect(DEFAULT_PIPELINE_CONFIG.templateExtensions).toEqual(['.eta', '.template'])
+      expect(DEFAULT_PIPELINE_CONFIG.variableDelimiters).toEqual({start: '<%', end: '%>'})
+    })
+
+    it.concurrent('has default ignore patterns', () => {
+      expect(DEFAULT_PIPELINE_CONFIG.ignorePatterns).toContain('**/node_modules/**')
+      expect(DEFAULT_PIPELINE_CONFIG.ignorePatterns).toContain('**/.git/**')
+      expect(DEFAULT_PIPELINE_CONFIG.ignorePatterns).toContain('**/dist/**')
+    })
+  })
+
+  describe('createTemplateProcessingPipeline', () => {
+    describe('pipeline creation', () => {
+      it.concurrent('creates a pipeline with default config', () => {
+        const dependencies = createMockDependencies()
+        const pipeline = createTemplateProcessingPipeline(dependencies)
+
+        expect(pipeline).toHaveProperty('execute')
+        expect(pipeline).toHaveProperty('getConfig')
+        expect(pipeline).toHaveProperty('updateConfig')
+      })
+
+      it.concurrent('creates a pipeline with custom config', () => {
+        const dependencies = createMockDependencies()
+        const customConfig: PipelineConfig = {
+          cacheEnabled: false,
+          verbose: true,
+          dryRun: true,
+        }
+        const pipeline = createTemplateProcessingPipeline(dependencies, customConfig)
+        const config = pipeline.getConfig()
+
+        expect(config.cacheEnabled).toBe(false)
+        expect(config.verbose).toBe(true)
+        expect(config.dryRun).toBe(true)
+      })
+
+      it.concurrent('merges custom config with defaults', () => {
+        const dependencies = createMockDependencies()
+        const pipeline = createTemplateProcessingPipeline(dependencies, {verbose: true})
+        const config = pipeline.getConfig()
+
+        expect(config.verbose).toBe(true)
+        expect(config.cacheEnabled).toBe(DEFAULT_PIPELINE_CONFIG.cacheEnabled)
+        expect(config.cacheTTL).toBe(DEFAULT_PIPELINE_CONFIG.cacheTTL)
+      })
+    })
+
+    describe('getConfig', () => {
+      it.concurrent('returns a copy of current config', () => {
+        const dependencies = createMockDependencies()
+        const pipeline = createTemplateProcessingPipeline(dependencies)
+        const config1 = pipeline.getConfig()
+        const config2 = pipeline.getConfig()
+
+        expect(config1).toEqual(config2)
+        expect(config1).not.toBe(config2)
+      })
+    })
+
+    describe('updateConfig', () => {
+      it('updates specific config values', () => {
+        const dependencies = createMockDependencies()
+        const pipeline = createTemplateProcessingPipeline(dependencies)
+
+        pipeline.updateConfig({verbose: true})
+        expect(pipeline.getConfig().verbose).toBe(true)
+
+        pipeline.updateConfig({dryRun: true})
+        expect(pipeline.getConfig().dryRun).toBe(true)
+        expect(pipeline.getConfig().verbose).toBe(true)
+      })
+
+      it('preserves unmodified config values', () => {
+        const dependencies = createMockDependencies()
+        const pipeline = createTemplateProcessingPipeline(dependencies, {
+          cacheEnabled: false,
+          cacheTTL: 7200,
+        })
+
+        pipeline.updateConfig({verbose: true})
+        const config = pipeline.getConfig()
+
+        expect(config.verbose).toBe(true)
+        expect(config.cacheEnabled).toBe(false)
+        expect(config.cacheTTL).toBe(7200)
+      })
+    })
+
+    describe('execute', () => {
+      describe('successful execution', () => {
+        it('executes all pipeline stages in order', async () => {
+          const dependencies = createMockDependencies()
+          const pipeline = createTemplateProcessingPipeline(dependencies)
+          const options = createMockOptions()
+
+          const result = await pipeline.execute('user/repo', options)
+
+          expect(isOk(result)).toBe(true)
+          expect(dependencies.resolve).toHaveBeenCalledWith('user/repo')
+          expect(dependencies.fetch).toHaveBeenCalled()
+          expect(dependencies.validate).toHaveBeenCalled()
+          expect(dependencies.process).toHaveBeenCalled()
+        })
+
+        it('returns pipeline result with correct structure', async () => {
+          const dependencies = createMockDependencies()
+          const pipeline = createTemplateProcessingPipeline(dependencies)
+          const options = createMockOptions()
+
+          const result = await pipeline.execute('user/repo', options)
+
+          expect(isOk(result)).toBe(true)
+          expect(isOk(result) && result.data).toHaveProperty('template')
+          expect(isOk(result) && result.data).toHaveProperty('operations')
+          expect(isOk(result) && result.data).toHaveProperty('stats')
+          expect(isOk(result) && result.data.operations).toHaveLength(2)
+        })
+
+        it('returns pipeline stats with timing information', async () => {
+          const dependencies = createMockDependencies()
+          const pipeline = createTemplateProcessingPipeline(dependencies)
+          const options = createMockOptions()
+
+          const result = await pipeline.execute('user/repo', options)
+
+          expect(isOk(result)).toBe(true)
+          const stats = isOk(result) ? result.data.stats : null
+          expect(stats?.totalTimeMs).toBeGreaterThanOrEqual(0)
+          expect(stats?.stageTimings).toHaveProperty('resolve')
+          expect(stats?.stageTimings).toHaveProperty('fetch')
+          expect(stats?.stageTimings).toHaveProperty('validate')
+          expect(stats?.stageTimings).toHaveProperty('render')
+          expect(stats?.filesProcessed).toBe(2)
+          expect(stats?.cacheHit).toBe(false)
+        })
+
+        it('calls progress callback for each stage', async () => {
+          const dependencies = createMockDependencies()
+          const pipeline = createTemplateProcessingPipeline(dependencies)
+          const progressCallback = vi.fn()
+          const options = createMockOptions({onProgress: progressCallback})
+
+          await pipeline.execute('user/repo', options)
+
+          expect(progressCallback).toHaveBeenCalled()
+          const stages = progressCallback.mock.calls.map((call: unknown[]) => call[0] as string)
+          expect(stages).toContain('resolve')
+          expect(stages).toContain('fetch')
+          expect(stages).toContain('validate')
+          expect(stages).toContain('render')
+        })
+      })
+
+      describe('template validation', () => {
+        it('rejects invalid template identifiers', async () => {
+          const dependencies = createMockDependencies()
+          const pipeline = createTemplateProcessingPipeline(dependencies)
+          const options = createMockOptions()
+
+          const result = await pipeline.execute('', options)
+
+          expect(isErr(result)).toBe(true)
+          expect(isErr(result) && result.error.message).toContain('Invalid template identifier')
+        })
+
+        it('rejects path traversal attempts', async () => {
+          const dependencies = createMockDependencies()
+          const pipeline = createTemplateProcessingPipeline(dependencies)
+          const options = createMockOptions()
+
+          const result = await pipeline.execute('../../../etc/passwd', options)
+
+          expect(isErr(result)).toBe(true)
+        })
+      })
+
+      describe('stage failure handling', () => {
+        it('returns error when resolve stage fails', async () => {
+          const dependencies = createMockDependencies({
+            resolve: vi.fn().mockImplementation(() => {
+              throw new Error('Failed to resolve template')
+            }),
+          })
+          const pipeline = createTemplateProcessingPipeline(dependencies)
+          const options = createMockOptions()
+
+          const result = await pipeline.execute('user/repo', options)
+
+          expect(isErr(result)).toBe(true)
+          expect(isErr(result) && result.error.message).toContain('resolve')
+        })
+
+        it('returns error when fetch stage fails', async () => {
+          const dependencies = createMockDependencies({
+            fetch: vi.fn().mockResolvedValue(err(new Error('Failed to fetch template'))),
+          })
+          const pipeline = createTemplateProcessingPipeline(dependencies)
+          const options = createMockOptions()
+
+          const result = await pipeline.execute('user/repo', options)
+
+          expect(isErr(result)).toBe(true)
+        })
+
+        it('returns error when validate stage fails', async () => {
+          const dependencies = createMockDependencies({
+            validate: vi.fn().mockResolvedValue(err(new Error('Validation failed'))),
+          })
+          const pipeline = createTemplateProcessingPipeline(dependencies)
+          const options = createMockOptions()
+
+          const result = await pipeline.execute('user/repo', options)
+
+          expect(isErr(result)).toBe(true)
+        })
+
+        it('returns error when process stage fails', async () => {
+          const dependencies = createMockDependencies({
+            process: vi.fn().mockResolvedValue(err(new Error('Processing failed'))),
+          })
+          const pipeline = createTemplateProcessingPipeline(dependencies)
+          const options = createMockOptions()
+
+          const result = await pipeline.execute('user/repo', options)
+
+          expect(isErr(result)).toBe(true)
+        })
+
+        it('stops execution after first stage failure', async () => {
+          const dependencies = createMockDependencies({
+            fetch: vi.fn().mockResolvedValue(err(new Error('Failed to fetch'))),
+          })
+          const pipeline = createTemplateProcessingPipeline(dependencies)
+          const options = createMockOptions()
+
+          await pipeline.execute('user/repo', options)
+
+          expect(dependencies.resolve).toHaveBeenCalled()
+          expect(dependencies.fetch).toHaveBeenCalled()
+          expect(dependencies.validate).not.toHaveBeenCalled()
+          expect(dependencies.process).not.toHaveBeenCalled()
+        })
+      })
+
+      describe('dry run mode', () => {
+        it('skips file writes in dry run mode', async () => {
+          const dependencies = createMockDependencies()
+          const pipeline = createTemplateProcessingPipeline(dependencies, {dryRun: true})
+          const options = createMockOptions()
+
+          const result = await pipeline.execute('user/repo', options)
+
+          expect(isOk(result)).toBe(true)
+          expect(isOk(result) && result.data.operations).toHaveLength(0)
+        })
+
+        it('still validates template in dry run mode', async () => {
+          const dependencies = createMockDependencies()
+          const pipeline = createTemplateProcessingPipeline(dependencies, {dryRun: true})
+          const options = createMockOptions()
+
+          await pipeline.execute('user/repo', options)
+
+          expect(dependencies.validate).toHaveBeenCalled()
+        })
+      })
+
+      describe('context handling', () => {
+        it('passes context to process stage', async () => {
+          const dependencies = createMockDependencies()
+          const pipeline = createTemplateProcessingPipeline(dependencies)
+          const context: TemplateContext = {
+            projectName: 'my-custom-project',
+            description: 'Custom description',
+            author: 'Custom Author',
+            version: '2.0.0',
+            packageManager: 'pnpm',
+          }
+          const options = createMockOptions({context})
+
+          await pipeline.execute('user/repo', options)
+
+          expect(dependencies.process).toHaveBeenCalledWith(
+            expect.any(String),
+            options.outputDir,
+            context,
+          )
+        })
+      })
+    })
+  })
+
+  describe('createResolveStage', () => {
+    it.concurrent('returns ok result for successful resolution', () => {
+      const mockSource: TemplateSource = {
+        type: 'github',
+        location: 'user/repo',
+      }
+      const resolver = vi.fn().mockReturnValue(mockSource)
+      const resolveStage = createResolveStage(resolver)
+
+      const result = resolveStage('user/repo')
+
+      expect(isOk(result)).toBe(true)
+      expect(isOk(result) && result.data).toEqual(mockSource)
+    })
+
+    it.concurrent('returns err result when resolver throws', () => {
+      const resolver = vi.fn().mockImplementation(() => {
+        throw new Error('Resolution failed')
+      })
+      const resolveStage = createResolveStage(resolver)
+
+      const result = resolveStage('invalid/template')
+
+      expect(isErr(result)).toBe(true)
+      expect(isErr(result) && result.error.message).toContain('Failed to resolve template')
+    })
+
+    it.concurrent('passes template to resolver', () => {
+      const resolver = vi.fn().mockReturnValue({type: 'github', location: 'test'})
+      const resolveStage = createResolveStage(resolver)
+
+      resolveStage('my-template')
+
+      expect(resolver).toHaveBeenCalledWith('my-template')
+    })
+  })
+
+  describe('createFetchStage', () => {
+    it('calls fetcher with source and target directory', async () => {
+      const mockResult = ok({path: '/tmp/template', metadata: {} as TemplateMetadata})
+      const fetcher = vi.fn().mockResolvedValue(mockResult)
+      const fetchStage = createFetchStage(fetcher)
+      const source: TemplateSource = {type: 'github', location: 'user/repo'}
+
+      const result = await fetchStage(source, '/tmp/target')
+
+      expect(fetcher).toHaveBeenCalledWith(source, '/tmp/target')
+      expect(isOk(result)).toBe(true)
+    })
+
+    it('returns error when fetcher fails', async () => {
+      const fetcher = vi.fn().mockResolvedValue(err(new Error('Fetch failed')))
+      const fetchStage = createFetchStage(fetcher)
+      const source: TemplateSource = {type: 'github', location: 'user/repo'}
+
+      const result = await fetchStage(source, '/tmp/target')
+
+      expect(isErr(result)).toBe(true)
+    })
+
+    it('passes through result when cache is disabled', async () => {
+      const mockResult = ok({path: '/tmp/template', metadata: {} as TemplateMetadata})
+      const fetcher = vi.fn().mockResolvedValue(mockResult)
+      const fetchStage = createFetchStage(fetcher, {cacheEnabled: false})
+      const source: TemplateSource = {type: 'github', location: 'user/repo'}
+
+      const result = await fetchStage(source, '/tmp/target')
+
+      expect(isOk(result)).toBe(true)
+      expect(fetcher).toHaveBeenCalled()
+    })
+  })
+
+  describe('createValidateStage', () => {
+    it('returns ok result for valid template', async () => {
+      const validator = vi.fn().mockResolvedValue({valid: true} as ValidationResult)
+      const validateStage = createValidateStage(validator)
+
+      const result = await validateStage('/tmp/template')
+
+      expect(isOk(result)).toBe(true)
+      expect(validator).toHaveBeenCalledWith('/tmp/template')
+    })
+
+    it('returns err result for invalid template', async () => {
+      const validator = vi.fn().mockResolvedValue({
+        valid: false,
+        errors: ['Missing template.json', 'Invalid metadata format'],
+      } as ValidationResult)
+      const validateStage = createValidateStage(validator)
+
+      const result = await validateStage('/tmp/template')
+
+      expect(isErr(result)).toBe(true)
+      const errorMessage = isErr(result) ? result.error.message : ''
+      expect(errorMessage).toContain('validation failed')
+      expect(errorMessage).toContain('Missing template.json')
+    })
+
+    it('handles warnings without failing', async () => {
+      const validator = vi.fn().mockResolvedValue({
+        valid: true,
+        warnings: ['Deprecated field in template.json'],
+      } as ValidationResult)
+      const validateStage = createValidateStage(validator)
+
+      const result = await validateStage('/tmp/template')
+
+      expect(isOk(result)).toBe(true)
+    })
+
+    it('handles empty error array', async () => {
+      const validator = vi.fn().mockResolvedValue({
+        valid: false,
+        errors: [],
+      } as ValidationResult)
+      const validateStage = createValidateStage(validator)
+
+      const result = await validateStage('/tmp/template')
+
+      expect(isErr(result)).toBe(true)
+      const errorMessage = isErr(result) ? result.error.message : ''
+      // Empty errors array results in empty string after join
+      expect(errorMessage).toContain('validation failed')
+    })
+  })
+
+  describe('createProcessStage', () => {
+    it('passes through to processor function', async () => {
+      const mockResult = ok({operations: [] as FileOperation[]})
+      const processor = vi.fn().mockResolvedValue(mockResult)
+      const processStage = createProcessStage(processor)
+      const context: TemplateContext = {projectName: 'test'}
+
+      const result = await processStage('/tmp/template', '/output', context)
+
+      expect(processor).toHaveBeenCalledWith('/tmp/template', '/output', context)
+      expect(isOk(result)).toBe(true)
+    })
+
+    it('returns processor result unchanged', async () => {
+      const operations: FileOperation[] = [
+        {type: 'create', target: 'index.ts', content: 'export {}'},
+      ]
+      const processor = vi.fn().mockResolvedValue(ok({operations}))
+      const processStage = createProcessStage(processor)
+      const context: TemplateContext = {projectName: 'test'}
+
+      const result = await processStage('/tmp/template', '/output', context)
+
+      expect(isOk(result)).toBe(true)
+      const resultOps = isOk(result) ? result.data.operations : null
+      expect(resultOps).toEqual(operations)
+    })
+
+    it('accepts config parameter for future use', async () => {
+      const processor = vi.fn().mockResolvedValue(ok({operations: []}))
+      const processStage = createProcessStage(processor, {
+        templateExtensions: ['.eta'],
+        ignorePatterns: ['**/*.test.ts'],
+        variableDelimiters: {start: '{{', end: '}}'},
+      })
+      const context: TemplateContext = {projectName: 'test'}
+
+      const result = await processStage('/tmp/template', '/output', context)
+
+      expect(isOk(result)).toBe(true)
+    })
+  })
+
+  describe('pipeline integration', () => {
+    it('handles complete workflow with all stages', async () => {
+      const mockMetadata: TemplateMetadata = {
+        name: 'integration-template',
+        description: 'Integration test template',
+        version: '1.0.0',
+      }
+
+      const mockOperations: FileOperation[] = [
+        {type: 'create', target: 'package.json', content: '{"name": "test"}'},
+        {type: 'create', target: 'src/index.ts', content: 'export {}'},
+        {type: 'copy', source: 'README.md', target: 'README.md'},
+      ]
+
+      const dependencies = createMockDependencies({
+        resolve: vi.fn().mockReturnValue({type: 'github', location: 'integration/test'}),
+        fetch: vi.fn().mockResolvedValue(ok({path: '/tmp/integration', metadata: mockMetadata})),
+        validate: vi.fn().mockResolvedValue(ok(undefined)),
+        process: vi.fn().mockResolvedValue(ok({operations: mockOperations})),
+      })
+
+      const pipeline = createTemplateProcessingPipeline(dependencies, {verbose: true})
+      const options = createMockOptions({
+        outputDir: '/projects/integration-test',
+        context: {
+          projectName: 'integration-test',
+          description: 'Integration test project',
+          packageManager: 'pnpm',
+        },
+      })
+
+      const result = await pipeline.execute('integration/test', options)
+
+      expect(isOk(result)).toBe(true)
+      const data = isOk(result) ? result.data : null
+      expect(data?.template.metadata.name).toBe('integration-template')
+      expect(data?.operations).toHaveLength(3)
+      expect(data?.stats.filesProcessed).toBe(3)
+    })
+
+    it('propagates context through entire pipeline', async () => {
+      let capturedContext: TemplateContext | undefined
+
+      const dependencies = createMockDependencies({
+        process: vi
+          .fn()
+          .mockImplementation(
+            async (_template: string, _output: string, context: TemplateContext) => {
+              capturedContext = context
+              return ok({operations: []})
+            },
+          ),
+      })
+
+      const pipeline = createTemplateProcessingPipeline(dependencies)
+      const expectedContext: TemplateContext = {
+        projectName: 'context-test',
+        description: 'Testing context propagation',
+        author: 'Test',
+        version: '1.0.0',
+        packageManager: 'yarn',
+        variables: {customVar: 'customValue'},
+      }
+      const options = createMockOptions({context: expectedContext})
+
+      await pipeline.execute('user/repo', options)
+
+      expect(capturedContext).toEqual(expectedContext)
+    })
+  })
+})

--- a/packages/create/test/utils/command-options.test.ts
+++ b/packages/create/test/utils/command-options.test.ts
@@ -1,0 +1,508 @@
+import {describe, expect, it} from 'vitest'
+import {
+  AddCommandOptionDefinitions,
+  applyConfigurationPreset,
+  CommonOptions,
+  ConfigurationPresets,
+  CreateCommandOptionDefinitions,
+  mergeCommandOptions,
+  parseFeatures,
+  validateCreateCommandOptions,
+  validateFeatureName,
+} from '../../src/utils/command-options.js'
+
+describe('CommonOptions', () => {
+  it('should have verbose option', () => {
+    expect(CommonOptions.verbose).toBeDefined()
+    expect(CommonOptions.verbose.flags).toBe('--verbose')
+    expect(CommonOptions.verbose.description).toContain('verbose')
+  })
+
+  it('should have dryRun option', () => {
+    expect(CommonOptions.dryRun).toBeDefined()
+    expect(CommonOptions.dryRun.flags).toBe('--dry-run')
+    expect(CommonOptions.dryRun.description).toContain('without making changes')
+  })
+
+  it('should have cwd option', () => {
+    expect(CommonOptions.cwd).toBeDefined()
+    expect(CommonOptions.cwd.flags).toBe('--cwd <dir>')
+    expect(CommonOptions.cwd.description).toContain('directory')
+  })
+})
+
+describe('CreateCommandOptionDefinitions', () => {
+  it('should have template option', () => {
+    expect(CreateCommandOptionDefinitions.template).toBeDefined()
+    expect(CreateCommandOptionDefinitions.template.flags).toContain('--template')
+  })
+
+  it('should have description option', () => {
+    expect(CreateCommandOptionDefinitions.description).toBeDefined()
+    expect(CreateCommandOptionDefinitions.description.flags).toContain('--description')
+  })
+
+  it('should have author option', () => {
+    expect(CreateCommandOptionDefinitions.author).toBeDefined()
+    expect(CreateCommandOptionDefinitions.author.flags).toContain('--author')
+  })
+
+  it('should have version option with default', () => {
+    expect(CreateCommandOptionDefinitions.version).toBeDefined()
+    expect(CreateCommandOptionDefinitions.version.default).toBe('1.0.0')
+  })
+
+  it('should have outputDir option', () => {
+    expect(CreateCommandOptionDefinitions.outputDir).toBeDefined()
+    expect(CreateCommandOptionDefinitions.outputDir.flags).toContain('--output-dir')
+  })
+
+  it('should have packageManager option', () => {
+    expect(CreateCommandOptionDefinitions.packageManager).toBeDefined()
+    expect(CreateCommandOptionDefinitions.packageManager.description).toContain('npm')
+    expect(CreateCommandOptionDefinitions.packageManager.description).toContain('pnpm')
+  })
+
+  it('should have skipPrompts option', () => {
+    expect(CreateCommandOptionDefinitions.skipPrompts).toBeDefined()
+    expect(CreateCommandOptionDefinitions.skipPrompts.flags).toBe('--skip-prompts')
+  })
+
+  it('should have force option', () => {
+    expect(CreateCommandOptionDefinitions.force).toBeDefined()
+    expect(CreateCommandOptionDefinitions.force.flags).toBe('--force')
+  })
+
+  it('should have interactive option', () => {
+    expect(CreateCommandOptionDefinitions.interactive).toBeDefined()
+    expect(CreateCommandOptionDefinitions.interactive.flags).toBe('--no-interactive')
+  })
+
+  it('should have features option', () => {
+    expect(CreateCommandOptionDefinitions.features).toBeDefined()
+    expect(CreateCommandOptionDefinitions.features.description).toContain('Comma-separated')
+  })
+
+  it('should have git option', () => {
+    expect(CreateCommandOptionDefinitions.git).toBeDefined()
+    expect(CreateCommandOptionDefinitions.git.flags).toBe('--no-git')
+  })
+
+  it('should have install option', () => {
+    expect(CreateCommandOptionDefinitions.install).toBeDefined()
+    expect(CreateCommandOptionDefinitions.install.flags).toBe('--no-install')
+  })
+
+  it('should have preset option', () => {
+    expect(CreateCommandOptionDefinitions.preset).toBeDefined()
+    expect(CreateCommandOptionDefinitions.preset.description).toContain('minimal')
+    expect(CreateCommandOptionDefinitions.preset.description).toContain('standard')
+  })
+
+  it('should have ai option', () => {
+    expect(CreateCommandOptionDefinitions.ai).toBeDefined()
+    expect(CreateCommandOptionDefinitions.ai.description).toContain('AI-powered')
+  })
+
+  it('should have describe option', () => {
+    expect(CreateCommandOptionDefinitions.describe).toBeDefined()
+    expect(CreateCommandOptionDefinitions.describe.description).toContain('Natural language')
+  })
+
+  it('should have templateRef option', () => {
+    expect(CreateCommandOptionDefinitions.templateRef).toBeDefined()
+    expect(CreateCommandOptionDefinitions.templateRef.description).toContain('Git branch')
+  })
+
+  it('should have templateSubdir option', () => {
+    expect(CreateCommandOptionDefinitions.templateSubdir).toBeDefined()
+    expect(CreateCommandOptionDefinitions.templateSubdir.description).toContain('Subdirectory')
+  })
+})
+
+describe('AddCommandOptionDefinitions', () => {
+  it('should have skipConfirm option', () => {
+    expect(AddCommandOptionDefinitions.skipConfirm).toBeDefined()
+    expect(AddCommandOptionDefinitions.skipConfirm.flags).toBe('--skip-confirm')
+  })
+
+  it('should have list option', () => {
+    expect(AddCommandOptionDefinitions.list).toBeDefined()
+    expect(AddCommandOptionDefinitions.list.flags).toBe('--list')
+    expect(AddCommandOptionDefinitions.list.description).toContain('List available')
+  })
+})
+
+describe('validateCreateCommandOptions', () => {
+  it('should validate valid options', () => {
+    const result = validateCreateCommandOptions({
+      name: 'my-project',
+      template: 'library',
+      version: '1.0.0',
+    })
+
+    expect(result.success).toBe(true)
+    expect(result.success && result.data.name).toBe('my-project')
+  })
+
+  it('should validate options without name', () => {
+    const result = validateCreateCommandOptions({
+      template: 'library',
+    })
+
+    expect(result.success).toBe(true)
+  })
+
+  it('should reject invalid project name', () => {
+    const result = validateCreateCommandOptions({
+      name: 'My Project With Spaces',
+    })
+
+    expect(result.success).toBe(false)
+  })
+
+  it('should reject invalid project name with uppercase', () => {
+    const result = validateCreateCommandOptions({
+      name: 'MyProject',
+    })
+
+    expect(result.success).toBe(false)
+  })
+
+  it('should validate valid package manager', () => {
+    const result = validateCreateCommandOptions({
+      packageManager: 'pnpm',
+    })
+
+    expect(result.success).toBe(true)
+    expect(result.success && result.data.packageManager).toBe('pnpm')
+  })
+
+  it('should reject invalid package manager', () => {
+    const result = validateCreateCommandOptions({
+      packageManager: 'invalid' as 'npm',
+    })
+
+    expect(result.success).toBe(false)
+  })
+
+  it('should validate valid version', () => {
+    const result = validateCreateCommandOptions({
+      version: '2.0.0',
+    })
+
+    expect(result.success).toBe(true)
+    expect(result.success && result.data.version).toBe('2.0.0')
+  })
+
+  it('should reject invalid version', () => {
+    const result = validateCreateCommandOptions({
+      version: 'not-a-version',
+    })
+
+    expect(result.success).toBe(false)
+  })
+
+  it('should validate valid preset', () => {
+    const result = validateCreateCommandOptions({
+      preset: 'minimal',
+    })
+
+    expect(result.success).toBe(true)
+  })
+
+  it('should reject invalid preset', () => {
+    const result = validateCreateCommandOptions({
+      preset: 'invalid' as 'minimal',
+    })
+
+    expect(result.success).toBe(false)
+    expect(!result.success && result.error.message).toContain('Invalid preset')
+  })
+
+  it('should reject AI without describe', () => {
+    const result = validateCreateCommandOptions({
+      ai: true,
+    })
+
+    expect(result.success).toBe(false)
+    expect(!result.success && result.error.message).toContain('AI features require')
+  })
+
+  it('should accept AI with describe', () => {
+    const result = validateCreateCommandOptions({
+      ai: true,
+      describe: 'A React dashboard project',
+    })
+
+    expect(result.success).toBe(true)
+  })
+
+  it('should validate output directory', () => {
+    const result = validateCreateCommandOptions({
+      outputDir: './my-project',
+    })
+
+    expect(result.success).toBe(true)
+  })
+
+  it('should handle empty output directory', () => {
+    const result = validateCreateCommandOptions({
+      outputDir: '',
+    })
+
+    expect(result.success).toBe(true)
+  })
+
+  it('should handle whitespace-only output directory', () => {
+    const result = validateCreateCommandOptions({
+      outputDir: '   ',
+    })
+
+    expect(result.success).toBe(true)
+  })
+
+  it('should validate all valid presets', () => {
+    const presets = ['minimal', 'standard', 'full'] as const
+    for (const preset of presets) {
+      const result = validateCreateCommandOptions({preset})
+      expect(result.success).toBe(true)
+    }
+  })
+
+  it('should handle empty name string', () => {
+    const result = validateCreateCommandOptions({
+      name: '',
+    })
+
+    expect(result.success).toBe(true)
+  })
+
+  it('should handle whitespace-only name', () => {
+    const result = validateCreateCommandOptions({
+      name: '   ',
+    })
+
+    expect(result.success).toBe(true)
+  })
+})
+
+describe('parseFeatures', () => {
+  it('should parse comma-separated features', () => {
+    const features = parseFeatures('eslint,prettier,vitest')
+    expect(features).toEqual(['eslint', 'prettier', 'vitest'])
+  })
+
+  it('should handle features with spaces', () => {
+    const features = parseFeatures('eslint, prettier , vitest')
+    expect(features).toEqual(['eslint', 'prettier', 'vitest'])
+  })
+
+  it('should return empty array for undefined', () => {
+    const features = parseFeatures(undefined)
+    expect(features).toEqual([])
+  })
+
+  it('should return empty array for empty string', () => {
+    const features = parseFeatures('')
+    expect(features).toEqual([])
+  })
+
+  it('should return empty array for whitespace-only string', () => {
+    const features = parseFeatures('   ')
+    expect(features).toEqual([])
+  })
+
+  it('should filter out empty features from extra commas', () => {
+    const features = parseFeatures('eslint,,prettier,,,vitest,')
+    expect(features).toEqual(['eslint', 'prettier', 'vitest'])
+  })
+
+  it('should handle single feature', () => {
+    const features = parseFeatures('eslint')
+    expect(features).toEqual(['eslint'])
+  })
+})
+
+describe('ConfigurationPresets', () => {
+  it('should have minimal preset', () => {
+    const minimal = ConfigurationPresets.minimal
+    expect(minimal).toBeDefined()
+    expect(minimal?.template).toBe('minimal')
+    expect(minimal?.git).toBe(false)
+    expect(minimal?.install).toBe(false)
+    expect(minimal?.interactive).toBe(false)
+    expect(minimal?.verbose).toBe(false)
+  })
+
+  it('should have standard preset', () => {
+    const standard = ConfigurationPresets.standard
+    expect(standard).toBeDefined()
+    expect(standard?.template).toBe('library')
+    expect(standard?.git).toBe(true)
+    expect(standard?.install).toBe(true)
+    expect(standard?.interactive).toBe(true)
+    expect(standard?.verbose).toBe(false)
+  })
+
+  it('should have full preset', () => {
+    const full = ConfigurationPresets.full
+    expect(full).toBeDefined()
+    expect(full?.template).toBe('library')
+    expect(full?.git).toBe(true)
+    expect(full?.install).toBe(true)
+    expect(full?.interactive).toBe(true)
+    expect(full?.verbose).toBe(true)
+  })
+})
+
+describe('applyConfigurationPreset', () => {
+  it('should apply minimal preset', () => {
+    const options = applyConfigurationPreset('minimal')
+
+    expect(options.template).toBe('minimal')
+    expect(options.git).toBe(false)
+    expect(options.install).toBe(false)
+    expect(options.interactive).toBe(false)
+    expect(options.verbose).toBe(false)
+  })
+
+  it('should apply standard preset', () => {
+    const options = applyConfigurationPreset('standard')
+
+    expect(options.template).toBe('library')
+    expect(options.git).toBe(true)
+    expect(options.install).toBe(true)
+    expect(options.interactive).toBe(true)
+    expect(options.verbose).toBe(false)
+  })
+
+  it('should apply full preset', () => {
+    const options = applyConfigurationPreset('full')
+
+    expect(options.template).toBe('library')
+    expect(options.git).toBe(true)
+    expect(options.install).toBe(true)
+    expect(options.interactive).toBe(true)
+    expect(options.verbose).toBe(true)
+  })
+
+  it('should return empty object for undefined preset', () => {
+    const options = applyConfigurationPreset(undefined)
+    expect(options).toEqual({})
+  })
+
+  it('should return empty object for unknown preset', () => {
+    const options = applyConfigurationPreset('unknown' as 'minimal')
+    expect(options).toEqual({})
+  })
+})
+
+describe('mergeCommandOptions', () => {
+  it('should merge options with defaults', () => {
+    const defaults = {
+      verbose: false,
+      interactive: true,
+      template: 'default',
+    }
+
+    const provided = {
+      verbose: true,
+      template: 'library',
+    }
+
+    const merged = mergeCommandOptions(provided, defaults)
+
+    expect(merged.verbose).toBe(true)
+    expect('interactive' in merged && merged.interactive).toBe(true)
+    expect(merged.template).toBe('library')
+  })
+
+  it('should override defaults with provided values', () => {
+    const defaults = {name: 'default-name', version: '1.0.0'}
+    const provided = {name: 'custom-name'}
+
+    const merged = mergeCommandOptions(provided, defaults)
+
+    expect(merged.name).toBe('custom-name')
+    expect('version' in merged && merged.version).toBe('1.0.0')
+  })
+
+  it('should handle empty provided options', () => {
+    const defaults = {name: 'default', template: 'library'}
+    const merged = mergeCommandOptions({}, defaults)
+
+    expect(merged.name).toBe('default')
+    expect(merged.template).toBe('library')
+  })
+
+  it('should handle empty defaults', () => {
+    const provided = {name: 'custom', template: 'cli'}
+    const merged = mergeCommandOptions(provided, {})
+
+    expect(merged.name).toBe('custom')
+    expect(merged.template).toBe('cli')
+  })
+})
+
+describe('validateFeatureName', () => {
+  it('should validate lowercase feature names', () => {
+    const result = validateFeatureName('eslint')
+    expect(result.success).toBe(true)
+    expect(result.success && result.data).toBe('eslint')
+  })
+
+  it('should validate feature names with numbers', () => {
+    const result = validateFeatureName('vitest2')
+    expect(result.success).toBe(true)
+    expect(result.success && result.data).toBe('vitest2')
+  })
+
+  it('should validate feature names with hyphens', () => {
+    const result = validateFeatureName('react-query')
+    expect(result.success).toBe(true)
+    expect(result.success && result.data).toBe('react-query')
+  })
+
+  it('should trim whitespace', () => {
+    const result = validateFeatureName('  eslint  ')
+    expect(result.success).toBe(true)
+    expect(result.success && result.data).toBe('eslint')
+  })
+
+  it('should reject empty feature name', () => {
+    const result = validateFeatureName('')
+    expect(result.success).toBe(false)
+    expect(!result.success && result.error.message).toContain('required')
+  })
+
+  it('should reject whitespace-only feature name', () => {
+    const result = validateFeatureName('   ')
+    expect(result.success).toBe(false)
+    expect(!result.success && result.error.message).toContain('required')
+  })
+
+  it('should reject uppercase letters', () => {
+    const result = validateFeatureName('ESLint')
+    expect(result.success).toBe(false)
+    expect(!result.success && result.error.message).toContain('lowercase')
+  })
+
+  it('should reject spaces in feature name', () => {
+    const result = validateFeatureName('react query')
+    expect(result.success).toBe(false)
+    expect(!result.success && result.error.message).toContain('lowercase')
+  })
+
+  it('should reject special characters', () => {
+    const result = validateFeatureName('eslint@latest')
+    expect(result.success).toBe(false)
+    expect(!result.success && result.error.message).toContain('lowercase')
+  })
+
+  it('should reject underscores', () => {
+    const result = validateFeatureName('react_query')
+    expect(result.success).toBe(false)
+    expect(!result.success && result.error.message).toContain('lowercase')
+  })
+})

--- a/packages/create/test/utils/errors.test.ts
+++ b/packages/create/test/utils/errors.test.ts
@@ -1,0 +1,412 @@
+/**
+ * Tests for unified error handling system
+ * Part of Phase 5: Comprehensive Testing Implementation (TASK-033)
+ */
+
+import {describe, expect, it} from 'vitest'
+import {
+  AIErrorCode,
+  BaseError,
+  CLIErrorCode,
+  createAIError,
+  createCLIError,
+  createProjectError,
+  createTemplateError,
+  getUserFriendlyMessage,
+  hasErrorCode,
+  isBaseError,
+  ProjectErrorCode,
+  TemplateErrorCode,
+} from '../../src/utils/errors.js'
+
+describe('unified error handling system', () => {
+  describe('error code constants', () => {
+    describe('TemplateErrorCode', () => {
+      it.concurrent('contains all expected template error codes', () => {
+        expect(TemplateErrorCode).toMatchObject({
+          TEMPLATE_NOT_FOUND: 'TEMPLATE_NOT_FOUND',
+          TEMPLATE_INVALID: 'TEMPLATE_INVALID',
+          TEMPLATE_FETCH_FAILED: 'TEMPLATE_FETCH_FAILED',
+          TEMPLATE_PARSE_ERROR: 'TEMPLATE_PARSE_ERROR',
+          TEMPLATE_RENDER_ERROR: 'TEMPLATE_RENDER_ERROR',
+          TEMPLATE_METADATA_INVALID: 'TEMPLATE_METADATA_INVALID',
+          TEMPLATE_VARIABLE_MISSING: 'TEMPLATE_VARIABLE_MISSING',
+          TEMPLATE_CACHE_ERROR: 'TEMPLATE_CACHE_ERROR',
+        })
+      })
+    })
+
+    describe('AIErrorCode', () => {
+      it.concurrent('contains all expected AI error codes', () => {
+        expect(AIErrorCode).toMatchObject({
+          AI_PROVIDER_UNAVAILABLE: 'AI_PROVIDER_UNAVAILABLE',
+          AI_API_KEY_MISSING: 'AI_API_KEY_MISSING',
+          AI_API_KEY_INVALID: 'AI_API_KEY_INVALID',
+          AI_REQUEST_FAILED: 'AI_REQUEST_FAILED',
+          AI_RESPONSE_INVALID: 'AI_RESPONSE_INVALID',
+          AI_RATE_LIMIT: 'AI_RATE_LIMIT',
+          AI_TIMEOUT: 'AI_TIMEOUT',
+          AI_ANALYSIS_FAILED: 'AI_ANALYSIS_FAILED',
+        })
+      })
+    })
+
+    describe('CLIErrorCode', () => {
+      it.concurrent('contains all expected CLI error codes', () => {
+        expect(CLIErrorCode).toMatchObject({
+          INVALID_INPUT: 'INVALID_INPUT',
+          INVALID_PROJECT_NAME: 'INVALID_PROJECT_NAME',
+          INVALID_PATH: 'INVALID_PATH',
+          PATH_TRAVERSAL_ATTEMPT: 'PATH_TRAVERSAL_ATTEMPT',
+          DIRECTORY_EXISTS: 'DIRECTORY_EXISTS',
+          DIRECTORY_NOT_EMPTY: 'DIRECTORY_NOT_EMPTY',
+          FILE_SYSTEM_ERROR: 'FILE_SYSTEM_ERROR',
+          PERMISSION_DENIED: 'PERMISSION_DENIED',
+          COMMAND_FAILED: 'COMMAND_FAILED',
+          VALIDATION_FAILED: 'VALIDATION_FAILED',
+        })
+      })
+    })
+
+    describe('ProjectErrorCode', () => {
+      it.concurrent('contains all expected project error codes', () => {
+        expect(ProjectErrorCode).toMatchObject({
+          PROJECT_DETECTION_FAILED: 'PROJECT_DETECTION_FAILED',
+          PACKAGE_JSON_NOT_FOUND: 'PACKAGE_JSON_NOT_FOUND',
+          PACKAGE_JSON_INVALID: 'PACKAGE_JSON_INVALID',
+          PACKAGE_MANAGER_NOT_DETECTED: 'PACKAGE_MANAGER_NOT_DETECTED',
+        })
+      })
+    })
+  })
+
+  describe('error factory functions', () => {
+    describe('createTemplateError', () => {
+      it.concurrent('creates a template error with code and message', () => {
+        const error = createTemplateError(
+          'Template not found',
+          TemplateErrorCode.TEMPLATE_NOT_FOUND,
+        )
+
+        expect(error).toBeInstanceOf(BaseError)
+        expect(error.message).toBe('Template not found')
+        expect(error.code).toBe('TEMPLATE_NOT_FOUND')
+      })
+
+      it.concurrent('creates a template error with context', () => {
+        const error = createTemplateError(
+          'Failed to fetch template',
+          TemplateErrorCode.TEMPLATE_FETCH_FAILED,
+          {url: 'https://github.com/user/repo'},
+        )
+
+        expect(error).toBeInstanceOf(BaseError)
+        expect(error.message).toBe('Failed to fetch template')
+        expect(error.code).toBe('TEMPLATE_FETCH_FAILED')
+        expect(error.context).toEqual({url: 'https://github.com/user/repo'})
+      })
+
+      it.concurrent('creates errors for all template error codes', () => {
+        const codes = Object.values(TemplateErrorCode)
+
+        for (const code of codes) {
+          const error = createTemplateError(`Test error: ${code}`, code)
+          expect(error.code).toBe(code)
+          expect(isBaseError(error)).toBe(true)
+        }
+      })
+    })
+
+    describe('createAIError', () => {
+      it.concurrent('creates an AI error with code and message', () => {
+        const error = createAIError('API key is missing', AIErrorCode.AI_API_KEY_MISSING)
+
+        expect(error).toBeInstanceOf(BaseError)
+        expect(error.message).toBe('API key is missing')
+        expect(error.code).toBe('AI_API_KEY_MISSING')
+      })
+
+      it.concurrent('creates an AI error with context', () => {
+        const error = createAIError('Rate limit exceeded', AIErrorCode.AI_RATE_LIMIT, {
+          provider: 'openai',
+          retryAfter: 60,
+        })
+
+        expect(error).toBeInstanceOf(BaseError)
+        expect(error.code).toBe('AI_RATE_LIMIT')
+        expect(error.context).toEqual({provider: 'openai', retryAfter: 60})
+      })
+
+      it.concurrent('creates errors for all AI error codes', () => {
+        const codes = Object.values(AIErrorCode)
+
+        for (const code of codes) {
+          const error = createAIError(`Test error: ${code}`, code)
+          expect(error.code).toBe(code)
+          expect(isBaseError(error)).toBe(true)
+        }
+      })
+    })
+
+    describe('createCLIError', () => {
+      it.concurrent('creates a CLI error with code and message', () => {
+        const error = createCLIError('Invalid project name', CLIErrorCode.INVALID_PROJECT_NAME)
+
+        expect(error).toBeInstanceOf(BaseError)
+        expect(error.message).toBe('Invalid project name')
+        expect(error.code).toBe('INVALID_PROJECT_NAME')
+      })
+
+      it.concurrent('creates a CLI error with context', () => {
+        const error = createCLIError(
+          'Path traversal detected',
+          CLIErrorCode.PATH_TRAVERSAL_ATTEMPT,
+          {
+            path: '../../../etc/passwd',
+          },
+        )
+
+        expect(error).toBeInstanceOf(BaseError)
+        expect(error.code).toBe('PATH_TRAVERSAL_ATTEMPT')
+        expect(error.context).toEqual({path: '../../../etc/passwd'})
+      })
+
+      it.concurrent('creates errors for all CLI error codes', () => {
+        const codes = Object.values(CLIErrorCode)
+
+        for (const code of codes) {
+          const error = createCLIError(`Test error: ${code}`, code)
+          expect(error.code).toBe(code)
+          expect(isBaseError(error)).toBe(true)
+        }
+      })
+    })
+
+    describe('createProjectError', () => {
+      it.concurrent('creates a project error with code and message', () => {
+        const error = createProjectError(
+          'Package.json not found',
+          ProjectErrorCode.PACKAGE_JSON_NOT_FOUND,
+        )
+
+        expect(error).toBeInstanceOf(BaseError)
+        expect(error.message).toBe('Package.json not found')
+        expect(error.code).toBe('PACKAGE_JSON_NOT_FOUND')
+      })
+
+      it.concurrent('creates a project error with context', () => {
+        const error = createProjectError(
+          'Project detection failed',
+          ProjectErrorCode.PROJECT_DETECTION_FAILED,
+          {directory: '/path/to/project'},
+        )
+
+        expect(error).toBeInstanceOf(BaseError)
+        expect(error.code).toBe('PROJECT_DETECTION_FAILED')
+        expect(error.context).toEqual({directory: '/path/to/project'})
+      })
+
+      it.concurrent('creates errors for all project error codes', () => {
+        const codes = Object.values(ProjectErrorCode)
+
+        for (const code of codes) {
+          const error = createProjectError(`Test error: ${code}`, code)
+          expect(error.code).toBe(code)
+          expect(isBaseError(error)).toBe(true)
+        }
+      })
+    })
+  })
+
+  describe('type guards', () => {
+    describe('isBaseError', () => {
+      it.concurrent('returns true for BaseError instances', () => {
+        const error = createTemplateError('Test', TemplateErrorCode.TEMPLATE_INVALID)
+        expect(isBaseError(error)).toBe(true)
+      })
+
+      it.concurrent('returns true for AI errors', () => {
+        const error = createAIError('Test', AIErrorCode.AI_REQUEST_FAILED)
+        expect(isBaseError(error)).toBe(true)
+      })
+
+      it.concurrent('returns true for CLI errors', () => {
+        const error = createCLIError('Test', CLIErrorCode.INVALID_INPUT)
+        expect(isBaseError(error)).toBe(true)
+      })
+
+      it.concurrent('returns false for regular Error instances', () => {
+        const error = new Error('Regular error')
+        expect(isBaseError(error)).toBe(false)
+      })
+
+      it.concurrent('returns false for non-error values', () => {
+        expect(isBaseError(null)).toBe(false)
+        expect(isBaseError(undefined)).toBe(false)
+        expect(isBaseError('string error')).toBe(false)
+        expect(isBaseError({message: 'object error'})).toBe(false)
+        expect(isBaseError(42)).toBe(false)
+      })
+    })
+
+    describe('hasErrorCode', () => {
+      it.concurrent('returns true when error has matching code', () => {
+        const error = createTemplateError('Test', TemplateErrorCode.TEMPLATE_NOT_FOUND)
+        expect(hasErrorCode(error, TemplateErrorCode.TEMPLATE_NOT_FOUND)).toBe(true)
+      })
+
+      it.concurrent('returns false when error has different code', () => {
+        const error = createTemplateError('Test', TemplateErrorCode.TEMPLATE_NOT_FOUND)
+        expect(hasErrorCode(error, TemplateErrorCode.TEMPLATE_INVALID)).toBe(false)
+      })
+
+      it.concurrent('returns false for non-BaseError instances', () => {
+        const error = new Error('Regular error')
+        expect(hasErrorCode(error, TemplateErrorCode.TEMPLATE_NOT_FOUND)).toBe(false)
+      })
+
+      it.concurrent('returns false for non-error values', () => {
+        expect(hasErrorCode(null, TemplateErrorCode.TEMPLATE_NOT_FOUND)).toBe(false)
+        expect(hasErrorCode(undefined, TemplateErrorCode.TEMPLATE_NOT_FOUND)).toBe(false)
+        expect(hasErrorCode('string', TemplateErrorCode.TEMPLATE_NOT_FOUND)).toBe(false)
+      })
+
+      it.concurrent('works with AI error codes', () => {
+        const error = createAIError('Test', AIErrorCode.AI_API_KEY_MISSING)
+        expect(hasErrorCode(error, AIErrorCode.AI_API_KEY_MISSING)).toBe(true)
+        expect(hasErrorCode(error, AIErrorCode.AI_TIMEOUT)).toBe(false)
+      })
+
+      it.concurrent('works with CLI error codes', () => {
+        const error = createCLIError('Test', CLIErrorCode.DIRECTORY_EXISTS)
+        expect(hasErrorCode(error, CLIErrorCode.DIRECTORY_EXISTS)).toBe(true)
+        expect(hasErrorCode(error, CLIErrorCode.INVALID_PATH)).toBe(false)
+      })
+    })
+  })
+
+  describe('getUserFriendlyMessage', () => {
+    describe('template errors', () => {
+      it.concurrent('returns friendly message for TEMPLATE_NOT_FOUND', () => {
+        const error = createTemplateError('Test', TemplateErrorCode.TEMPLATE_NOT_FOUND)
+        const message = getUserFriendlyMessage(error)
+        expect(message).toContain('Template not found')
+        expect(message).toContain('Please check')
+      })
+
+      it.concurrent('returns friendly message for TEMPLATE_INVALID', () => {
+        const error = createTemplateError('Test', TemplateErrorCode.TEMPLATE_INVALID)
+        const message = getUserFriendlyMessage(error)
+        expect(message).toContain('Invalid template')
+      })
+
+      it.concurrent('returns friendly message for TEMPLATE_FETCH_FAILED', () => {
+        const error = createTemplateError('Test', TemplateErrorCode.TEMPLATE_FETCH_FAILED)
+        const message = getUserFriendlyMessage(error)
+        expect(message).toContain('Failed to fetch template')
+        expect(message).toContain('internet connection')
+      })
+    })
+
+    describe('AI errors', () => {
+      it.concurrent('returns friendly message for AI_API_KEY_MISSING', () => {
+        const error = createAIError('Test', AIErrorCode.AI_API_KEY_MISSING)
+        const message = getUserFriendlyMessage(error)
+        expect(message).toContain('API key is missing')
+        expect(message).toContain('OPENAI_API_KEY')
+        expect(message).toContain('ANTHROPIC_API_KEY')
+      })
+
+      it.concurrent('returns friendly message for AI_PROVIDER_UNAVAILABLE', () => {
+        const error = createAIError('Test', AIErrorCode.AI_PROVIDER_UNAVAILABLE)
+        const message = getUserFriendlyMessage(error)
+        expect(message).toContain('unavailable')
+      })
+    })
+
+    describe('CLI errors', () => {
+      it.concurrent('returns friendly message for INVALID_PROJECT_NAME', () => {
+        const error = createCLIError('Must be lowercase', CLIErrorCode.INVALID_PROJECT_NAME)
+        const message = getUserFriendlyMessage(error)
+        expect(message).toContain('Invalid project name')
+        expect(message).toContain('Must be lowercase')
+      })
+
+      it.concurrent('returns friendly message for PATH_TRAVERSAL_ATTEMPT', () => {
+        const error = createCLIError('Test', CLIErrorCode.PATH_TRAVERSAL_ATTEMPT)
+        const message = getUserFriendlyMessage(error)
+        expect(message).toContain('Invalid path')
+        expect(message).toContain('not allowed')
+      })
+
+      it.concurrent('returns friendly message for DIRECTORY_EXISTS', () => {
+        const error = createCLIError('Test', CLIErrorCode.DIRECTORY_EXISTS)
+        const message = getUserFriendlyMessage(error)
+        expect(message).toContain('Directory already exists')
+        expect(message).toContain('--force')
+      })
+
+      it.concurrent('returns friendly message for PERMISSION_DENIED', () => {
+        const error = createCLIError('Test', CLIErrorCode.PERMISSION_DENIED)
+        const message = getUserFriendlyMessage(error)
+        expect(message).toContain('Permission denied')
+      })
+    })
+
+    describe('fallback behavior', () => {
+      it.concurrent('returns original message for unrecognized BaseError codes', () => {
+        const error = createTemplateError(
+          'Custom error message',
+          TemplateErrorCode.TEMPLATE_PARSE_ERROR,
+        )
+        const message = getUserFriendlyMessage(error)
+        expect(message).toBe('Custom error message')
+      })
+
+      it.concurrent('returns message for regular Error instances', () => {
+        const error = new Error('Regular error message')
+        const message = getUserFriendlyMessage(error)
+        expect(message).toBe('Regular error message')
+      })
+
+      it.concurrent('returns fallback message for non-error values', () => {
+        expect(getUserFriendlyMessage(null)).toBe('An unknown error occurred.')
+        expect(getUserFriendlyMessage(undefined)).toBe('An unknown error occurred.')
+        expect(getUserFriendlyMessage('string error')).toBe('An unknown error occurred.')
+      })
+    })
+  })
+
+  describe('cross-domain error handling', () => {
+    it.concurrent('validates errors work correctly across domains', () => {
+      const templateError = createTemplateError(
+        'Template issue',
+        TemplateErrorCode.TEMPLATE_INVALID,
+      )
+      const aiError = createAIError('AI issue', AIErrorCode.AI_REQUEST_FAILED)
+      const cliError = createCLIError('CLI issue', CLIErrorCode.INVALID_INPUT)
+      const projectError = createProjectError(
+        'Project issue',
+        ProjectErrorCode.PACKAGE_JSON_NOT_FOUND,
+      )
+
+      // All should be BaseError instances
+      expect(isBaseError(templateError)).toBe(true)
+      expect(isBaseError(aiError)).toBe(true)
+      expect(isBaseError(cliError)).toBe(true)
+      expect(isBaseError(projectError)).toBe(true)
+
+      // Each should have its correct code
+      expect(hasErrorCode(templateError, TemplateErrorCode.TEMPLATE_INVALID)).toBe(true)
+      expect(hasErrorCode(aiError, AIErrorCode.AI_REQUEST_FAILED)).toBe(true)
+      expect(hasErrorCode(cliError, CLIErrorCode.INVALID_INPUT)).toBe(true)
+      expect(hasErrorCode(projectError, ProjectErrorCode.PACKAGE_JSON_NOT_FOUND)).toBe(true)
+
+      // Cross-domain checks should return false
+      expect(hasErrorCode(templateError, AIErrorCode.AI_REQUEST_FAILED)).toBe(false)
+      expect(hasErrorCode(aiError, CLIErrorCode.INVALID_INPUT)).toBe(false)
+      expect(hasErrorCode(cliError, ProjectErrorCode.PACKAGE_JSON_NOT_FOUND)).toBe(false)
+      expect(hasErrorCode(projectError, TemplateErrorCode.TEMPLATE_INVALID)).toBe(false)
+    })
+  })
+})

--- a/packages/create/test/utils/file-system.test.ts
+++ b/packages/create/test/utils/file-system.test.ts
@@ -1,0 +1,464 @@
+/**
+ * Tests for File System Utilities
+ * Part of Phase 5: Comprehensive Testing Implementation (TASK-038)
+ *
+ * Tests file system operations including creation, copying, removal, and path utilities.
+ */
+
+import {existsSync, rmSync} from 'node:fs'
+import {mkdir, rm, writeFile} from 'node:fs/promises'
+import path from 'node:path'
+import {afterEach, beforeEach, describe, expect, it} from 'vitest'
+import {
+  copy,
+  createFile,
+  createTempDir,
+  ensureDir,
+  exists,
+  findFiles,
+  getRelativePath,
+  getSize,
+  getStats,
+  isDirectory,
+  isEmpty,
+  isFile,
+  joinPaths,
+  move,
+  readDir,
+  remove,
+  resolvePath,
+} from '../../src/utils/file-system.js'
+
+describe('File System Utilities', () => {
+  let testDir: string
+
+  beforeEach(async () => {
+    testDir = path.join(process.cwd(), '.tmp', `fs-test-${Date.now()}`)
+    await mkdir(testDir, {recursive: true})
+  })
+
+  afterEach(async () => {
+    if (existsSync(testDir)) {
+      rmSync(testDir, {recursive: true, force: true})
+    }
+  })
+
+  describe('exists', () => {
+    it('returns true for existing path', async () => {
+      const filePath = path.join(testDir, 'test.txt')
+      await writeFile(filePath, 'test content')
+
+      expect(exists(filePath)).toBe(true)
+    })
+
+    it('returns false for non-existing path', () => {
+      expect(exists(path.join(testDir, 'nonexistent.txt'))).toBe(false)
+    })
+
+    it('returns true for existing directory', () => {
+      expect(exists(testDir)).toBe(true)
+    })
+  })
+
+  describe('ensureDir', () => {
+    it('creates directory if not exists', async () => {
+      const newDir = path.join(testDir, 'new-dir')
+
+      await ensureDir(newDir)
+
+      expect(existsSync(newDir)).toBe(true)
+    })
+
+    it('creates nested directories', async () => {
+      const nestedDir = path.join(testDir, 'a', 'b', 'c')
+
+      await ensureDir(nestedDir)
+
+      expect(existsSync(nestedDir)).toBe(true)
+    })
+
+    it('does not fail if directory already exists', async () => {
+      await ensureDir(testDir)
+
+      expect(existsSync(testDir)).toBe(true)
+    })
+  })
+
+  describe('copy', () => {
+    it('copies file to new location', async () => {
+      const source = path.join(testDir, 'source.txt')
+      const target = path.join(testDir, 'target.txt')
+      await writeFile(source, 'content')
+
+      await copy(source, target)
+
+      expect(existsSync(target)).toBe(true)
+    })
+
+    it('copies directory recursively', async () => {
+      const sourceDir = path.join(testDir, 'source-dir')
+      await mkdir(sourceDir)
+      await writeFile(path.join(sourceDir, 'file.txt'), 'content')
+
+      const targetDir = path.join(testDir, 'target-dir')
+
+      await copy(sourceDir, targetDir)
+
+      expect(existsSync(path.join(targetDir, 'file.txt'))).toBe(true)
+    })
+
+    it('respects overwrite false option', async () => {
+      const source = path.join(testDir, 'source.txt')
+      const target = path.join(testDir, 'target.txt')
+      await writeFile(source, 'new content')
+      await writeFile(target, 'original content')
+
+      await copy(source, target, {overwrite: false})
+
+      // Original content should be preserved
+      const fs = await import('node:fs/promises')
+      const content = await fs.readFile(target, 'utf-8')
+      expect(content).toBe('original content')
+    })
+
+    it('respects filter function', async () => {
+      const source = path.join(testDir, 'source.txt')
+      const target = path.join(testDir, 'target.txt')
+      await writeFile(source, 'content')
+
+      // Filter that rejects everything
+      await copy(source, target, {filter: () => false})
+
+      expect(existsSync(target)).toBe(false)
+    })
+
+    it('creates target directory if not exists', async () => {
+      const source = path.join(testDir, 'source.txt')
+      const target = path.join(testDir, 'new-dir', 'target.txt')
+      await writeFile(source, 'content')
+
+      await copy(source, target)
+
+      expect(existsSync(target)).toBe(true)
+    })
+  })
+
+  describe('remove', () => {
+    it('removes file', async () => {
+      const filePath = path.join(testDir, 'to-remove.txt')
+      await writeFile(filePath, 'content')
+
+      await remove(filePath)
+
+      expect(existsSync(filePath)).toBe(false)
+    })
+
+    it('removes directory recursively', async () => {
+      const dirPath = path.join(testDir, 'to-remove-dir')
+      await mkdir(dirPath)
+      await writeFile(path.join(dirPath, 'file.txt'), 'content')
+
+      await remove(dirPath)
+
+      expect(existsSync(dirPath)).toBe(false)
+    })
+
+    it('does nothing for non-existing path', async () => {
+      // Should not throw
+      await expect(remove(path.join(testDir, 'nonexistent'))).resolves.not.toThrow()
+    })
+  })
+
+  describe('createTempDir', () => {
+    it('creates temp directory with prefix', async () => {
+      const tempDir = await createTempDir('test-prefix-')
+
+      try {
+        expect(existsSync(tempDir)).toBe(true)
+        expect(path.basename(tempDir)).toMatch(/^test-prefix-/)
+      } finally {
+        await rm(tempDir, {recursive: true, force: true})
+      }
+    })
+
+    it('creates temp directory with default prefix', async () => {
+      const tempDir = await createTempDir()
+
+      try {
+        expect(existsSync(tempDir)).toBe(true)
+        expect(path.basename(tempDir)).toMatch(/^bfra-me-create-/)
+      } finally {
+        await rm(tempDir, {recursive: true, force: true})
+      }
+    })
+  })
+
+  describe('readDir', () => {
+    it('returns directory contents', async () => {
+      await writeFile(path.join(testDir, 'file1.txt'), 'content')
+      await writeFile(path.join(testDir, 'file2.txt'), 'content')
+
+      const contents = await readDir(testDir)
+
+      expect(contents).toContain('file1.txt')
+      expect(contents).toContain('file2.txt')
+    })
+
+    it('returns empty array for non-existing directory', async () => {
+      const contents = await readDir(path.join(testDir, 'nonexistent'))
+
+      expect(contents).toEqual([])
+    })
+  })
+
+  describe('getStats', () => {
+    it('returns stats for existing file', async () => {
+      const filePath = path.join(testDir, 'test.txt')
+      await writeFile(filePath, 'content')
+
+      const stats = await getStats(filePath)
+
+      expect(stats).not.toBeNull()
+      expect(stats?.isFile()).toBe(true)
+    })
+
+    it('returns stats for existing directory', async () => {
+      const stats = await getStats(testDir)
+
+      expect(stats).not.toBeNull()
+      expect(stats?.isDirectory()).toBe(true)
+    })
+
+    it('returns null for non-existing path', async () => {
+      const stats = await getStats(path.join(testDir, 'nonexistent'))
+
+      expect(stats).toBeNull()
+    })
+  })
+
+  describe('isDirectory', () => {
+    it('returns true for directory', () => {
+      expect(isDirectory(testDir)).toBe(true)
+    })
+
+    it('returns false for file', async () => {
+      const filePath = path.join(testDir, 'test.txt')
+      await writeFile(filePath, 'content')
+
+      expect(isDirectory(filePath)).toBe(false)
+    })
+
+    it('returns false for non-existing path', () => {
+      expect(isDirectory(path.join(testDir, 'nonexistent'))).toBe(false)
+    })
+  })
+
+  describe('isFile', () => {
+    it('returns true for file', async () => {
+      const filePath = path.join(testDir, 'test.txt')
+      await writeFile(filePath, 'content')
+
+      expect(isFile(filePath)).toBe(true)
+    })
+
+    it('returns false for directory', () => {
+      expect(isFile(testDir)).toBe(false)
+    })
+
+    it('returns false for non-existing path', () => {
+      expect(isFile(path.join(testDir, 'nonexistent'))).toBe(false)
+    })
+  })
+
+  describe('findFiles', () => {
+    it('finds files matching pattern', async () => {
+      await writeFile(path.join(testDir, 'file1.txt'), 'content')
+      await writeFile(path.join(testDir, 'file2.txt'), 'content')
+      await writeFile(path.join(testDir, 'other.json'), 'content')
+
+      const files = await findFiles('*.txt', {cwd: testDir})
+
+      expect(files).toContain('file1.txt')
+      expect(files).toContain('file2.txt')
+      expect(files).not.toContain('other.json')
+    })
+
+    it('respects ignore patterns', async () => {
+      const nodeModules = path.join(testDir, 'node_modules')
+      await mkdir(nodeModules)
+      await writeFile(path.join(nodeModules, 'file.txt'), 'content')
+      await writeFile(path.join(testDir, 'file.txt'), 'content')
+
+      const files = await findFiles('**/*.txt', {
+        cwd: testDir,
+        ignore: ['node_modules/**'],
+      })
+
+      expect(files).toContain('file.txt')
+      expect(files).not.toContain('node_modules/file.txt')
+    })
+
+    it('returns empty array on error', async () => {
+      // Pass invalid pattern that might cause error
+      const files = await findFiles('', {cwd: '/nonexistent/path'})
+
+      expect(Array.isArray(files)).toBe(true)
+    })
+  })
+
+  describe('getSize', () => {
+    it('returns file size', async () => {
+      const filePath = path.join(testDir, 'test.txt')
+      const content = 'hello world'
+      await writeFile(filePath, content)
+
+      const size = await getSize(filePath)
+
+      expect(size).toBe(content.length)
+    })
+
+    it('returns directory size', async () => {
+      const subDir = path.join(testDir, 'sub')
+      await mkdir(subDir)
+      await writeFile(path.join(subDir, 'file1.txt'), 'hello')
+      await writeFile(path.join(subDir, 'file2.txt'), 'world')
+
+      const size = await getSize(subDir)
+
+      expect(size).toBe(10) // 'hello' + 'world'
+    })
+
+    it('returns 0 for non-existing path', async () => {
+      const size = await getSize(path.join(testDir, 'nonexistent'))
+
+      expect(size).toBe(0)
+    })
+  })
+
+  describe('createFile', () => {
+    it('creates file with content', async () => {
+      const filePath = path.join(testDir, 'new-file.txt')
+
+      await createFile(filePath, 'test content')
+
+      expect(existsSync(filePath)).toBe(true)
+      const fs = await import('node:fs/promises')
+      const content = await fs.readFile(filePath, 'utf-8')
+      expect(content).toBe('test content')
+    })
+
+    it('creates parent directories if needed', async () => {
+      const filePath = path.join(testDir, 'nested', 'dir', 'file.txt')
+
+      await createFile(filePath, 'content')
+
+      expect(existsSync(filePath)).toBe(true)
+    })
+  })
+
+  describe('isEmpty', () => {
+    it('returns true for empty directory', async () => {
+      const emptyDir = path.join(testDir, 'empty')
+      await mkdir(emptyDir)
+
+      const result = await isEmpty(emptyDir)
+
+      expect(result).toBe(true)
+    })
+
+    it('returns false for non-empty directory', async () => {
+      await writeFile(path.join(testDir, 'file.txt'), 'content')
+
+      const result = await isEmpty(testDir)
+
+      expect(result).toBe(false)
+    })
+
+    it('returns true for non-existing directory', async () => {
+      const result = await isEmpty(path.join(testDir, 'nonexistent'))
+
+      expect(result).toBe(true)
+    })
+  })
+
+  describe('move', () => {
+    it('moves file to new location', async () => {
+      const source = path.join(testDir, 'source.txt')
+      const target = path.join(testDir, 'target.txt')
+      await writeFile(source, 'content')
+
+      await move(source, target)
+
+      expect(existsSync(source)).toBe(false)
+      expect(existsSync(target)).toBe(true)
+    })
+
+    it('moves directory to new location', async () => {
+      const sourceDir = path.join(testDir, 'source-dir')
+      await mkdir(sourceDir)
+      await writeFile(path.join(sourceDir, 'file.txt'), 'content')
+
+      const targetDir = path.join(testDir, 'target-dir')
+
+      await move(sourceDir, targetDir)
+
+      expect(existsSync(sourceDir)).toBe(false)
+      expect(existsSync(path.join(targetDir, 'file.txt'))).toBe(true)
+    })
+  })
+
+  describe('getRelativePath', () => {
+    it('calculates relative path between directories', () => {
+      const from = '/a/b/c'
+      const to = '/a/b/d/e'
+
+      const result = getRelativePath(from, to)
+
+      expect(result).toBe('../d/e')
+    })
+
+    it('handles same directory', () => {
+      const dir = '/a/b/c'
+
+      const result = getRelativePath(dir, dir)
+
+      expect(result).toBe('')
+    })
+  })
+
+  describe('resolvePath', () => {
+    it('resolves to absolute path', () => {
+      const result = resolvePath('test', 'path')
+
+      expect(path.isAbsolute(result)).toBe(true)
+      expect(result).toContain('test')
+      expect(result).toContain('path')
+    })
+
+    it('handles absolute paths', () => {
+      const result = resolvePath('/absolute/path')
+
+      expect(result).toBe('/absolute/path')
+    })
+  })
+
+  describe('joinPaths', () => {
+    it('joins path segments', () => {
+      const result = joinPaths('a', 'b', 'c')
+
+      expect(result).toBe('a/b/c')
+    })
+
+    it('handles leading slashes', () => {
+      const result = joinPaths('/a', 'b', 'c')
+
+      expect(result).toBe('/a/b/c')
+    })
+
+    it('normalizes path separators', () => {
+      const result = joinPaths('a', 'b/c', 'd')
+
+      expect(result).toBe('a/b/c/d')
+    })
+  })
+})

--- a/packages/create/test/utils/help.test.ts
+++ b/packages/create/test/utils/help.test.ts
@@ -1,0 +1,467 @@
+import {consola} from 'consola'
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+import {HelpSystem, helpSystem, showErrorHelp} from '../../src/utils/help.js'
+
+vi.mock('consola', () => ({
+  consola: {
+    box: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+  },
+}))
+
+const getBoxCall = (): string => {
+  const calls = vi.mocked(consola.box).mock.calls
+  return (calls[0]?.[0] as string) ?? ''
+}
+
+const getInfoCall = (): string => {
+  const calls = vi.mocked(consola.info).mock.calls
+  return (calls[0]?.[0] as string) ?? ''
+}
+
+describe('HelpSystem', () => {
+  let system: HelpSystem
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    system = new HelpSystem()
+  })
+
+  describe('constructor', () => {
+    it('should initialize with default topics and commands', () => {
+      const newSystem = new HelpSystem()
+      expect(newSystem).toBeDefined()
+    })
+  })
+
+  describe('getTopicHelp', () => {
+    it('should return templates topic', () => {
+      const topic = system.getTopicHelp('templates')
+      expect(topic).toBeDefined()
+      expect(topic?.name).toBe('Templates')
+      expect(topic?.description).toContain('template')
+      expect(topic?.examples.length).toBeGreaterThan(0)
+      expect(topic?.relatedTopics).toContain('customization')
+    })
+
+    it('should return customization topic', () => {
+      const topic = system.getTopicHelp('customization')
+      expect(topic).toBeDefined()
+      expect(topic?.name).toBe('Customization')
+      expect(topic?.description).toContain('Configuring')
+      expect(topic?.examples.length).toBeGreaterThan(0)
+      expect(topic?.relatedTopics).toContain('templates')
+    })
+
+    it('should return ai topic', () => {
+      const topic = system.getTopicHelp('ai')
+      expect(topic).toBeDefined()
+      expect(topic?.name).toBe('AI Features')
+      expect(topic?.description).toContain('AI-powered')
+      expect(topic?.examples.length).toBeGreaterThan(0)
+    })
+
+    it('should return troubleshooting topic', () => {
+      const topic = system.getTopicHelp('troubleshooting')
+      expect(topic).toBeDefined()
+      expect(topic?.name).toBe('Troubleshooting')
+      expect(topic?.examples.length).toBeGreaterThan(0)
+    })
+
+    it('should return undefined for unknown topic', () => {
+      const topic = system.getTopicHelp('unknown-topic')
+      expect(topic).toBeUndefined()
+    })
+  })
+
+  describe('getCommandHelp', () => {
+    it('should return create command help', () => {
+      const cmd = system.getCommandHelp('create')
+      expect(cmd).toBeDefined()
+      expect(cmd?.command).toBe('create')
+      expect(cmd?.description).toContain('new project')
+      expect(cmd?.usage).toContain('npx')
+      expect(cmd?.options.length).toBeGreaterThan(0)
+      expect(cmd?.examples.length).toBeGreaterThan(0)
+    })
+
+    it('should include template option', () => {
+      const cmd = system.getCommandHelp('create')
+      const templateOption = cmd?.options.find(o => o.flag.includes('--template'))
+      expect(templateOption).toBeDefined()
+      expect(templateOption?.description).toContain('Template')
+    })
+
+    it('should include description option', () => {
+      const cmd = system.getCommandHelp('create')
+      const descOption = cmd?.options.find(o => o.flag.includes('--description'))
+      expect(descOption).toBeDefined()
+    })
+
+    it('should include author option', () => {
+      const cmd = system.getCommandHelp('create')
+      const authorOption = cmd?.options.find(o => o.flag.includes('--author'))
+      expect(authorOption).toBeDefined()
+    })
+
+    it('should include package-manager option', () => {
+      const cmd = system.getCommandHelp('create')
+      const pmOption = cmd?.options.find(o => o.flag.includes('--package-manager'))
+      expect(pmOption).toBeDefined()
+      expect(pmOption?.description).toContain('npm')
+    })
+
+    it('should include ai option', () => {
+      const cmd = system.getCommandHelp('create')
+      const aiOption = cmd?.options.find(o => o.flag.includes('--ai'))
+      expect(aiOption).toBeDefined()
+      expect(aiOption?.description).toContain('AI-powered')
+    })
+
+    it('should include describe option', () => {
+      const cmd = system.getCommandHelp('create')
+      const describeOption = cmd?.options.find(o => o.flag.includes('--describe'))
+      expect(describeOption).toBeDefined()
+      expect(describeOption?.description).toContain('Natural language')
+    })
+
+    it('should return undefined for unknown command', () => {
+      const cmd = system.getCommandHelp('unknown-command')
+      expect(cmd).toBeUndefined()
+    })
+  })
+
+  describe('showContextualHelp', () => {
+    it('should show template selection help', () => {
+      system.showContextualHelp('template-selection')
+      expect(consola.box).toHaveBeenCalled()
+      const call = getBoxCall()
+      expect(call).toContain('Template Selection Help')
+    })
+
+    it('should show customization help', () => {
+      system.showContextualHelp('customization')
+      expect(consola.box).toHaveBeenCalled()
+      const call = getBoxCall()
+      expect(call).toContain('Project Customization Help')
+    })
+
+    it('should show error help', () => {
+      system.showContextualHelp('error')
+      expect(consola.box).toHaveBeenCalled()
+      const call = getBoxCall()
+      expect(call).toContain('Troubleshooting Help')
+    })
+
+    it('should show general help', () => {
+      system.showContextualHelp('general')
+      expect(consola.box).toHaveBeenCalled()
+      const call = getBoxCall()
+      expect(call).toContain('@bfra.me/create')
+    })
+
+    it('should default to general help for unknown context', () => {
+      system.showContextualHelp('unknown' as 'general')
+      expect(consola.box).toHaveBeenCalled()
+    })
+  })
+
+  describe('showExamples', () => {
+    it('should show usage examples', () => {
+      system.showExamples()
+      expect(consola.box).toHaveBeenCalled()
+      const call = getBoxCall()
+      expect(call).toContain('Usage Examples')
+      expect(call).toContain('Basic Project Creation')
+      expect(call).toContain('Library with Custom Settings')
+    })
+  })
+
+  describe('showAdvancedTips', () => {
+    it('should show advanced tips', () => {
+      system.showAdvancedTips()
+      expect(consola.box).toHaveBeenCalled()
+      const call = getBoxCall()
+      expect(call).toContain('Advanced Tips')
+      expect(call).toContain('Environment Variables')
+      expect(call).toContain('AI-Powered Features')
+      expect(call).toContain('OPENAI_API_KEY')
+      expect(call).toContain('ANTHROPIC_API_KEY')
+    })
+  })
+})
+
+describe('helpSystem singleton', () => {
+  it('should export a global help system instance', () => {
+    expect(helpSystem).toBeDefined()
+    expect(helpSystem).toBeInstanceOf(HelpSystem)
+  })
+
+  it('should have initialized topics', () => {
+    const topic = helpSystem.getTopicHelp('templates')
+    expect(topic).toBeDefined()
+  })
+
+  it('should have initialized commands', () => {
+    const cmd = helpSystem.getCommandHelp('create')
+    expect(cmd).toBeDefined()
+  })
+})
+
+describe('showErrorHelp', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should show network error help', () => {
+    const error = new Error('Connection refused')
+    showErrorHelp('network', error)
+
+    expect(consola.error).toHaveBeenCalledWith(expect.stringContaining('Connection refused'))
+    expect(consola.info).toHaveBeenCalled()
+    const infoCall = getInfoCall()
+    expect(infoCall).toContain('Network Error Help')
+    expect(infoCall).toContain('internet connection')
+  })
+
+  it('should show permission error help', () => {
+    const error = new Error('EACCES: permission denied')
+    showErrorHelp('permission', error)
+
+    expect(consola.error).toHaveBeenCalledWith(expect.stringContaining('permission denied'))
+    expect(consola.info).toHaveBeenCalled()
+    const infoCall = getInfoCall()
+    expect(infoCall).toContain('Permission Error Help')
+  })
+
+  it('should show template error help', () => {
+    const error = new Error('Template not found')
+    showErrorHelp('template', error)
+
+    expect(consola.error).toHaveBeenCalled()
+    expect(consola.info).toHaveBeenCalled()
+    const infoCall = getInfoCall()
+    expect(infoCall).toContain('Template Error Help')
+    expect(infoCall).toContain('built-in template')
+  })
+
+  it('should show validation error help', () => {
+    const error = new Error('Invalid project name')
+    showErrorHelp('validation', error)
+
+    expect(consola.error).toHaveBeenCalled()
+    expect(consola.info).toHaveBeenCalled()
+    const infoCall = getInfoCall()
+    expect(infoCall).toContain('Validation Error Help')
+    expect(infoCall).toContain('lowercase')
+  })
+
+  it('should show AI error help', () => {
+    const error = new Error('API key not found')
+    showErrorHelp('ai', error)
+
+    expect(consola.error).toHaveBeenCalled()
+    expect(consola.info).toHaveBeenCalled()
+    const infoCall = getInfoCall()
+    expect(infoCall).toContain('AI Feature Error Help')
+    expect(infoCall).toContain('OPENAI_API_KEY')
+    expect(infoCall).toContain('ANTHROPIC_API_KEY')
+  })
+
+  it('should show default error help for unknown error type', () => {
+    showErrorHelp('unknown')
+
+    expect(consola.error).toHaveBeenCalled()
+    expect(consola.box).toHaveBeenCalled()
+  })
+
+  it('should handle missing error object', () => {
+    showErrorHelp('network')
+
+    expect(consola.error).toHaveBeenCalledWith(expect.stringContaining('network'))
+    expect(consola.info).toHaveBeenCalled()
+  })
+
+  it('should show error type when no error message', () => {
+    showErrorHelp('validation')
+
+    expect(consola.error).toHaveBeenCalledWith('Error: validation')
+  })
+})
+
+describe('template-selection help content', () => {
+  let system: HelpSystem
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    system = new HelpSystem()
+  })
+
+  it('should include built-in templates list', () => {
+    system.showContextualHelp('template-selection')
+    const call = getBoxCall()
+    expect(call).toContain('default')
+    expect(call).toContain('library')
+    expect(call).toContain('cli')
+    expect(call).toContain('node')
+    expect(call).toContain('react')
+  })
+
+  it('should include custom template sources', () => {
+    system.showContextualHelp('template-selection')
+    const call = getBoxCall()
+    expect(call).toContain('GitHub')
+    expect(call).toContain('URL')
+    expect(call).toContain('Local')
+  })
+})
+
+describe('customization help content', () => {
+  let system: HelpSystem
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    system = new HelpSystem()
+  })
+
+  it('should include project details guidance', () => {
+    system.showContextualHelp('customization')
+    const call = getBoxCall()
+    expect(call).toContain('Name')
+    expect(call).toContain('Description')
+    expect(call).toContain('Author')
+    expect(call).toContain('Version')
+  })
+
+  it('should include package manager options', () => {
+    system.showContextualHelp('customization')
+    const call = getBoxCall()
+    expect(call).toContain('npm')
+    expect(call).toContain('yarn')
+    expect(call).toContain('pnpm')
+    expect(call).toContain('bun')
+  })
+})
+
+describe('general help content', () => {
+  let system: HelpSystem
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    system = new HelpSystem()
+  })
+
+  it('should include quick start examples', () => {
+    system.showContextualHelp('general')
+    const call = getBoxCall()
+    expect(call).toContain('Quick Start')
+    expect(call).toContain('npx @bfra.me/create')
+  })
+
+  it('should include AI-powered quick start', () => {
+    system.showContextualHelp('general')
+    const call = getBoxCall()
+    expect(call).toContain('AI-Powered Quick Start')
+    expect(call).toContain('--describe')
+  })
+
+  it('should include available commands', () => {
+    system.showContextualHelp('general')
+    const call = getBoxCall()
+    expect(call).toContain('Available Commands')
+    expect(call).toContain('create')
+  })
+
+  it('should include interactive vs non-interactive info', () => {
+    system.showContextualHelp('general')
+    const call = getBoxCall()
+    expect(call).toContain('Interactive Mode')
+    expect(call).toContain('Non-Interactive Mode')
+  })
+})
+
+describe('advanced tips content', () => {
+  let system: HelpSystem
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    system = new HelpSystem()
+  })
+
+  it('should include environment variables', () => {
+    system.showAdvancedTips()
+    const call = getBoxCall()
+    expect(call).toContain('NO_COLOR')
+    expect(call).toContain('DEBUG')
+    expect(call).toContain('CI')
+  })
+
+  it('should include template development tips', () => {
+    system.showAdvancedTips()
+    const call = getBoxCall()
+    expect(call).toContain('Template Development')
+    expect(call).toContain('template.json')
+    expect(call).toContain('Eta')
+  })
+
+  it('should include performance tips', () => {
+    system.showAdvancedTips()
+    const call = getBoxCall()
+    expect(call).toContain('Performance Tips')
+    expect(call).toContain('pnpm')
+    expect(call).toContain('caching')
+  })
+})
+
+describe('examples content', () => {
+  let system: HelpSystem
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    system = new HelpSystem()
+  })
+
+  it('should include basic project creation example', () => {
+    system.showExamples()
+    const call = getBoxCall()
+    expect(call).toContain('Basic Project Creation')
+    expect(call).toContain('npx @bfra.me/create my-project')
+  })
+
+  it('should include library creation example', () => {
+    system.showExamples()
+    const call = getBoxCall()
+    expect(call).toContain('Library with Custom Settings')
+    expect(call).toContain('--template=library')
+  })
+
+  it('should include react app example', () => {
+    system.showExamples()
+    const call = getBoxCall()
+    expect(call).toContain('React App')
+    expect(call).toContain('--template=react')
+  })
+
+  it('should include custom GitHub template example', () => {
+    system.showExamples()
+    const call = getBoxCall()
+    expect(call).toContain('Custom GitHub Template')
+    expect(call).toContain('github:user/repo')
+  })
+
+  it('should include non-interactive mode example', () => {
+    system.showExamples()
+    const call = getBoxCall()
+    expect(call).toContain('Non-Interactive Mode')
+    expect(call).toContain('--no-interactive')
+    expect(call).toContain('--force')
+  })
+
+  it('should include CLI tool example', () => {
+    system.showExamples()
+    const call = getBoxCall()
+    expect(call).toContain('CLI Tool Project')
+    expect(call).toContain('--template=cli')
+  })
+})

--- a/packages/create/test/utils/index.test.ts
+++ b/packages/create/test/utils/index.test.ts
@@ -1,0 +1,70 @@
+import {describe, expect, it} from 'vitest'
+import * as utils from '../../src/utils/index.js'
+
+describe('utils/index', () => {
+  it('should export command-options utilities', () => {
+    expect(utils.validateCreateCommandOptions).toBeDefined()
+    expect(utils.parseFeatures).toBeDefined()
+    expect(utils.applyConfigurationPreset).toBeDefined()
+  })
+
+  it('should export constants', () => {
+    expect(utils.RESERVED_PACKAGE_NAMES).toBeDefined()
+    expect(utils.BUILTIN_NODE_MODULES).toBeDefined()
+    expect(utils.isReservedName).toBeDefined()
+    expect(utils.isBuiltinModule).toBeDefined()
+  })
+
+  it('should export error utilities', () => {
+    expect(utils.createCLIError).toBeDefined()
+    expect(utils.CLIErrorCode).toBeDefined()
+  })
+
+  it('should export file system utilities', () => {
+    expect(utils.ensureDir).toBeDefined()
+    expect(utils.copy).toBeDefined()
+    expect(utils.exists).toBeDefined()
+    expect(utils.isDirectory).toBeDefined()
+    expect(utils.isFile).toBeDefined()
+  })
+
+  it('should export help utilities', () => {
+    expect(utils.HelpSystem).toBeDefined()
+    expect(utils.helpSystem).toBeDefined()
+    expect(utils.showErrorHelp).toBeDefined()
+  })
+
+  it('should export logger utilities', () => {
+    expect(utils.createLogger).toBeDefined()
+    expect(utils.logError).toBeDefined()
+    expect(utils.logInfo).toBeDefined()
+    expect(utils.logSuccess).toBeDefined()
+    expect(utils.logWarning).toBeDefined()
+  })
+
+  it('should export progress utilities', () => {
+    expect(utils.ProgressTracker).toBeDefined()
+  })
+
+  it('should export project detection utilities', () => {
+    expect(utils.analyzeProject).toBeDefined()
+    expect(utils.isNodeProject).toBeDefined()
+    expect(utils.isTypeScriptProject).toBeDefined()
+  })
+
+  it('should export type guard utilities', () => {
+    expect(utils.isPackageManager).toBeDefined()
+    expect(utils.isTemplateMetadata).toBeDefined()
+    expect(utils.isTemplateSource).toBeDefined()
+  })
+
+  it('should export validation factory utilities', () => {
+    expect(utils.validateProjectName).toBeDefined()
+    expect(utils.validatePackageManager).toBeDefined()
+    expect(utils.validateSemver).toBeDefined()
+  })
+
+  it('should export validation utilities', () => {
+    expect(utils.ValidationUtils).toBeDefined()
+  })
+})

--- a/packages/create/test/utils/logger.test.ts
+++ b/packages/create/test/utils/logger.test.ts
@@ -1,0 +1,465 @@
+/**
+ * Tests for logging and telemetry factory
+ * Part of Phase 5: Comprehensive Testing Implementation (TASK-033)
+ */
+
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+import {CLIErrorCode, createCLIError} from '../../src/utils/errors.js'
+import {
+  consola,
+  createLogger,
+  createProgressReporter,
+  createSpinner,
+  displayInfoBox,
+  displaySuccessBox,
+  displayWarningBox,
+  logDebug,
+  logError,
+  logInfo,
+  logSuccess,
+  logValidationErrors,
+  logValidationWarnings,
+  logWarning,
+} from '../../src/utils/logger.js'
+
+describe('logger utilities', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe('createLogger', () => {
+    it('should create a logger with default options', () => {
+      const logger = createLogger()
+      expect(logger).toBeDefined()
+      expect(typeof logger.info).toBe('function')
+      expect(typeof logger.error).toBe('function')
+      expect(typeof logger.warn).toBe('function')
+      expect(typeof logger.debug).toBe('function')
+    })
+
+    it('should create a logger with custom tag', () => {
+      const logger = createLogger({tag: 'test-tag'})
+      expect(logger).toBeDefined()
+    })
+
+    it('should create a logger with custom level', () => {
+      const logger = createLogger({level: 3})
+      expect(logger).toBeDefined()
+    })
+
+    it('should create a verbose logger', () => {
+      const logger = createLogger({verbose: true})
+      expect(logger).toBeDefined()
+    })
+
+    it('should create a logger with all options', () => {
+      const logger = createLogger({
+        tag: 'full-options',
+        level: 5,
+        verbose: true,
+      })
+      expect(logger).toBeDefined()
+    })
+  })
+
+  describe('logError', () => {
+    it('should log BaseError with user-friendly message', () => {
+      const errorSpy = vi.spyOn(consola, 'error').mockImplementation(() => {})
+      const error = createCLIError('Test validation error', CLIErrorCode.VALIDATION_FAILED)
+
+      logError(error)
+
+      expect(errorSpy).toHaveBeenCalled()
+    })
+
+    it('should log BaseError with verbose details', () => {
+      const errorSpy = vi.spyOn(consola, 'error').mockImplementation(() => {})
+      const boxSpy = vi.spyOn(consola, 'box').mockImplementation(() => {})
+      const error = createCLIError('Test validation error', CLIErrorCode.VALIDATION_FAILED)
+
+      logError(error, {verbose: true})
+
+      expect(errorSpy).toHaveBeenCalled()
+      expect(boxSpy).toHaveBeenCalled()
+    })
+
+    it('should log standard Error', () => {
+      const errorSpy = vi.spyOn(consola, 'error').mockImplementation(() => {})
+      const error = new Error('Standard error message')
+
+      logError(error)
+
+      expect(errorSpy).toHaveBeenCalledWith('Standard error message')
+    })
+
+    it('should log standard Error with verbose stack trace', () => {
+      const errorSpy = vi.spyOn(consola, 'error').mockImplementation(() => {})
+      const debugSpy = vi.spyOn(consola, 'debug').mockImplementation(() => {})
+      const error = new Error('Error with stack')
+
+      logError(error, {verbose: true})
+
+      expect(errorSpy).toHaveBeenCalled()
+      expect(debugSpy).toHaveBeenCalled()
+    })
+
+    it('should log unknown error types', () => {
+      const errorSpy = vi.spyOn(consola, 'error').mockImplementation(() => {})
+
+      logError('string error')
+      expect(errorSpy).toHaveBeenCalledWith('string error')
+
+      logError(123)
+      expect(errorSpy).toHaveBeenCalledWith('123')
+
+      logError(null)
+      expect(errorSpy).toHaveBeenCalledWith('null')
+    })
+
+    it('should handle undefined options', () => {
+      const errorSpy = vi.spyOn(consola, 'error').mockImplementation(() => {})
+      const error = new Error('Test')
+
+      logError(error, undefined)
+
+      expect(errorSpy).toHaveBeenCalled()
+    })
+  })
+
+  describe('logWarning', () => {
+    it('should log warning message', () => {
+      const warnSpy = vi.spyOn(consola, 'warn').mockImplementation(() => {})
+
+      logWarning('Warning message')
+
+      expect(warnSpy).toHaveBeenCalledWith('Warning message')
+    })
+  })
+
+  describe('logInfo', () => {
+    it('should log info message', () => {
+      const infoSpy = vi.spyOn(consola, 'info').mockImplementation(() => {})
+
+      logInfo('Info message')
+
+      expect(infoSpy).toHaveBeenCalledWith('Info message')
+    })
+  })
+
+  describe('logSuccess', () => {
+    it('should log success message', () => {
+      const successSpy = vi.spyOn(consola, 'success').mockImplementation(() => {})
+
+      logSuccess('Success message')
+
+      expect(successSpy).toHaveBeenCalledWith('Success message')
+    })
+  })
+
+  describe('logDebug', () => {
+    it('should not log debug message when verbose is false', () => {
+      const debugSpy = vi.spyOn(consola, 'debug').mockImplementation(() => {})
+
+      logDebug('Debug message')
+
+      expect(debugSpy).not.toHaveBeenCalled()
+    })
+
+    it('should log debug message when verbose is true', () => {
+      const debugSpy = vi.spyOn(consola, 'debug').mockImplementation(() => {})
+
+      logDebug('Debug message', {verbose: true})
+
+      expect(debugSpy).toHaveBeenCalledWith('Debug message')
+    })
+
+    it('should handle undefined options', () => {
+      const debugSpy = vi.spyOn(consola, 'debug').mockImplementation(() => {})
+
+      logDebug('Debug message', undefined)
+
+      expect(debugSpy).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('displayInfoBox', () => {
+    it('should display info box with blue border', () => {
+      const boxSpy = vi.spyOn(consola, 'box').mockImplementation(() => {})
+
+      displayInfoBox('Info Title', 'Info message content')
+
+      expect(boxSpy).toHaveBeenCalledWith({
+        title: 'Info Title',
+        message: 'Info message content',
+        style: {
+          borderColor: 'blue',
+          borderStyle: 'rounded',
+        },
+      })
+    })
+  })
+
+  describe('displaySuccessBox', () => {
+    it('should display success box with green border', () => {
+      const boxSpy = vi.spyOn(consola, 'box').mockImplementation(() => {})
+
+      displaySuccessBox('Success Title', 'Success message content')
+
+      expect(boxSpy).toHaveBeenCalledWith({
+        title: 'Success Title',
+        message: 'Success message content',
+        style: {
+          borderColor: 'green',
+          borderStyle: 'rounded',
+        },
+      })
+    })
+  })
+
+  describe('displayWarningBox', () => {
+    it('should display warning box with yellow border', () => {
+      const boxSpy = vi.spyOn(consola, 'box').mockImplementation(() => {})
+
+      displayWarningBox('Warning Title', 'Warning message content')
+
+      expect(boxSpy).toHaveBeenCalledWith({
+        title: 'Warning Title',
+        message: 'Warning message content',
+        style: {
+          borderColor: 'yellow',
+          borderStyle: 'rounded',
+        },
+      })
+    })
+  })
+
+  describe('logValidationErrors', () => {
+    it('should log validation errors with formatting', () => {
+      const errorSpy = vi.spyOn(consola, 'error').mockImplementation(() => {})
+
+      logValidationErrors(['Error 1', 'Error 2', 'Error 3'])
+
+      expect(errorSpy).toHaveBeenCalledWith('Validation failed:')
+      expect(errorSpy).toHaveBeenCalledWith('  • Error 1')
+      expect(errorSpy).toHaveBeenCalledWith('  • Error 2')
+      expect(errorSpy).toHaveBeenCalledWith('  • Error 3')
+    })
+
+    it('should handle empty error array', () => {
+      const errorSpy = vi.spyOn(consola, 'error').mockImplementation(() => {})
+
+      logValidationErrors([])
+
+      expect(errorSpy).toHaveBeenCalledWith('Validation failed:')
+      expect(errorSpy).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('logValidationWarnings', () => {
+    it('should log validation warnings with formatting', () => {
+      const warnSpy = vi.spyOn(consola, 'warn').mockImplementation(() => {})
+
+      logValidationWarnings(['Warning 1', 'Warning 2'])
+
+      expect(warnSpy).toHaveBeenCalledWith('Validation warnings:')
+      expect(warnSpy).toHaveBeenCalledWith('  ⚠ Warning 1')
+      expect(warnSpy).toHaveBeenCalledWith('  ⚠ Warning 2')
+    })
+
+    it('should handle empty warnings array', () => {
+      const warnSpy = vi.spyOn(consola, 'warn').mockImplementation(() => {})
+
+      logValidationWarnings([])
+
+      expect(warnSpy).toHaveBeenCalledWith('Validation warnings:')
+      expect(warnSpy).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('createProgressReporter', () => {
+    it('should create a progress reporter with correct interface', () => {
+      const reporter = createProgressReporter(5, 'Test Operation')
+
+      expect(reporter).toBeDefined()
+      expect(typeof reporter.start).toBe('function')
+      expect(typeof reporter.complete).toBe('function')
+      expect(typeof reporter.fail).toBe('function')
+      expect(typeof reporter.finish).toBe('function')
+      expect(typeof reporter.formatDuration).toBe('function')
+    })
+
+    it('should format duration in milliseconds', () => {
+      const reporter = createProgressReporter(3, 'Test')
+      expect(reporter.formatDuration(500)).toBe('500ms')
+      expect(reporter.formatDuration(999)).toBe('999ms')
+    })
+
+    it('should format duration in seconds', () => {
+      const reporter = createProgressReporter(3, 'Test')
+      expect(reporter.formatDuration(1000)).toBe('1s')
+      expect(reporter.formatDuration(2000)).toBe('2s')
+      expect(reporter.formatDuration(59000)).toBe('59s')
+    })
+
+    it('should format duration in minutes and seconds', () => {
+      const reporter = createProgressReporter(3, 'Test')
+      expect(reporter.formatDuration(60000)).toBe('1m 0s')
+      expect(reporter.formatDuration(65000)).toBe('1m 5s')
+      expect(reporter.formatDuration(125000)).toBe('2m 5s')
+    })
+
+    it('should track progress through start calls', () => {
+      const startSpy = vi.spyOn(consola, 'start').mockImplementation(() => {})
+      const reporter = createProgressReporter(3, 'Test')
+
+      reporter.start('First step')
+      expect(startSpy).toHaveBeenCalledWith(expect.stringContaining('[1/3]'))
+
+      reporter.start('Second step')
+      expect(startSpy).toHaveBeenCalledWith(expect.stringContaining('[2/3]'))
+    })
+
+    it('should complete step with message', () => {
+      const successSpy = vi.spyOn(consola, 'success').mockImplementation(() => {})
+      const reporter = createProgressReporter(3, 'Test')
+
+      reporter.start('First step')
+      reporter.complete('Step completed')
+
+      expect(successSpy).toHaveBeenCalledWith(expect.stringContaining('Step completed'))
+    })
+
+    it('should complete step without message', () => {
+      const successSpy = vi.spyOn(consola, 'success').mockImplementation(() => {})
+      const reporter = createProgressReporter(3, 'Test')
+
+      reporter.start('First step')
+      reporter.complete()
+
+      expect(successSpy).toHaveBeenCalledWith(expect.stringContaining('Step 1 completed'))
+    })
+
+    it('should complete step with empty message', () => {
+      const successSpy = vi.spyOn(consola, 'success').mockImplementation(() => {})
+      const reporter = createProgressReporter(3, 'Test')
+
+      reporter.start('First step')
+      reporter.complete('   ')
+
+      expect(successSpy).toHaveBeenCalledWith(expect.stringContaining('Step 1 completed'))
+    })
+
+    it('should fail with BaseError', () => {
+      const errorSpy = vi.spyOn(consola, 'error').mockImplementation(() => {})
+      const reporter = createProgressReporter(3, 'Test')
+      const error = createCLIError('Validation failed', CLIErrorCode.VALIDATION_FAILED)
+
+      reporter.start('First step')
+      reporter.fail(error)
+
+      expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('❌'))
+    })
+
+    it('should fail with standard Error', () => {
+      const errorSpy = vi.spyOn(consola, 'error').mockImplementation(() => {})
+      const reporter = createProgressReporter(3, 'Test')
+
+      reporter.start('First step')
+      reporter.fail(new Error('Something went wrong'))
+
+      expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('Something went wrong'))
+    })
+
+    it('should fail with unknown error type', () => {
+      const errorSpy = vi.spyOn(consola, 'error').mockImplementation(() => {})
+      const reporter = createProgressReporter(3, 'Test')
+
+      reporter.start('First step')
+      reporter.fail('String error')
+
+      expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('String error'))
+    })
+
+    it('should finish with completion message', () => {
+      const successSpy = vi.spyOn(consola, 'success').mockImplementation(() => {})
+      const reporter = createProgressReporter(3, 'Test Operation')
+
+      reporter.finish()
+
+      expect(successSpy).toHaveBeenCalledWith(expect.stringContaining('Test Operation completed'))
+    })
+  })
+
+  describe('createSpinner', () => {
+    it('should create spinner with correct interface', () => {
+      const spinner = createSpinner('Loading...')
+
+      expect(typeof spinner.start).toBe('function')
+      expect(typeof spinner.update).toBe('function')
+      expect(typeof spinner.success).toBe('function')
+      expect(typeof spinner.fail).toBe('function')
+    })
+
+    it('should start spinner', () => {
+      const startSpy = vi.spyOn(consola, 'start').mockImplementation(() => {})
+      const spinner = createSpinner('Loading...')
+
+      spinner.start()
+
+      expect(startSpy).toHaveBeenCalledWith('Loading...')
+    })
+
+    it('should update spinner message', () => {
+      const startSpy = vi.spyOn(consola, 'start').mockImplementation(() => {})
+      const spinner = createSpinner('Loading...')
+
+      spinner.update('Still loading...')
+
+      expect(startSpy).toHaveBeenCalledWith('Still loading...')
+    })
+
+    it('should complete with success message', () => {
+      const successSpy = vi.spyOn(consola, 'success').mockImplementation(() => {})
+      const spinner = createSpinner('Loading...')
+
+      spinner.success('Done!')
+
+      expect(successSpy).toHaveBeenCalledWith('Done!')
+    })
+
+    it('should complete with default message', () => {
+      const successSpy = vi.spyOn(consola, 'success').mockImplementation(() => {})
+      const spinner = createSpinner('Loading...')
+
+      spinner.success()
+
+      expect(successSpy).toHaveBeenCalledWith('Loading...')
+    })
+
+    it('should fail with error message', () => {
+      const errorSpy = vi.spyOn(consola, 'error').mockImplementation(() => {})
+      const spinner = createSpinner('Loading...')
+
+      spinner.fail('Failed!')
+
+      expect(errorSpy).toHaveBeenCalledWith('Failed!')
+    })
+
+    it('should fail with default message', () => {
+      const errorSpy = vi.spyOn(consola, 'error').mockImplementation(() => {})
+      const spinner = createSpinner('Loading...')
+
+      spinner.fail()
+
+      expect(errorSpy).toHaveBeenCalledWith('Failed: Loading...')
+    })
+  })
+
+  describe('consola export', () => {
+    it('should export consola instance', () => {
+      expect(consola).toBeDefined()
+      expect(typeof consola.info).toBe('function')
+      expect(typeof consola.error).toBe('function')
+    })
+  })
+})

--- a/packages/create/test/utils/package-manager.test.ts
+++ b/packages/create/test/utils/package-manager.test.ts
@@ -1,0 +1,240 @@
+import {existsSync, mkdirSync, rmSync, writeFileSync} from 'node:fs'
+import {readFile} from 'node:fs/promises'
+import path from 'node:path'
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
+import {
+  addDependencies,
+  addScripts,
+  detectPackageManager,
+  installDependencies,
+} from '../../src/utils/package-manager.js'
+
+interface PackageJson {
+  name: string
+  scripts?: Record<string, string>
+  dependencies?: Record<string, string>
+  devDependencies?: Record<string, string>
+}
+
+// Mock consola
+vi.mock('consola', () => ({
+  consola: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}))
+
+describe('package-manager utilities', () => {
+  let tempDir: string
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    tempDir = path.join(process.cwd(), `test-temp-pm-${Date.now()}`)
+    mkdirSync(tempDir, {recursive: true})
+    writeFileSync(
+      path.join(tempDir, 'package.json'),
+      JSON.stringify({name: 'test-project'}, null, 2),
+    )
+  })
+
+  afterEach(() => {
+    if (existsSync(tempDir)) {
+      rmSync(tempDir, {recursive: true, force: true})
+    }
+  })
+
+  describe('detectPackageManager', () => {
+    it('should detect pnpm from lock file', () => {
+      writeFileSync(path.join(tempDir, 'pnpm-lock.yaml'), '')
+      expect(detectPackageManager(tempDir)).toBe('pnpm')
+    })
+
+    it('should detect yarn from lock file', () => {
+      writeFileSync(path.join(tempDir, 'yarn.lock'), '')
+      expect(detectPackageManager(tempDir)).toBe('yarn')
+    })
+
+    it('should detect bun from lock file', () => {
+      writeFileSync(path.join(tempDir, 'bun.lockb'), '')
+      expect(detectPackageManager(tempDir)).toBe('bun')
+    })
+
+    it('should default to npm when no lock file found', () => {
+      expect(detectPackageManager(tempDir)).toBe('npm')
+    })
+
+    it('should prioritize pnpm over yarn when both exist', () => {
+      writeFileSync(path.join(tempDir, 'pnpm-lock.yaml'), '')
+      writeFileSync(path.join(tempDir, 'yarn.lock'), '')
+      expect(detectPackageManager(tempDir)).toBe('pnpm')
+    })
+  })
+
+  describe('addDependencies', () => {
+    it('should add regular dependencies to package.json', async () => {
+      await addDependencies(tempDir, ['lodash', 'axios'], [], undefined, false)
+
+      const content = await readFile(path.join(tempDir, 'package.json'), 'utf-8')
+      const pkg = JSON.parse(content) as PackageJson
+
+      expect(pkg.dependencies).toBeDefined()
+      expect(pkg.dependencies?.lodash).toBe('latest')
+      expect(pkg.dependencies?.axios).toBe('latest')
+    })
+
+    it('should add dev dependencies to package.json', async () => {
+      await addDependencies(tempDir, [], ['vitest', 'typescript'], undefined, false)
+
+      const content = await readFile(path.join(tempDir, 'package.json'), 'utf-8')
+      const pkg = JSON.parse(content) as PackageJson
+
+      expect(pkg.devDependencies).toBeDefined()
+      expect(pkg.devDependencies?.vitest).toBe('latest')
+      expect(pkg.devDependencies?.typescript).toBe('latest')
+    })
+
+    it('should not overwrite existing dependencies', async () => {
+      writeFileSync(
+        path.join(tempDir, 'package.json'),
+        JSON.stringify(
+          {
+            name: 'test-project',
+            dependencies: {lodash: '^4.17.0'},
+          },
+          null,
+          2,
+        ),
+      )
+
+      await addDependencies(tempDir, ['lodash', 'axios'], [], undefined, false)
+
+      const content = await readFile(path.join(tempDir, 'package.json'), 'utf-8')
+      const pkg = JSON.parse(content) as PackageJson
+
+      expect(pkg.dependencies?.lodash).toBe('^4.17.0')
+      expect(pkg.dependencies?.axios).toBe('latest')
+    })
+
+    it('should throw error when package.json not found', async () => {
+      const nonExistentDir = path.join(tempDir, 'nonexistent')
+      mkdirSync(nonExistentDir, {recursive: true})
+
+      await expect(
+        addDependencies(nonExistentDir, ['lodash'], [], undefined, false),
+      ).rejects.toThrow('package.json not found')
+    })
+
+    it('should return early when no dependencies provided', async () => {
+      const originalContent = await readFile(path.join(tempDir, 'package.json'), 'utf-8')
+
+      await addDependencies(tempDir, [], [], undefined, false)
+
+      const content = await readFile(path.join(tempDir, 'package.json'), 'utf-8')
+      expect(content).toBe(originalContent)
+    })
+  })
+
+  describe('installDependencies', () => {
+    it('should call npm install for npm package manager', async () => {
+      const {consola} = await import('consola')
+
+      // With verbose=true, it should log messages
+      await installDependencies(tempDir, 'npm', true)
+
+      expect(consola.info).toHaveBeenCalledWith('Installing dependencies with npm...')
+    })
+
+    it('should handle installation errors gracefully', async () => {
+      // Create a directory without a package.json to simulate failure
+      const badDir = path.join(tempDir, 'bad')
+      mkdirSync(badDir, {recursive: true})
+
+      // The function logs info then potentially warns - just verify it doesn't throw
+      await expect(installDependencies(badDir, 'npm', true)).resolves.not.toThrow()
+    })
+  })
+
+  describe('addScripts', () => {
+    it('should add scripts to package.json', async () => {
+      await addScripts(tempDir, {build: 'tsc', test: 'vitest'}, false)
+
+      const content = await readFile(path.join(tempDir, 'package.json'), 'utf-8')
+      const pkg = JSON.parse(content) as PackageJson
+
+      expect(pkg.scripts).toBeDefined()
+      expect(pkg.scripts?.build).toBe('tsc')
+      expect(pkg.scripts?.test).toBe('vitest')
+    })
+
+    it('should not overwrite existing scripts', async () => {
+      writeFileSync(
+        path.join(tempDir, 'package.json'),
+        JSON.stringify(
+          {
+            name: 'test-project',
+            scripts: {build: 'existing-build'},
+          },
+          null,
+          2,
+        ),
+      )
+
+      await addScripts(tempDir, {build: 'new-build', test: 'vitest'}, false)
+
+      const content = await readFile(path.join(tempDir, 'package.json'), 'utf-8')
+      const pkg = JSON.parse(content) as PackageJson
+
+      expect(pkg.scripts?.build).toBe('existing-build')
+      expect(pkg.scripts?.test).toBe('vitest')
+    })
+
+    it('should throw error when package.json not found', async () => {
+      const nonExistentDir = path.join(tempDir, 'nonexistent')
+      mkdirSync(nonExistentDir, {recursive: true})
+
+      await expect(addScripts(nonExistentDir, {build: 'tsc'}, false)).rejects.toThrow(
+        'package.json not found',
+      )
+    })
+
+    it('should log success with verbose mode', async () => {
+      const {consola} = await import('consola')
+
+      await addScripts(tempDir, {build: 'tsc'}, true)
+
+      expect(consola.success).toHaveBeenCalledWith('Added scripts to package.json')
+    })
+
+    it('should handle package.json without scripts property', async () => {
+      await addScripts(tempDir, {build: 'tsc'}, false)
+
+      const content = await readFile(path.join(tempDir, 'package.json'), 'utf-8')
+      const pkg = JSON.parse(content) as PackageJson
+
+      expect(pkg.scripts).toBeDefined()
+      expect(pkg.scripts?.build).toBe('tsc')
+    })
+
+    it('should not modify file when scripts already exist', async () => {
+      writeFileSync(
+        path.join(tempDir, 'package.json'),
+        JSON.stringify(
+          {
+            name: 'test-project',
+            scripts: {build: 'tsc', test: 'vitest'},
+          },
+          null,
+          2,
+        ),
+      )
+
+      const {consola} = await import('consola')
+
+      await addScripts(tempDir, {build: 'tsc', test: 'vitest'}, true)
+
+      expect(consola.info).toHaveBeenCalledWith('Scripts already exist in package.json')
+    })
+  })
+})

--- a/packages/create/test/utils/progress.test.ts
+++ b/packages/create/test/utils/progress.test.ts
@@ -1,0 +1,303 @@
+/**
+ * Tests for Progress Utilities
+ * Part of Phase 5: Comprehensive Testing Implementation (TASK-038)
+ *
+ * Tests progress tracking, spinners, and status feedback utilities.
+ */
+
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
+import {
+  estimateOperationTime,
+  FeatureProgress,
+  ProgressTracker,
+  showProgress,
+  TemplateProgress,
+  withSpinner,
+} from '../../src/utils/progress.js'
+
+describe('Progress Utilities', () => {
+  beforeEach(() => {
+    vi.mock('consola', () => ({
+      consola: {
+        start: vi.fn(),
+        success: vi.fn(),
+        error: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+      },
+    }))
+    vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+    vi.resetModules()
+  })
+
+  describe('ProgressTracker', () => {
+    it('initializes with total steps', () => {
+      const tracker = new ProgressTracker(5)
+
+      expect(tracker).toBeDefined()
+    })
+
+    it('tracks step progress', async () => {
+      const tracker = new ProgressTracker(3)
+
+      await tracker.startStep('Step 1')
+      await tracker.completeStep('Step 1 done')
+      await tracker.startStep('Step 2')
+      await tracker.completeStep('Step 2 done')
+
+      // Tracker should still be functional
+      expect(tracker).toBeDefined()
+    })
+
+    it('completes all steps', async () => {
+      const tracker = new ProgressTracker(2)
+
+      await tracker.startStep('Step 1')
+      await tracker.completeStep()
+      await tracker.startStep('Step 2')
+      await tracker.completeStep()
+      await tracker.complete()
+
+      expect(tracker).toBeDefined()
+    })
+
+    it('handles step failure', async () => {
+      const tracker = new ProgressTracker(2)
+
+      await tracker.startStep('Step 1')
+      await tracker.failStep('Something went wrong')
+
+      expect(tracker).toBeDefined()
+    })
+
+    it('adds steps to tracker', () => {
+      const tracker = new ProgressTracker(2)
+
+      tracker.addStep({name: 'step1', message: 'First step'})
+      tracker.addStep({name: 'step2', message: 'Second step', duration: 100})
+
+      expect(tracker).toBeDefined()
+    })
+  })
+
+  describe('showProgress', () => {
+    it('shows progress bar', () => {
+      showProgress({total: 100, current: 50, message: 'Processing'})
+
+      // Just verify it doesn't throw
+      expect(true).toBe(true)
+    })
+
+    it('shows progress at 0%', () => {
+      showProgress({total: 100, current: 0, message: 'Starting'})
+
+      expect(true).toBe(true)
+    })
+
+    it('shows progress at 100%', () => {
+      showProgress({total: 100, current: 100, message: 'Done'})
+
+      expect(true).toBe(true)
+    })
+  })
+
+  describe('withSpinner', () => {
+    it('executes operation with spinner', async () => {
+      const result = await withSpinner('Loading', async () => {
+        return 'success'
+      })
+
+      expect(result).toBe('success')
+    })
+
+    it('handles operation errors', async () => {
+      await expect(
+        withSpinner('Failing', async () => {
+          throw new Error('Test error')
+        }),
+      ).rejects.toThrow('Test error')
+    })
+
+    it('returns operation result', async () => {
+      const result = await withSpinner('Computing', async () => {
+        return {value: 42}
+      })
+
+      expect(result).toEqual({value: 42})
+    })
+  })
+
+  describe('estimateOperationTime', () => {
+    it('estimates download time', () => {
+      const time = estimateOperationTime('download', 100)
+
+      expect(time).toBeGreaterThan(0)
+    })
+
+    it('estimates extract time', () => {
+      const time = estimateOperationTime('extract', 50)
+
+      expect(time).toBeGreaterThan(0)
+    })
+
+    it('estimates process time', () => {
+      const time = estimateOperationTime('process', 200)
+
+      expect(time).toBeGreaterThan(0)
+    })
+
+    it('estimates install time', () => {
+      const time = estimateOperationTime('install', 10)
+
+      expect(time).toBeGreaterThan(0)
+    })
+
+    it('returns minimum time of 500ms', () => {
+      const time = estimateOperationTime('process', 1)
+
+      expect(time).toBeGreaterThanOrEqual(500)
+    })
+  })
+
+  describe('TemplateProgress', () => {
+    it('creates template progress tracker', () => {
+      const progress = new TemplateProgress()
+
+      expect(progress).toBeDefined()
+    })
+
+    it('tracks template resolution', async () => {
+      const progress = new TemplateProgress()
+
+      await progress.startTemplateResolution()
+      await progress.completeTemplateResolution()
+
+      expect(progress).toBeDefined()
+    })
+
+    it('tracks template download', async () => {
+      const progress = new TemplateProgress()
+
+      await progress.startTemplateDownload()
+      await progress.completeTemplateDownload()
+
+      expect(progress).toBeDefined()
+    })
+
+    it('tracks template processing', async () => {
+      const progress = new TemplateProgress()
+
+      await progress.startTemplateProcessing()
+      await progress.completeTemplateProcessing()
+
+      expect(progress).toBeDefined()
+    })
+
+    it('tracks project generation', async () => {
+      const progress = new TemplateProgress()
+
+      await progress.startProjectGeneration()
+      await progress.completeProjectGeneration()
+
+      expect(progress).toBeDefined()
+    })
+
+    it('tracks dependency installation', async () => {
+      const progress = new TemplateProgress()
+
+      await progress.startDependencyInstallation()
+      await progress.completeDependencyInstallation()
+
+      expect(progress).toBeDefined()
+    })
+
+    it('tracks post-processing', async () => {
+      const progress = new TemplateProgress()
+
+      await progress.startPostProcessing()
+      await progress.completePostProcessing()
+
+      expect(progress).toBeDefined()
+    })
+
+    it('completes tracking', async () => {
+      const progress = new TemplateProgress()
+
+      await progress.complete()
+
+      expect(progress).toBeDefined()
+    })
+
+    it('handles failure', async () => {
+      const progress = new TemplateProgress()
+
+      await progress.fail('download', 'Network error')
+
+      expect(progress).toBeDefined()
+    })
+  })
+
+  describe('FeatureProgress', () => {
+    it('creates feature progress tracker', () => {
+      const progress = new FeatureProgress('eslint')
+
+      expect(progress).toBeDefined()
+    })
+
+    it('tracks analysis phase', async () => {
+      const progress = new FeatureProgress('prettier')
+
+      await progress.startAnalysis()
+      await progress.completeAnalysis()
+
+      expect(progress).toBeDefined()
+    })
+
+    it('tracks dependencies phase', async () => {
+      const progress = new FeatureProgress('vitest')
+
+      await progress.startDependencies()
+      await progress.completeDependencies()
+
+      expect(progress).toBeDefined()
+    })
+
+    it('tracks configuration phase', async () => {
+      const progress = new FeatureProgress('typescript')
+
+      await progress.startConfiguration()
+      await progress.completeConfiguration()
+
+      expect(progress).toBeDefined()
+    })
+
+    it('tracks finalization phase', async () => {
+      const progress = new FeatureProgress('eslint')
+
+      await progress.startFinalization()
+      await progress.completeFinalization()
+
+      expect(progress).toBeDefined()
+    })
+
+    it('completes tracking', async () => {
+      const progress = new FeatureProgress('husky')
+
+      await progress.complete()
+
+      expect(progress).toBeDefined()
+    })
+
+    it('handles failure', async () => {
+      const progress = new FeatureProgress('lint-staged')
+
+      await progress.fail('configuration', 'Invalid config')
+
+      expect(progress).toBeDefined()
+    })
+  })
+})

--- a/packages/create/test/utils/type-guards.test.ts
+++ b/packages/create/test/utils/type-guards.test.ts
@@ -1,0 +1,494 @@
+/**
+ * Tests for type guards
+ * Part of Phase 5: Comprehensive Testing Implementation (TASK-033)
+ */
+
+import {describe, expect, it} from 'vitest'
+import {
+  createPackageName,
+  createProjectPath,
+  createTemplateSource,
+  isPackageManager,
+  isPackageName,
+  isProjectPath,
+  isProjectType,
+  isTemplateMetadata,
+  isTemplateSource,
+  isTemplateSourceObject,
+  isTemplateVariable,
+} from '../../src/utils/type-guards.js'
+
+describe('type guards', () => {
+  describe('isTemplateSource', () => {
+    it.concurrent('returns true for non-empty strings', () => {
+      expect(isTemplateSource('default')).toBe(true)
+      expect(isTemplateSource('user/repo')).toBe(true)
+      expect(isTemplateSource('https://example.com')).toBe(true)
+    })
+
+    it.concurrent('returns false for empty strings', () => {
+      expect(isTemplateSource('')).toBe(false)
+      expect(isTemplateSource('   ')).toBe(false)
+    })
+
+    it.concurrent('returns false for non-strings', () => {
+      expect(isTemplateSource(123)).toBe(false)
+      expect(isTemplateSource(null)).toBe(false)
+      expect(isTemplateSource(undefined)).toBe(false)
+      expect(isTemplateSource({})).toBe(false)
+    })
+  })
+
+  describe('createTemplateSource', () => {
+    it.concurrent('creates branded template source for valid strings', () => {
+      const source = createTemplateSource('my-template')
+      expect(source).toBe('my-template')
+    })
+
+    it.concurrent('throws for empty strings', () => {
+      expect(() => createTemplateSource('')).toThrow('Invalid template source')
+    })
+
+    it.concurrent('throws for whitespace-only strings', () => {
+      expect(() => createTemplateSource('   ')).toThrow('Invalid template source')
+    })
+  })
+
+  describe('isProjectPath', () => {
+    it.concurrent('returns true for valid paths', () => {
+      expect(isProjectPath('./my-project')).toBe(true)
+      expect(isProjectPath('/home/user/project')).toBe(true)
+      expect(isProjectPath('project-name')).toBe(true)
+    })
+
+    it.concurrent('returns false for paths with null bytes', () => {
+      expect(isProjectPath('path\0with\0nulls')).toBe(false)
+    })
+
+    it.concurrent('returns false for path traversal attempts', () => {
+      expect(isProjectPath('../../../etc/passwd')).toBe(false)
+    })
+
+    it.concurrent('returns false for empty strings', () => {
+      expect(isProjectPath('')).toBe(false)
+      expect(isProjectPath('   ')).toBe(false)
+    })
+
+    it.concurrent('returns false for non-strings', () => {
+      expect(isProjectPath(123)).toBe(false)
+      expect(isProjectPath(null)).toBe(false)
+      expect(isProjectPath(undefined)).toBe(false)
+    })
+  })
+
+  describe('createProjectPath', () => {
+    it.concurrent('creates branded project path for valid paths', () => {
+      const projectPath = createProjectPath('./my-project')
+      expect(projectPath).toBe('./my-project')
+    })
+
+    it.concurrent('throws for invalid paths', () => {
+      expect(() => createProjectPath('../../../etc')).toThrow('Invalid project path')
+    })
+
+    it.concurrent('throws for paths with null bytes', () => {
+      expect(() => createProjectPath('path\0null')).toThrow('Invalid project path')
+    })
+  })
+
+  describe('isPackageName', () => {
+    describe('valid package names', () => {
+      it.concurrent('accepts lowercase names', () => {
+        expect(isPackageName('my-package')).toBe(true)
+      })
+
+      it.concurrent('accepts names with numbers', () => {
+        expect(isPackageName('package123')).toBe(true)
+      })
+
+      it.concurrent('accepts names with dots', () => {
+        expect(isPackageName('my.package')).toBe(true)
+      })
+
+      it.concurrent('accepts names with underscores', () => {
+        expect(isPackageName('my_package')).toBe(true)
+      })
+
+      it.concurrent('accepts scoped packages', () => {
+        expect(isPackageName('@org/package')).toBe(true)
+        expect(isPackageName('@bfra-me/create')).toBe(true)
+      })
+    })
+
+    describe('invalid package names', () => {
+      it.concurrent('rejects empty strings', () => {
+        expect(isPackageName('')).toBe(false)
+      })
+
+      it.concurrent('rejects names starting with dot', () => {
+        expect(isPackageName('.package')).toBe(false)
+      })
+
+      it.concurrent('rejects names starting with underscore', () => {
+        expect(isPackageName('_package')).toBe(false)
+      })
+
+      it.concurrent('rejects names with uppercase', () => {
+        expect(isPackageName('MyPackage')).toBe(false)
+      })
+
+      it.concurrent('rejects names exceeding 214 characters', () => {
+        const longName = 'a'.repeat(215)
+        expect(isPackageName(longName)).toBe(false)
+      })
+
+      it.concurrent('rejects reserved names', () => {
+        expect(isPackageName('node_modules')).toBe(false)
+      })
+
+      it.concurrent('rejects Node.js builtin module names', () => {
+        expect(isPackageName('fs')).toBe(false)
+        expect(isPackageName('path')).toBe(false)
+        expect(isPackageName('http')).toBe(false)
+      })
+
+      it.concurrent('rejects non-strings', () => {
+        expect(isPackageName(123)).toBe(false)
+        expect(isPackageName(null)).toBe(false)
+      })
+    })
+  })
+
+  describe('createPackageName', () => {
+    it.concurrent('creates branded package name for valid names', () => {
+      const name = createPackageName('my-package')
+      expect(name).toBe('my-package')
+    })
+
+    it.concurrent('creates branded scoped package name', () => {
+      const name = createPackageName('@org/my-package')
+      expect(name).toBe('@org/my-package')
+    })
+
+    it.concurrent('throws for invalid package names', () => {
+      expect(() => createPackageName('MyPackage')).toThrow('Invalid package name')
+    })
+
+    it.concurrent('throws for reserved names', () => {
+      expect(() => createPackageName('node_modules')).toThrow('Invalid package name')
+    })
+  })
+
+  describe('isTemplateSourceObject', () => {
+    it.concurrent('returns true for valid github source', () => {
+      const source = {type: 'github', location: 'user/repo'}
+      expect(isTemplateSourceObject(source)).toBe(true)
+    })
+
+    it.concurrent('returns true for valid local source', () => {
+      const source = {type: 'local', location: './my-template'}
+      expect(isTemplateSourceObject(source)).toBe(true)
+    })
+
+    it.concurrent('returns true for valid url source', () => {
+      const source = {type: 'url', location: 'https://example.com/template.zip'}
+      expect(isTemplateSourceObject(source)).toBe(true)
+    })
+
+    it.concurrent('returns true for valid builtin source', () => {
+      const source = {type: 'builtin', location: 'default'}
+      expect(isTemplateSourceObject(source)).toBe(true)
+    })
+
+    it.concurrent('returns true with optional ref', () => {
+      const source = {type: 'github', location: 'user/repo', ref: 'main'}
+      expect(isTemplateSourceObject(source)).toBe(true)
+    })
+
+    it.concurrent('returns true with optional subdir', () => {
+      const source = {type: 'github', location: 'user/repo', subdir: 'packages/template'}
+      expect(isTemplateSourceObject(source)).toBe(true)
+    })
+
+    it.concurrent('returns false for invalid type', () => {
+      const source = {type: 'invalid', location: 'something'}
+      expect(isTemplateSourceObject(source)).toBe(false)
+    })
+
+    it.concurrent('returns false for empty location', () => {
+      const source = {type: 'github', location: ''}
+      expect(isTemplateSourceObject(source)).toBe(false)
+    })
+
+    it.concurrent('returns false for non-object values', () => {
+      expect(isTemplateSourceObject(null)).toBe(false)
+      expect(isTemplateSourceObject(undefined)).toBe(false)
+      expect(isTemplateSourceObject('string')).toBe(false)
+      expect(isTemplateSourceObject(123)).toBe(false)
+    })
+
+    it.concurrent('returns false for invalid ref type', () => {
+      const source = {type: 'github', location: 'user/repo', ref: 123}
+      expect(isTemplateSourceObject(source)).toBe(false)
+    })
+
+    it.concurrent('returns false for invalid subdir type', () => {
+      const source = {type: 'github', location: 'user/repo', subdir: 123}
+      expect(isTemplateSourceObject(source)).toBe(false)
+    })
+  })
+
+  describe('isTemplateVariable', () => {
+    it.concurrent('returns true for valid string variable', () => {
+      const variable = {name: 'projectName', description: 'Project name', type: 'string'}
+      expect(isTemplateVariable(variable)).toBe(true)
+    })
+
+    it.concurrent('returns true for valid boolean variable', () => {
+      const variable = {name: 'typescript', description: 'Use TypeScript', type: 'boolean'}
+      expect(isTemplateVariable(variable)).toBe(true)
+    })
+
+    it.concurrent('returns true for valid number variable', () => {
+      const variable = {name: 'port', description: 'Server port', type: 'number'}
+      expect(isTemplateVariable(variable)).toBe(true)
+    })
+
+    it.concurrent('returns true for valid select variable with options', () => {
+      const variable = {
+        name: 'framework',
+        description: 'Framework',
+        type: 'select',
+        options: ['react', 'vue'],
+      }
+      expect(isTemplateVariable(variable)).toBe(true)
+    })
+
+    it.concurrent('returns true with optional required flag', () => {
+      const variable = {
+        name: 'projectName',
+        description: 'Project name',
+        type: 'string',
+        required: true,
+      }
+      expect(isTemplateVariable(variable)).toBe(true)
+    })
+
+    it.concurrent('returns true with optional pattern', () => {
+      const variable = {
+        name: 'version',
+        description: 'Version',
+        type: 'string',
+        pattern: String.raw`^\d+\.\d+\.\d+$`,
+      }
+      expect(isTemplateVariable(variable)).toBe(true)
+    })
+
+    it.concurrent('returns false for empty name', () => {
+      const variable = {name: '', description: 'Description', type: 'string'}
+      expect(isTemplateVariable(variable)).toBe(false)
+    })
+
+    it.concurrent('returns false for invalid type', () => {
+      const variable = {name: 'test', description: 'Test', type: 'invalid'}
+      expect(isTemplateVariable(variable)).toBe(false)
+    })
+
+    it.concurrent('returns false for non-boolean required', () => {
+      const variable = {name: 'test', description: 'Test', type: 'string', required: 'yes'}
+      expect(isTemplateVariable(variable)).toBe(false)
+    })
+
+    it.concurrent('returns false for non-string pattern', () => {
+      const variable = {name: 'test', description: 'Test', type: 'string', pattern: 123}
+      expect(isTemplateVariable(variable)).toBe(false)
+    })
+
+    it.concurrent('returns false for non-array options', () => {
+      const variable = {name: 'test', description: 'Test', type: 'select', options: 'invalid'}
+      expect(isTemplateVariable(variable)).toBe(false)
+    })
+
+    it.concurrent('returns false for options with non-string elements', () => {
+      const variable = {name: 'test', description: 'Test', type: 'select', options: [1, 2, 3]}
+      expect(isTemplateVariable(variable)).toBe(false)
+    })
+  })
+
+  describe('isTemplateMetadata', () => {
+    const validMetadata = {
+      name: 'my-template',
+      description: 'A test template',
+      version: '1.0.0',
+    }
+
+    it.concurrent('returns true for minimal valid metadata', () => {
+      expect(isTemplateMetadata(validMetadata)).toBe(true)
+    })
+
+    it.concurrent('returns true with optional author', () => {
+      const metadata = {...validMetadata, author: 'Test Author'}
+      expect(isTemplateMetadata(metadata)).toBe(true)
+    })
+
+    it.concurrent('returns true with optional tags', () => {
+      const metadata = {...validMetadata, tags: ['typescript', 'library']}
+      expect(isTemplateMetadata(metadata)).toBe(true)
+    })
+
+    it.concurrent('returns true with optional variables', () => {
+      const metadata = {
+        ...validMetadata,
+        variables: [{name: 'projectName', description: 'Name', type: 'string'}],
+      }
+      expect(isTemplateMetadata(metadata)).toBe(true)
+    })
+
+    it.concurrent('returns true with optional dependencies', () => {
+      const metadata = {...validMetadata, dependencies: ['typescript', 'vitest']}
+      expect(isTemplateMetadata(metadata)).toBe(true)
+    })
+
+    it.concurrent('returns true with optional nodeVersion', () => {
+      const metadata = {...validMetadata, nodeVersion: '>=18'}
+      expect(isTemplateMetadata(metadata)).toBe(true)
+    })
+
+    it.concurrent('returns false for missing name', () => {
+      const metadata = {description: 'Description', version: '1.0.0'}
+      expect(isTemplateMetadata(metadata)).toBe(false)
+    })
+
+    it.concurrent('returns false for empty name', () => {
+      const metadata = {name: '', description: 'Description', version: '1.0.0'}
+      expect(isTemplateMetadata(metadata)).toBe(false)
+    })
+
+    it.concurrent('returns false for missing description', () => {
+      const metadata = {name: 'template', version: '1.0.0'}
+      expect(isTemplateMetadata(metadata)).toBe(false)
+    })
+
+    it.concurrent('returns false for non-string description', () => {
+      const metadata = {name: 'template', description: 123, version: '1.0.0'}
+      expect(isTemplateMetadata(metadata)).toBe(false)
+    })
+
+    it.concurrent('returns false for missing version', () => {
+      const metadata = {name: 'template', description: 'Description'}
+      expect(isTemplateMetadata(metadata)).toBe(false)
+    })
+
+    it.concurrent('returns false for empty version', () => {
+      const metadata = {name: 'template', description: 'Description', version: ''}
+      expect(isTemplateMetadata(metadata)).toBe(false)
+    })
+
+    it.concurrent('returns false for non-string author', () => {
+      const metadata = {...validMetadata, author: 123}
+      expect(isTemplateMetadata(metadata)).toBe(false)
+    })
+
+    it.concurrent('returns false for non-array tags', () => {
+      const metadata = {...validMetadata, tags: 'invalid'}
+      expect(isTemplateMetadata(metadata)).toBe(false)
+    })
+
+    it.concurrent('returns false for tags with non-string elements', () => {
+      const metadata = {...validMetadata, tags: [1, 2, 3]}
+      expect(isTemplateMetadata(metadata)).toBe(false)
+    })
+
+    it.concurrent('returns false for invalid variables', () => {
+      const metadata = {
+        ...validMetadata,
+        variables: [{name: '', description: 'Invalid', type: 'string'}],
+      }
+      expect(isTemplateMetadata(metadata)).toBe(false)
+    })
+
+    it.concurrent('returns false for non-array dependencies', () => {
+      const metadata = {...validMetadata, dependencies: 'invalid'}
+      expect(isTemplateMetadata(metadata)).toBe(false)
+    })
+
+    it.concurrent('returns false for non-string nodeVersion', () => {
+      const metadata = {...validMetadata, nodeVersion: 18}
+      expect(isTemplateMetadata(metadata)).toBe(false)
+    })
+
+    it.concurrent('returns false for non-object values', () => {
+      expect(isTemplateMetadata(null)).toBe(false)
+      expect(isTemplateMetadata(undefined)).toBe(false)
+      expect(isTemplateMetadata('string')).toBe(false)
+    })
+  })
+
+  describe('isPackageManager', () => {
+    it.concurrent('returns true for npm', () => {
+      expect(isPackageManager('npm')).toBe(true)
+    })
+
+    it.concurrent('returns true for yarn', () => {
+      expect(isPackageManager('yarn')).toBe(true)
+    })
+
+    it.concurrent('returns true for pnpm', () => {
+      expect(isPackageManager('pnpm')).toBe(true)
+    })
+
+    it.concurrent('returns true for bun', () => {
+      expect(isPackageManager('bun')).toBe(true)
+    })
+
+    it.concurrent('returns false for unknown package managers', () => {
+      expect(isPackageManager('pip')).toBe(false)
+      expect(isPackageManager('cargo')).toBe(false)
+    })
+
+    it.concurrent('returns false for non-strings', () => {
+      expect(isPackageManager(123)).toBe(false)
+      expect(isPackageManager(null)).toBe(false)
+    })
+  })
+
+  describe('isProjectType', () => {
+    it.concurrent('returns true for typescript', () => {
+      expect(isProjectType('typescript')).toBe(true)
+    })
+
+    it.concurrent('returns true for javascript', () => {
+      expect(isProjectType('javascript')).toBe(true)
+    })
+
+    it.concurrent('returns true for react', () => {
+      expect(isProjectType('react')).toBe(true)
+    })
+
+    it.concurrent('returns true for vue', () => {
+      expect(isProjectType('vue')).toBe(true)
+    })
+
+    it.concurrent('returns true for angular', () => {
+      expect(isProjectType('angular')).toBe(true)
+    })
+
+    it.concurrent('returns true for node', () => {
+      expect(isProjectType('node')).toBe(true)
+    })
+
+    it.concurrent('returns true for unknown', () => {
+      expect(isProjectType('unknown')).toBe(true)
+    })
+
+    it.concurrent('returns false for invalid types', () => {
+      expect(isProjectType('svelte')).toBe(false)
+      expect(isProjectType('ruby')).toBe(false)
+    })
+
+    it.concurrent('returns false for non-strings', () => {
+      expect(isProjectType(123)).toBe(false)
+      expect(isProjectType(null)).toBe(false)
+    })
+  })
+})

--- a/packages/create/test/utils/validation-factory.test.ts
+++ b/packages/create/test/utils/validation-factory.test.ts
@@ -1,0 +1,562 @@
+/**
+ * Tests for validation factory functions
+ * Part of Phase 5: Comprehensive Testing Implementation (TASK-033)
+ */
+
+import type {TemplateVariable} from '../../src/types.js'
+import {isErr, isOk} from '@bfra.me/es/result'
+import {describe, expect, it} from 'vitest'
+import {
+  createTemplateValidator,
+  validateEmailAddress,
+  validatePackageManager,
+  validateProjectName,
+  validateProjectPath,
+  validateSemver,
+  validateTemplateId,
+  validateTemplateVariableValue,
+} from '../../src/utils/validation-factory.js'
+
+describe('validation factory functions', () => {
+  describe('validateProjectName', () => {
+    describe('valid names', () => {
+      it.concurrent('accepts lowercase names', () => {
+        const result = validateProjectName('my-project')
+        expect(isOk(result)).toBe(true)
+        expect(isOk(result) && result.data).toBe('my-project')
+      })
+
+      it.concurrent('accepts names with numbers', () => {
+        const result = validateProjectName('project123')
+        expect(isOk(result)).toBe(true)
+      })
+
+      it.concurrent('accepts names with dots', () => {
+        const result = validateProjectName('my.project')
+        expect(isOk(result)).toBe(true)
+      })
+
+      it.concurrent('accepts names with underscores', () => {
+        const result = validateProjectName('my_project')
+        expect(isOk(result)).toBe(true)
+      })
+
+      it.concurrent('accepts scoped package names', () => {
+        const result = validateProjectName('@scope/my-package')
+        expect(isOk(result)).toBe(true)
+      })
+
+      it.concurrent('trims whitespace from names', () => {
+        const result = validateProjectName('  my-project  ')
+        expect(isOk(result)).toBe(true)
+        expect(isOk(result) && result.data).toBe('my-project')
+      })
+    })
+
+    describe('invalid names', () => {
+      it.concurrent('rejects empty names', () => {
+        const result = validateProjectName('')
+        expect(isErr(result)).toBe(true)
+      })
+
+      it.concurrent('rejects whitespace-only names', () => {
+        const result = validateProjectName('   ')
+        expect(isErr(result)).toBe(true)
+      })
+
+      it.concurrent('rejects names starting with dot', () => {
+        const result = validateProjectName('.my-project')
+        expect(isErr(result)).toBe(true)
+      })
+
+      it.concurrent('rejects names starting with underscore', () => {
+        const result = validateProjectName('_my-project')
+        expect(isErr(result)).toBe(true)
+      })
+
+      it.concurrent('rejects names with uppercase letters', () => {
+        const result = validateProjectName('MyProject')
+        expect(isErr(result)).toBe(true)
+      })
+
+      it.concurrent('rejects names with special characters', () => {
+        const result = validateProjectName('my@project!')
+        expect(isErr(result)).toBe(true)
+      })
+
+      it.concurrent('rejects names exceeding max length', () => {
+        const longName = 'a'.repeat(215)
+        const result = validateProjectName(longName)
+        expect(isErr(result)).toBe(true)
+      })
+    })
+
+    describe('options', () => {
+      it.concurrent('allows scoped packages by default', () => {
+        const result = validateProjectName('@org/package')
+        expect(isOk(result)).toBe(true)
+      })
+
+      it.concurrent('rejects scoped packages when allowScoped is false', () => {
+        const result = validateProjectName('@org/package', {allowScoped: false})
+        expect(isErr(result)).toBe(true)
+      })
+
+      it.concurrent('respects custom maxLength', () => {
+        const result = validateProjectName('my-project', {maxLength: 5})
+        expect(isErr(result)).toBe(true)
+
+        const validResult = validateProjectName('short', {maxLength: 10})
+        expect(isOk(validResult)).toBe(true)
+      })
+    })
+  })
+
+  describe('validateProjectPath', () => {
+    describe('valid paths', () => {
+      it.concurrent('accepts relative paths', () => {
+        const result = validateProjectPath('./my-project')
+        expect(isOk(result)).toBe(true)
+      })
+
+      it.concurrent('accepts absolute paths', () => {
+        const result = validateProjectPath('/home/user/projects')
+        expect(isOk(result)).toBe(true)
+      })
+
+      it.concurrent('accepts simple directory names', () => {
+        const result = validateProjectPath('my-project')
+        expect(isOk(result)).toBe(true)
+      })
+
+      it.concurrent('accepts nested paths', () => {
+        const result = validateProjectPath('parent/child/grandchild')
+        expect(isOk(result)).toBe(true)
+      })
+    })
+
+    describe('invalid paths', () => {
+      it.concurrent('rejects empty paths', () => {
+        const result = validateProjectPath('')
+        expect(isErr(result)).toBe(true)
+      })
+
+      it.concurrent('rejects whitespace-only paths', () => {
+        const result = validateProjectPath('   ')
+        expect(isErr(result)).toBe(true)
+      })
+
+      it.concurrent('rejects paths with null bytes', () => {
+        const result = validateProjectPath('path\0with\0nulls')
+        expect(isErr(result)).toBe(true)
+      })
+
+      it.concurrent('rejects path traversal attempts', () => {
+        const result = validateProjectPath('../../../etc/passwd')
+        expect(isErr(result)).toBe(true)
+      })
+    })
+
+    describe('options', () => {
+      it.concurrent('allows relative paths by default', () => {
+        const result = validateProjectPath('./relative-path')
+        expect(isOk(result)).toBe(true)
+      })
+
+      it.concurrent('rejects relative paths when allowRelative is false', () => {
+        const result = validateProjectPath('./relative-path', {allowRelative: false})
+        expect(isErr(result)).toBe(true)
+      })
+
+      it.concurrent('accepts absolute paths when allowRelative is false', () => {
+        const result = validateProjectPath('/absolute/path', {allowRelative: false})
+        expect(isOk(result)).toBe(true)
+      })
+    })
+  })
+
+  describe('validateTemplateId', () => {
+    describe('valid template identifiers', () => {
+      it.concurrent('accepts builtin template names', () => {
+        const result = validateTemplateId('default')
+        expect(isOk(result)).toBe(true)
+      })
+
+      it.concurrent('accepts GitHub repository format', () => {
+        const result = validateTemplateId('user/repo')
+        expect(isOk(result)).toBe(true)
+      })
+
+      it.concurrent('accepts GitHub org/repo format', () => {
+        const result = validateTemplateId('bfra-me/works')
+        expect(isOk(result)).toBe(true)
+      })
+
+      it.concurrent('accepts HTTPS URLs', () => {
+        const result = validateTemplateId('https://github.com/user/repo')
+        expect(isOk(result)).toBe(true)
+      })
+
+      it.concurrent('accepts SSH protocol URLs', () => {
+        const result = validateTemplateId('ssh://git@github.com/user/repo.git')
+        expect(isOk(result)).toBe(true)
+      })
+    })
+
+    describe('invalid template identifiers', () => {
+      it.concurrent('rejects empty identifiers', () => {
+        const result = validateTemplateId('')
+        expect(isErr(result)).toBe(true)
+      })
+
+      it.concurrent('rejects whitespace-only identifiers', () => {
+        const result = validateTemplateId('   ')
+        expect(isErr(result)).toBe(true)
+      })
+
+      it.concurrent('rejects path traversal attempts', () => {
+        const result = validateTemplateId('../../../malicious')
+        expect(isErr(result)).toBe(true)
+      })
+
+      it.concurrent('rejects invalid URL protocols', () => {
+        const result = validateTemplateId('ftp://invalid-protocol.com/template')
+        expect(isErr(result)).toBe(true)
+      })
+
+      it.concurrent('rejects incomplete GitHub format', () => {
+        const result = validateTemplateId('user/')
+        expect(isErr(result)).toBe(true)
+      })
+
+      it.concurrent('rejects Git SSH shorthand format', () => {
+        // Git SSH shorthand (git@host:path) contains special characters that fail GitHub validation
+        const result = validateTemplateId('git@github.com:user/repo.git')
+        expect(isErr(result)).toBe(true)
+      })
+    })
+
+    describe('sanitization', () => {
+      it.concurrent('trims whitespace from identifiers', () => {
+        const result = validateTemplateId('  user/repo  ')
+        expect(isOk(result)).toBe(true)
+        expect(isOk(result) && result.data).toBe('user/repo')
+      })
+    })
+  })
+
+  describe('validateEmailAddress', () => {
+    describe('valid emails', () => {
+      it.concurrent('accepts standard email format', () => {
+        const result = validateEmailAddress('user@example.com')
+        expect(isOk(result)).toBe(true)
+      })
+
+      it.concurrent('accepts email with subdomain', () => {
+        const result = validateEmailAddress('user@mail.example.com')
+        expect(isOk(result)).toBe(true)
+      })
+
+      it.concurrent('accepts email with plus sign', () => {
+        const result = validateEmailAddress('user+tag@example.com')
+        expect(isOk(result)).toBe(true)
+      })
+
+      it.concurrent('returns empty string for empty input', () => {
+        const result = validateEmailAddress('')
+        expect(isOk(result)).toBe(true)
+        expect(isOk(result) && result.data).toBe('')
+      })
+    })
+
+    describe('invalid emails', () => {
+      it.concurrent('rejects email without @', () => {
+        const result = validateEmailAddress('userexample.com')
+        expect(isErr(result)).toBe(true)
+      })
+
+      it.concurrent('rejects email without domain', () => {
+        const result = validateEmailAddress('user@')
+        expect(isErr(result)).toBe(true)
+      })
+
+      it.concurrent('rejects email without local part', () => {
+        const result = validateEmailAddress('@example.com')
+        expect(isErr(result)).toBe(true)
+      })
+    })
+  })
+
+  describe('validateSemver', () => {
+    describe('valid versions', () => {
+      it.concurrent('accepts standard semver', () => {
+        const result = validateSemver('1.0.0')
+        expect(isOk(result)).toBe(true)
+      })
+
+      it.concurrent('accepts prerelease versions', () => {
+        const result = validateSemver('1.0.0-alpha.1')
+        expect(isOk(result)).toBe(true)
+      })
+
+      it.concurrent('accepts versions with build metadata', () => {
+        const result = validateSemver('1.0.0+build.123')
+        expect(isOk(result)).toBe(true)
+      })
+
+      it.concurrent('returns default version for empty input', () => {
+        const result = validateSemver('')
+        expect(isOk(result)).toBe(true)
+        expect(isOk(result) && result.data).toBe('1.0.0')
+      })
+    })
+
+    describe('invalid versions', () => {
+      it.concurrent('rejects non-semver format', () => {
+        const result = validateSemver('version1')
+        expect(isErr(result)).toBe(true)
+      })
+
+      it.concurrent('rejects incomplete versions', () => {
+        const result = validateSemver('1.0')
+        expect(isErr(result)).toBe(true)
+      })
+    })
+  })
+
+  describe('validatePackageManager', () => {
+    describe('valid package managers', () => {
+      it.concurrent('accepts npm', () => {
+        const result = validatePackageManager('npm')
+        expect(isOk(result)).toBe(true)
+        expect(isOk(result) && result.data).toBe('npm')
+      })
+
+      it.concurrent('accepts yarn', () => {
+        const result = validatePackageManager('yarn')
+        expect(isOk(result)).toBe(true)
+      })
+
+      it.concurrent('accepts pnpm', () => {
+        const result = validatePackageManager('pnpm')
+        expect(isOk(result)).toBe(true)
+      })
+
+      it.concurrent('accepts bun', () => {
+        const result = validatePackageManager('bun')
+        expect(isOk(result)).toBe(true)
+      })
+
+      it.concurrent('handles case insensitivity', () => {
+        const result = validatePackageManager('NPM')
+        expect(isOk(result)).toBe(true)
+        expect(isOk(result) && result.data).toBe('npm')
+      })
+    })
+
+    describe('invalid package managers', () => {
+      it.concurrent('rejects unknown package managers', () => {
+        const result = validatePackageManager('pip')
+        expect(isErr(result)).toBe(true)
+      })
+
+      it.concurrent('rejects empty string', () => {
+        const result = validatePackageManager('')
+        expect(isErr(result)).toBe(true)
+      })
+    })
+  })
+
+  describe('validateTemplateVariableValue', () => {
+    describe('string variables', () => {
+      const stringVariable: TemplateVariable = {
+        name: 'projectName',
+        description: 'Project name',
+        type: 'string',
+        required: true,
+      }
+
+      it.concurrent('accepts valid string values', () => {
+        const result = validateTemplateVariableValue(stringVariable, 'my-project')
+        expect(isOk(result)).toBe(true)
+      })
+
+      it.concurrent('rejects non-string values for string type', () => {
+        const result = validateTemplateVariableValue(stringVariable, 123)
+        expect(isErr(result)).toBe(true)
+      })
+
+      it.concurrent('rejects empty required string', () => {
+        const result = validateTemplateVariableValue(stringVariable, '')
+        expect(isErr(result)).toBe(true)
+      })
+
+      it.concurrent('validates pattern when specified', () => {
+        const patternVar: TemplateVariable = {
+          name: 'version',
+          description: 'Version',
+          type: 'string',
+          required: true,
+          pattern: String.raw`^\d+\.\d+\.\d+$`,
+        }
+
+        const valid = validateTemplateVariableValue(patternVar, '1.0.0')
+        expect(isOk(valid)).toBe(true)
+
+        const invalid = validateTemplateVariableValue(patternVar, 'not-a-version')
+        expect(isErr(invalid)).toBe(true)
+      })
+    })
+
+    describe('boolean variables', () => {
+      const boolVariable: TemplateVariable = {
+        name: 'typescript',
+        description: 'Use TypeScript',
+        type: 'boolean',
+        required: true,
+      }
+
+      it.concurrent('accepts true', () => {
+        const result = validateTemplateVariableValue(boolVariable, true)
+        expect(isOk(result)).toBe(true)
+      })
+
+      it.concurrent('accepts false', () => {
+        const result = validateTemplateVariableValue(boolVariable, false)
+        expect(isOk(result)).toBe(true)
+      })
+
+      it.concurrent('rejects non-boolean values', () => {
+        const result = validateTemplateVariableValue(boolVariable, 'true')
+        expect(isErr(result)).toBe(true)
+      })
+    })
+
+    describe('number variables', () => {
+      const numberVariable: TemplateVariable = {
+        name: 'port',
+        description: 'Server port',
+        type: 'number',
+        required: true,
+      }
+
+      it.concurrent('accepts valid numbers', () => {
+        const result = validateTemplateVariableValue(numberVariable, 3000)
+        expect(isOk(result)).toBe(true)
+      })
+
+      it.concurrent('accepts string numbers and converts them', () => {
+        const result = validateTemplateVariableValue(numberVariable, '3000')
+        expect(isOk(result)).toBe(true)
+        expect(isOk(result) && result.data).toBe(3000)
+      })
+
+      it.concurrent('rejects non-numeric strings', () => {
+        const result = validateTemplateVariableValue(numberVariable, 'not-a-number')
+        expect(isErr(result)).toBe(true)
+      })
+    })
+
+    describe('select variables', () => {
+      const selectVariable: TemplateVariable = {
+        name: 'framework',
+        description: 'Framework choice',
+        type: 'select',
+        required: true,
+        options: ['react', 'vue', 'angular'],
+      }
+
+      it.concurrent('accepts valid options', () => {
+        const result = validateTemplateVariableValue(selectVariable, 'react')
+        expect(isOk(result)).toBe(true)
+      })
+
+      it.concurrent('rejects invalid options', () => {
+        const result = validateTemplateVariableValue(selectVariable, 'svelte')
+        expect(isErr(result)).toBe(true)
+      })
+
+      it.concurrent('rejects non-string values', () => {
+        const result = validateTemplateVariableValue(selectVariable, 123)
+        expect(isErr(result)).toBe(true)
+      })
+    })
+
+    describe('optional variables', () => {
+      const optionalVariable: TemplateVariable = {
+        name: 'description',
+        description: 'Project description',
+        type: 'string',
+        required: false,
+        default: 'A new project',
+      }
+
+      it.concurrent('returns default for undefined', () => {
+        const result = validateTemplateVariableValue(optionalVariable, undefined)
+        expect(isOk(result)).toBe(true)
+        expect(isOk(result) && result.data).toBe('A new project')
+      })
+
+      it.concurrent('returns default for null', () => {
+        const result = validateTemplateVariableValue(optionalVariable, null)
+        expect(isOk(result)).toBe(true)
+        expect(isOk(result) && result.data).toBe('A new project')
+      })
+
+      it.concurrent('returns default for empty string', () => {
+        const result = validateTemplateVariableValue(optionalVariable, '')
+        expect(isOk(result)).toBe(true)
+        expect(isOk(result) && result.data).toBe('A new project')
+      })
+    })
+  })
+
+  describe('createTemplateValidator', () => {
+    const variables: TemplateVariable[] = [
+      {name: 'projectName', description: 'Project name', type: 'string', required: true},
+      {
+        name: 'description',
+        description: 'Description',
+        type: 'string',
+        required: false,
+        default: '',
+      },
+      {name: 'typescript', description: 'Use TypeScript', type: 'boolean', required: true},
+    ]
+
+    const validator = createTemplateValidator(variables)
+
+    it.concurrent('validates all required fields', () => {
+      const result = validator({
+        projectName: 'my-project',
+        typescript: true,
+      })
+      expect(isOk(result)).toBe(true)
+    })
+
+    it.concurrent('returns error for missing required fields', () => {
+      const result = validator({
+        projectName: 'my-project',
+      })
+      expect(isErr(result)).toBe(true)
+    })
+
+    it.concurrent('applies defaults for optional fields', () => {
+      const result = validator({
+        projectName: 'my-project',
+        typescript: false,
+      })
+      expect(isOk(result)).toBe(true)
+      expect(isOk(result) && result.data.description).toBe('')
+    })
+
+    it.concurrent('collects multiple validation errors', () => {
+      const result = validator({
+        projectName: 123,
+        typescript: 'yes',
+      })
+      expect(isErr(result)).toBe(true)
+      expect(isErr(result) && result.error.message).toContain('Template validation failed')
+    })
+  })
+})


### PR DESCRIPTION
- Introduce tests for progress tracking, spinners, and status feedback utilities.
- Implement tests for type guards to validate various input types.
- Add tests for validation factory functions covering project names, paths, and template variables.
- Ensure all tests cover valid and invalid cases for robust validation.

Closes #2386.