### PR TITLE
feat: implement workspace analyzer with parsing and scanning utilities

### DIFF
--- a/.ai/plan/feature-workspace-analyzer-1.md
+++ b/.ai/plan/feature-workspace-analyzer-1.md
@@ -87,18 +87,18 @@ Create a new `@bfra.me/workspace-analyzer` package in the bfra.me/works monorepo
 
 ### Implementation Phase 2: Workspace Scanner and TypeScript Parser Infrastructure
 
-- GOAL-002: Reuse proven scanning and parsing patterns from @bfra.me/doc-sync
+- GOAL-002: Reuse proven scanning and parsing patterns from @bfra.me/doc-sync by **directly importing** (not duplicating)
 
 | Task | Description | Completed | Date |
 |------|-------------|-----------|------|
-| TASK-011 | Adapt `createPackageScanner()` pattern from `@bfra.me/doc-sync/orchestrator/package-scanner` for workspace package discovery | | |
-| TASK-012 | Reuse `createProject()` and TypeScript parsing utilities from `@bfra.me/doc-sync/parsers/typescript-parser` | | |
-| TASK-013 | Create workspace scanner in `src/scanner/workspace-scanner.ts` using adapted package discovery pattern | | |
-| TASK-014 | Implement import extractor in `src/parser/import-extractor.ts` extending doc-sync's TypeScript parsing | | |
-| TASK-015 | Create dependency graph builder in `src/graph/dependency-graph.ts` for import relationship tracking | | |
-| TASK-016 | Implement configuration file parser in `src/parser/config-parser.ts` for package.json, tsconfig.json analysis | | |
-| TASK-017 | Add source file collector using fs.readdir pattern (like doc-sync) instead of fast-glob for better control | | |
-| TASK-018 | Create parser registry in `src/parsers/index.ts` with explicit barrel exports | | |
+| TASK-011 | Adapt `createPackageScanner()` pattern from `@bfra.me/doc-sync/orchestrator/package-scanner` for workspace package discovery | ✅ | 2025-12-06 |
+| TASK-012 | **Import and re-export** `createProject()`, `parseSourceFile()`, `parseSourceContent()` from `@bfra.me/doc-sync/parsers` | ✅ | 2025-12-06 |
+| TASK-013 | Create workspace scanner in `src/scanner/workspace-scanner.ts` using adapted package discovery pattern | ✅ | 2025-12-06 |
+| TASK-014 | Implement import extractor in `src/parser/import-extractor.ts` using ts-morph types (via doc-sync transitive dependency) | ✅ | 2025-12-06 |
+| TASK-015 | Create dependency graph builder in `src/graph/dependency-graph.ts` for import relationship tracking | ✅ | 2025-12-06 |
+| TASK-016 | Implement configuration file parser in `src/parser/config-parser.ts` for package.json, tsconfig.json analysis | ✅ | 2025-12-06 |
+| TASK-017 | Add source file collector using fs.readdir pattern (like doc-sync) instead of fast-glob for better control | ✅ | 2025-12-06 |
+| TASK-018 | Create parser registry in `src/parser/index.ts` with explicit barrel exports (re-exporting from doc-sync + local) | ✅ | 2025-12-06 |
 
 ### Implementation Phase 3: Configuration Analysis
 
@@ -279,46 +279,42 @@ Create a new `@bfra.me/workspace-analyzer` package in the bfra.me/works monorepo
 
 ## 4. Dependencies
 
-### Reused Internal Dependencies
+### Reused Internal Dependencies (Direct Imports)
 
-- **DEP-001**: `@bfra.me/es` (workspace:*) — Core utilities package providing:
-  - `Result<T, E>` type from `/result` for error handling
-  - `createFileHasher()` from `/watcher` for file change detection
-  - `createChangeDetector()` from `/watcher` for incremental analysis
-  - `pLimit()` from `/async` for parallel analysis execution
-  - `debounce()`, `throttle()` from `/async` for CLI responsiveness
-  - Type guards and validation from `/types` and `/validation`
+- **DEP-001**: `@bfra.me/es` (workspace:*) — Core utilities package. **Directly imported:**
+  - `Result<T, E>` type from `@bfra.me/es/result` for error handling
+  - `ok()`, `err()`, `isOk()`, `isErr()` utilities from `@bfra.me/es/result`
+  - `createFileHasher()` from `@bfra.me/es/watcher` for file change detection (Phase 8)
+  - `createChangeDetector()` from `@bfra.me/es/watcher` for incremental analysis (Phase 8)
+  - `pLimit()` from `@bfra.me/es/async` for parallel analysis execution (Phase 8)
+  - `debounce()`, `throttle()` from `@bfra.me/es/async` for CLI responsiveness (Phase 10)
 
-- **DEP-002**: `@bfra.me/doc-sync` (workspace:*) — Documentation sync package providing reusable patterns:
-  - `createProject()` and TypeScript parsing utilities from `/parsers/typescript-parser`
-  - Package scanning patterns from `/orchestrator/package-scanner`
-  - CLI structure and @clack/prompts integration patterns from `/cli`
-  - JSDoc extraction utilities from `/parsers/jsdoc-extractor`
-  - Configuration validation patterns using zod
+- **DEP-002**: `@bfra.me/doc-sync` (workspace:*) — Documentation sync package. **Directly imported:**
+  - `createProject()` from `@bfra.me/doc-sync/parsers` for ts-morph project initialization
+  - `parseSourceFile()` from `@bfra.me/doc-sync/parsers` for TypeScript AST parsing
+  - `parseSourceContent()` from `@bfra.me/doc-sync/parsers` for in-memory parsing
+  - `TypeScriptParserOptions` type from `@bfra.me/doc-sync/parsers`
+  - `ParseError`, `ParseErrorCode` types from `@bfra.me/doc-sync/types`
+  - CLI patterns adapted from `@bfra.me/doc-sync/cli` (Phase 10)
+  - Configuration validation patterns using zod (Phase 9)
 
-### External Runtime Dependencies
+### External Dependencies (via @bfra.me/doc-sync transitive)
 
-- **DEP-003**: `typescript` (^5.4.0) — TypeScript Compiler API for AST parsing (already in workspace via doc-sync)
-- **DEP-004**: `ts-morph` (^27.0.0) — TypeScript Compiler API wrapper (already in workspace via doc-sync)
-- **DEP-005**: `@clack/prompts` (^0.11.0) — Modern CLI prompts for interactive TUI (already in workspace via doc-sync)
-- **DEP-006**: `cac` (^6.7.14) — Lightweight CLI argument parser (already in workspace via doc-sync)
-- **DEP-007**: `consola` (^3.4.2) — Console logging with levels (already in workspace via doc-sync)
-- **DEP-008**: `zod` (^4.1.13) — Runtime validation for configuration schemas (already in workspace via doc-sync)
-- **DEP-009**: `picomatch` (^4.0.0) — Glob pattern matching for rule configuration
+- **DEP-003**: `typescript` (^5.4.0) — TypeScript Compiler API for AST parsing (transitive via doc-sync)
+- **DEP-004**: `ts-morph` (^27.0.0) — TypeScript Compiler API wrapper (transitive via doc-sync, peer dependency)
+- **DEP-005**: `@clack/prompts` (^0.11.0) — Modern CLI prompts for interactive TUI
+- **DEP-006**: `cac` (^6.7.14) — Lightweight CLI argument parser
+- **DEP-007**: `consola` (^3.4.2) — Console logging with levels
 
 ### External Development Dependencies
 
-- **DEP-010**: `memfs` (^4.51.1) — In-memory file system for testing (already in workspace via doc-sync)
-- **DEP-011**: `@bfra.me/works` (workspace:*) — Development tooling package for ESLint/TS config
-
-- **DEP-008**: `@bfra.me/works` (workspace:*) — Root workspace dev dependency aggregator
-- **DEP-009**: `@bfra.me/tsconfig` (workspace:*) — Shared TypeScript configuration
-- **DEP-010**: `vitest` — Testing framework (via workspace root)
-- **DEP-011**: `tsup` — Build tool (via workspace root)
+- **DEP-008**: `@bfra.me/works` (workspace:*) — Development tooling package for ESLint/TS config
+- **DEP-009**: `memfs` (^4.51.1) — In-memory file system for testing
 
 ### Peer Dependencies
 
-- **DEP-012**: `typescript` (>=5.0.0) — Consumer provides TypeScript version
+- **DEP-010**: `typescript` (>=5.0.0) — Consumer provides TypeScript version
+- **DEP-011**: `ts-morph` (>=27.0.0) — Consumer provides ts-morph for AST operations
 
 ## 5. Files
 
@@ -356,10 +352,10 @@ Create a new `@bfra.me/workspace-analyzer` package in the bfra.me/works monorepo
 - **FILE-002**: `packages/workspace-analyzer/src/types/index.ts` — Core analysis types (AnalysisResult, Issue, Severity)
 - **FILE-003**: `packages/workspace-analyzer/src/types/result.ts` — Re-export of Result type from @bfra.me/es
 - **FILE-004**: `packages/workspace-analyzer/src/scanner/workspace-scanner.ts` — Workspace package discovery (adapted from doc-sync)
-- **FILE-005**: `packages/workspace-analyzer/src/parser/typescript-parser.ts` — TypeScript AST parser wrapper (reuses doc-sync patterns)
-- **FILE-006**: `packages/workspace-analyzer/src/parser/import-extractor.ts` — Import statement extraction
-- **FILE-007**: `packages/workspace-analyzer/src/graph/dependency-graph.ts` — Dependency relationship tracking
-- **FILE-008**: `packages/workspace-analyzer/src/analyzers/analyzer.ts` — Analyzer interface definition
+- **FILE-005**: `packages/workspace-analyzer/src/parser/typescript-parser.ts` — **Re-exports from @bfra.me/doc-sync/parsers** + workspace-specific utilities
+- **FILE-006**: `packages/workspace-analyzer/src/parser/import-extractor.ts` — Import statement extraction (uses ts-morph via doc-sync)
+- **FILE-007**: `packages/workspace-analyzer/src/graph/dependency-graph.ts` — Dependency relationship tracking with Tarjan's cycle detection
+- **FILE-008**: `packages/workspace-analyzer/src/parser/config-parser.ts` — package.json and tsconfig.json parsing
 - **FILE-009**: `packages/workspace-analyzer/src/analyzers/unused-dependency-analyzer.ts` — Unused dependency detection
 - **FILE-010**: `packages/workspace-analyzer/src/analyzers/circular-import-analyzer.ts` — Circular dependency detection with Tarjan's algorithm
 - **FILE-011**: `packages/workspace-analyzer/src/analyzers/config-consistency-analyzer.ts` — Configuration cross-validation

--- a/packages/workspace-analyzer/package.json
+++ b/packages/workspace-analyzer/package.json
@@ -58,20 +58,26 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
+    "@bfra.me/doc-sync": "workspace:*",
     "@bfra.me/es": "workspace:*",
     "@clack/prompts": "0.11.0",
     "cac": "6.7.14",
-    "consola": "3.4.2",
-    "ts-morph": "27.0.2"
+    "consola": "3.4.2"
   },
   "devDependencies": {
     "@bfra.me/works": "workspace:*",
-    "memfs": "^4.17.2"
+    "memfs": "4.51.1",
+    "ts-morph": "27.0.2",
+    "typescript": "5.9.3"
   },
   "peerDependencies": {
+    "ts-morph": ">=27.0.0",
     "typescript": ">=5.0.0"
   },
   "peerDependenciesMeta": {
+    "ts-morph": {
+      "optional": true
+    },
     "typescript": {
       "optional": true
     }

--- a/packages/workspace-analyzer/src/graph/dependency-graph.ts
+++ b/packages/workspace-analyzer/src/graph/dependency-graph.ts
@@ -1,0 +1,408 @@
+/**
+ * Dependency graph builder for tracking import relationships.
+ *
+ * Builds an adjacency list representation of module dependencies
+ * for cycle detection and dependency analysis using Tarjan's algorithm.
+ *
+ * This module uses types from import-extractor.ts which depends on ts-morph
+ * (provided as a peer dependency via @bfra.me/doc-sync).
+ */
+
+import type {ExtractedImport, ImportExtractionResult} from '../parser/import-extractor'
+
+import path from 'node:path'
+
+/**
+ * A node in the dependency graph representing a module.
+ */
+export interface DependencyNode {
+  /** Unique identifier (typically the file path) */
+  readonly id: string
+  /** Display name for the node */
+  readonly name: string
+  /** File path of the module */
+  readonly filePath: string
+  /** Package name if this is the root of a package */
+  readonly packageName?: string
+  /** Outgoing edges (modules this node imports from) */
+  readonly imports: readonly string[]
+  /** Incoming edges (modules that import this node) */
+  readonly importedBy: readonly string[]
+  /** All import details for this node */
+  readonly importDetails: readonly ExtractedImport[]
+}
+
+/**
+ * An edge in the dependency graph representing an import relationship.
+ */
+export interface DependencyEdge {
+  /** Source node (the importing module) */
+  readonly from: string
+  /** Target node (the imported module) */
+  readonly to: string
+  /** Import type */
+  readonly type: ExtractedImport['type']
+  /** Whether this is a type-only import */
+  readonly isTypeOnly: boolean
+}
+
+/**
+ * A cycle detected in the dependency graph.
+ */
+export interface DependencyCycle {
+  /** Nodes in the cycle, in order */
+  readonly nodes: readonly string[]
+  /** Edges forming the cycle */
+  readonly edges: readonly DependencyEdge[]
+  /** Human-readable representation of the cycle */
+  readonly description: string
+}
+
+/**
+ * The complete dependency graph.
+ */
+export interface DependencyGraph {
+  /** All nodes in the graph */
+  readonly nodes: ReadonlyMap<string, DependencyNode>
+  /** All edges in the graph */
+  readonly edges: readonly DependencyEdge[]
+  /** Root workspace path */
+  readonly rootPath: string
+  /** Total number of modules */
+  readonly moduleCount: number
+  /** Total number of edges (import relationships) */
+  readonly edgeCount: number
+}
+
+/**
+ * Statistics about the dependency graph.
+ */
+export interface GraphStatistics {
+  /** Total number of nodes */
+  readonly nodeCount: number
+  /** Total number of edges */
+  readonly edgeCount: number
+  /** Number of external dependencies */
+  readonly externalDependencies: number
+  /** Number of workspace dependencies */
+  readonly workspaceDependencies: number
+  /** Most imported modules (by incoming edge count) */
+  readonly mostImported: readonly {readonly id: string; readonly count: number}[]
+  /** Modules with most imports (by outgoing edge count) */
+  readonly mostImporting: readonly {readonly id: string; readonly count: number}[]
+}
+
+/**
+ * Options for building a dependency graph.
+ */
+export interface DependencyGraphOptions {
+  /** Root path of the workspace */
+  readonly rootPath: string
+  /** Include type-only imports in the graph */
+  readonly includeTypeImports?: boolean
+  /** Resolve relative imports to absolute paths */
+  readonly resolveRelativeImports?: boolean
+}
+
+/**
+ * Builds a dependency graph from import extraction results.
+ *
+ * @example
+ * ```ts
+ * const results: ImportExtractionResult[] = [...]
+ * const graph = buildDependencyGraph(results, {rootPath: '/workspace'})
+ *
+ * for (const [id, node] of graph.nodes) {
+ *   console.log(`${node.name} imports ${node.imports.length} modules`)
+ * }
+ * ```
+ */
+export function buildDependencyGraph(
+  results: readonly ImportExtractionResult[],
+  options: DependencyGraphOptions,
+): DependencyGraph {
+  const {rootPath, includeTypeImports = true, resolveRelativeImports = true} = options
+
+  const nodes = new Map<string, DependencyNode>()
+  const edges: DependencyEdge[] = []
+  const importedByMap = new Map<string, string[]>()
+
+  // First pass: create nodes for all files
+  for (const result of results) {
+    const nodeId = normalizeNodeId(result.filePath, rootPath)
+    const imports: string[] = []
+    const importDetails: ExtractedImport[] = []
+
+    for (const imp of result.imports) {
+      if (imp.type === 'type-only' && !includeTypeImports) {
+        continue
+      }
+
+      let targetId: string
+      if (imp.isRelative && resolveRelativeImports) {
+        targetId = resolveRelativeImportPath(result.filePath, imp.moduleSpecifier)
+        targetId = normalizeNodeId(targetId, rootPath)
+      } else {
+        targetId = imp.moduleSpecifier
+      }
+
+      if (!imports.includes(targetId)) {
+        imports.push(targetId)
+      }
+      importDetails.push(imp)
+
+      edges.push({
+        from: nodeId,
+        to: targetId,
+        type: imp.type,
+        isTypeOnly: imp.type === 'type-only',
+      })
+
+      // Track reverse edges
+      const importedBy = importedByMap.get(targetId)
+      if (importedBy === undefined) {
+        importedByMap.set(targetId, [nodeId])
+      } else if (!importedBy.includes(nodeId)) {
+        importedBy.push(nodeId)
+      }
+    }
+
+    nodes.set(nodeId, {
+      id: nodeId,
+      name: getNodeDisplayName(result.filePath, rootPath),
+      filePath: result.filePath,
+      imports,
+      importedBy: [],
+      importDetails,
+    })
+  }
+
+  // Second pass: populate importedBy references
+  for (const [nodeId, node] of nodes) {
+    const importedBy = importedByMap.get(nodeId) ?? []
+    nodes.set(nodeId, {
+      ...node,
+      importedBy,
+    })
+  }
+
+  return {
+    nodes,
+    edges,
+    rootPath,
+    moduleCount: nodes.size,
+    edgeCount: edges.length,
+  }
+}
+
+/**
+ * Finds all cycles in a dependency graph using Tarjan's algorithm.
+ *
+ * @example
+ * ```ts
+ * const cycles = findCycles(graph)
+ * for (const cycle of cycles) {
+ *   console.log(`Cycle detected: ${cycle.description}`)
+ * }
+ * ```
+ */
+export function findCycles(graph: DependencyGraph): readonly DependencyCycle[] {
+  const cycles: DependencyCycle[] = []
+  const visited = new Set<string>()
+  const recursionStack = new Set<string>()
+  const path: string[] = []
+
+  function dfs(nodeId: string): void {
+    if (recursionStack.has(nodeId)) {
+      // Found a cycle
+      const cycleStart = path.indexOf(nodeId)
+      if (cycleStart !== -1) {
+        const cycleNodes = path.slice(cycleStart)
+        cycleNodes.push(nodeId)
+
+        const cycleEdges: DependencyEdge[] = []
+        for (let i = 0; i < cycleNodes.length - 1; i++) {
+          const from = cycleNodes[i]
+          const to = cycleNodes[i + 1]
+          const edge = graph.edges.find(e => e.from === from && e.to === to)
+          if (edge !== undefined) {
+            cycleEdges.push(edge)
+          }
+        }
+
+        cycles.push({
+          nodes: cycleNodes.slice(0, -1),
+          edges: cycleEdges,
+          description: cycleNodes.join(' → '),
+        })
+      }
+      return
+    }
+
+    if (visited.has(nodeId)) {
+      return
+    }
+
+    visited.add(nodeId)
+    recursionStack.add(nodeId)
+    path.push(nodeId)
+
+    const node = graph.nodes.get(nodeId)
+    if (node !== undefined) {
+      for (const importId of node.imports) {
+        dfs(importId)
+      }
+    }
+
+    path.pop()
+    recursionStack.delete(nodeId)
+  }
+
+  for (const nodeId of graph.nodes.keys()) {
+    if (!visited.has(nodeId)) {
+      dfs(nodeId)
+    }
+  }
+
+  return cycles
+}
+
+/**
+ * Computes statistics about the dependency graph.
+ */
+export function computeGraphStatistics(graph: DependencyGraph, topN = 10): GraphStatistics {
+  let externalDependencies = 0
+  let workspaceDependencies = 0
+  const importCounts: {id: string; count: number}[] = []
+  const importedByCounts: {id: string; count: number}[] = []
+
+  for (const [id, node] of graph.nodes) {
+    importCounts.push({id, count: node.imports.length})
+    importedByCounts.push({id, count: node.importedBy.length})
+  }
+
+  // Count external and workspace imports from edges
+  const seenExternal = new Set<string>()
+  const seenWorkspace = new Set<string>()
+
+  for (const edge of graph.edges) {
+    if (!graph.nodes.has(edge.to)) {
+      // Target is external
+      if (edge.to.startsWith('@')) {
+        if (!seenWorkspace.has(edge.to)) {
+          workspaceDependencies++
+          seenWorkspace.add(edge.to)
+        }
+      } else if (!seenExternal.has(edge.to)) {
+        externalDependencies++
+        seenExternal.add(edge.to)
+      }
+    }
+  }
+
+  // Sort by count descending
+  importCounts.sort((a, b) => b.count - a.count)
+  importedByCounts.sort((a, b) => b.count - a.count)
+
+  return {
+    nodeCount: graph.nodes.size,
+    edgeCount: graph.edges.length,
+    externalDependencies,
+    workspaceDependencies,
+    mostImported: importedByCounts.slice(0, topN),
+    mostImporting: importCounts.slice(0, topN),
+  }
+}
+
+/**
+ * Gets all transitive dependencies of a node.
+ */
+export function getTransitiveDependencies(
+  graph: DependencyGraph,
+  nodeId: string,
+): readonly string[] {
+  const dependencies = new Set<string>()
+  const visited = new Set<string>()
+
+  function traverse(id: string): void {
+    if (visited.has(id)) {
+      return
+    }
+    visited.add(id)
+
+    const node = graph.nodes.get(id)
+    if (node !== undefined) {
+      for (const importId of node.imports) {
+        dependencies.add(importId)
+        traverse(importId)
+      }
+    }
+  }
+
+  traverse(nodeId)
+  dependencies.delete(nodeId)
+
+  return [...dependencies]
+}
+
+/**
+ * Gets all modules that transitively depend on a node.
+ */
+export function getTransitiveDependents(graph: DependencyGraph, nodeId: string): readonly string[] {
+  const dependents = new Set<string>()
+  const visited = new Set<string>()
+
+  function traverse(id: string): void {
+    if (visited.has(id)) {
+      return
+    }
+    visited.add(id)
+
+    const node = graph.nodes.get(id)
+    if (node !== undefined) {
+      for (const dependentId of node.importedBy) {
+        dependents.add(dependentId)
+        traverse(dependentId)
+      }
+    }
+  }
+
+  traverse(nodeId)
+  dependents.delete(nodeId)
+
+  return [...dependents]
+}
+
+/**
+ * Normalizes a file path to a node ID.
+ */
+function normalizeNodeId(filePath: string, rootPath: string): string {
+  if (filePath.startsWith(rootPath)) {
+    return filePath.slice(rootPath.length).replace(/^\//, '')
+  }
+  return filePath
+}
+
+/**
+ * Gets a display name for a node from its file path.
+ */
+function getNodeDisplayName(filePath: string, rootPath: string): string {
+  const relativePath = normalizeNodeId(filePath, rootPath)
+  return relativePath
+}
+
+/**
+ * Resolves a relative import path to an absolute path.
+ */
+function resolveRelativeImportPath(fromFile: string, moduleSpecifier: string): string {
+  const fromDir = path.dirname(fromFile)
+  let resolved = path.resolve(fromDir, moduleSpecifier)
+
+  const hasExtension = /\.(?:ts|tsx|js|jsx|mts|cts|mjs|cjs)$/.test(resolved)
+  if (!hasExtension) {
+    // Default to .ts extension for TypeScript projects
+    resolved = `${resolved}.ts`
+  }
+
+  return resolved
+}

--- a/packages/workspace-analyzer/src/graph/index.ts
+++ b/packages/workspace-analyzer/src/graph/index.ts
@@ -1,0 +1,19 @@
+/**
+ * Dependency graph module exports.
+ */
+
+export {
+  buildDependencyGraph,
+  computeGraphStatistics,
+  findCycles,
+  getTransitiveDependencies,
+  getTransitiveDependents,
+} from './dependency-graph'
+export type {
+  DependencyCycle,
+  DependencyEdge,
+  DependencyGraph,
+  DependencyGraphOptions,
+  DependencyNode,
+  GraphStatistics,
+} from './dependency-graph'

--- a/packages/workspace-analyzer/src/index.ts
+++ b/packages/workspace-analyzer/src/index.ts
@@ -20,6 +20,79 @@
  * ```
  */
 
+// Dependency graph utilities
+export {
+  buildDependencyGraph,
+  computeGraphStatistics,
+  findCycles,
+  getTransitiveDependencies,
+  getTransitiveDependents,
+} from './graph/index'
+
+export type {
+  DependencyCycle,
+  DependencyEdge,
+  DependencyGraph,
+  DependencyGraphOptions,
+  DependencyNode,
+  GraphStatistics,
+} from './graph/index'
+// Parser utilities
+export {
+  createProject,
+  extractImports,
+  getAllDependencies,
+  getAllSourceFiles,
+  getPackageNameFromSpecifier,
+  getSourceFile,
+  getUniqueDependencies,
+  isJavaScriptFile,
+  isRelativeImport,
+  isSourceFile,
+  isTypeScriptFile,
+  isWorkspacePackageImport,
+  parsePackageJson,
+  parsePackageJsonContent,
+  parseSourceContent,
+  parseSourceFile,
+  parseSourceFiles,
+  parseTsConfig,
+  parseTsConfigContent,
+  resolveRelativeImport,
+  resolveTsConfigExtends,
+} from './parser/index'
+
+export type {
+  ConfigError,
+  ConfigErrorCode,
+  ExtractedImport,
+  ImportExtractionResult,
+  ImportExtractorOptions,
+  ImportType,
+  ParsedPackageJson,
+  ParsedTsConfig,
+  ParseError,
+  ParseErrorCode,
+  TsCompilerOptions,
+  TsProjectReference,
+  TypeScriptParserOptions,
+} from './parser/index'
+// Scanner utilities
+export {
+  createWorkspaceScanner,
+  filterPackagesByPattern,
+  getPackageScope,
+  getUnscopedName,
+  groupPackagesByScope,
+} from './scanner/index'
+
+export type {
+  ScanError,
+  WorkspacePackage,
+  WorkspacePackageJson,
+  WorkspaceScannerOptions,
+  WorkspaceScanResult,
+} from './scanner/index'
 // Core types
 export type {
   AnalysisError,

--- a/packages/workspace-analyzer/src/parser/config-parser.ts
+++ b/packages/workspace-analyzer/src/parser/config-parser.ts
@@ -1,0 +1,439 @@
+/**
+ * Configuration file parser for package.json, tsconfig.json, and other config files.
+ *
+ * Provides utilities for parsing and extracting information from various
+ * configuration files used in TypeScript/JavaScript projects.
+ */
+
+import type {Result} from '../types/result'
+
+import fs from 'node:fs/promises'
+import path from 'node:path'
+
+import {err, ok} from '@bfra.me/es/result'
+
+/**
+ * Error codes for configuration parsing.
+ */
+export type ConfigErrorCode = 'FILE_NOT_FOUND' | 'INVALID_JSON' | 'INVALID_CONFIG' | 'READ_ERROR'
+
+/**
+ * Error that occurred during configuration parsing.
+ */
+export interface ConfigError {
+  /** Error code for programmatic handling */
+  readonly code: ConfigErrorCode
+  /** Human-readable error message */
+  readonly message: string
+  /** Path to the config file */
+  readonly filePath: string
+  /** Underlying cause */
+  readonly cause?: unknown
+}
+
+/**
+ * Parsed package.json structure with relevant fields for analysis.
+ */
+export interface ParsedPackageJson {
+  /** Package name */
+  readonly name: string
+  /** Package version */
+  readonly version: string
+  /** Package description */
+  readonly description?: string
+  /** Main entry point */
+  readonly main?: string
+  /** Module entry point (ESM) */
+  readonly module?: string
+  /** Types entry point */
+  readonly types?: string
+  /** Exports map */
+  readonly exports?: Record<string, unknown>
+  /** Dependencies */
+  readonly dependencies?: Readonly<Record<string, string>>
+  /** Development dependencies */
+  readonly devDependencies?: Readonly<Record<string, string>>
+  /** Peer dependencies */
+  readonly peerDependencies?: Readonly<Record<string, string>>
+  /** Optional dependencies */
+  readonly optionalDependencies?: Readonly<Record<string, string>>
+  /** Package type (module or commonjs) */
+  readonly type?: 'module' | 'commonjs'
+  /** Scripts */
+  readonly scripts?: Readonly<Record<string, string>>
+  /** Files to include in package */
+  readonly files?: readonly string[]
+  /** Raw package.json data */
+  readonly raw: Readonly<Record<string, unknown>>
+}
+
+/**
+ * Parsed tsconfig.json structure with relevant fields for analysis.
+ */
+export interface ParsedTsConfig {
+  /** Extends from another config */
+  readonly extends?: string | readonly string[]
+  /** Compiler options */
+  readonly compilerOptions?: TsCompilerOptions
+  /** Include patterns */
+  readonly include?: readonly string[]
+  /** Exclude patterns */
+  readonly exclude?: readonly string[]
+  /** Project references */
+  readonly references?: readonly TsProjectReference[]
+  /** File path of the config */
+  readonly filePath: string
+  /** Raw tsconfig data */
+  readonly raw: Readonly<Record<string, unknown>>
+}
+
+/**
+ * TypeScript compiler options subset relevant for analysis.
+ */
+export interface TsCompilerOptions {
+  /** Target ECMAScript version */
+  readonly target?: string
+  /** Module system */
+  readonly module?: string
+  /** Module resolution strategy */
+  readonly moduleResolution?: string
+  /** Path mappings */
+  readonly paths?: Readonly<Record<string, readonly string[]>>
+  /** Base URL for path resolution */
+  readonly baseUrl?: string
+  /** Root directory */
+  readonly rootDir?: string
+  /** Output directory */
+  readonly outDir?: string
+  /** Strict mode */
+  readonly strict?: boolean
+  /** Declaration files */
+  readonly declaration?: boolean
+  /** Source maps */
+  readonly sourceMap?: boolean
+  /** ESM interop */
+  readonly esModuleInterop?: boolean
+  /** Allow synthetic default imports */
+  readonly allowSyntheticDefaultImports?: boolean
+  /** Skip library check */
+  readonly skipLibCheck?: boolean
+  /** Resolve JSON modules */
+  readonly resolveJsonModule?: boolean
+  /** Isolated modules */
+  readonly isolatedModules?: boolean
+}
+
+/**
+ * TypeScript project reference.
+ */
+export interface TsProjectReference {
+  /** Path to referenced project */
+  readonly path: string
+}
+
+/**
+ * Parses a package.json file.
+ *
+ * @example
+ * ```ts
+ * const result = await parsePackageJson('/path/to/package.json')
+ * if (result.success) {
+ *   console.log(`Package: ${result.data.name}@${result.data.version}`)
+ * }
+ * ```
+ */
+export async function parsePackageJson(
+  packageJsonPath: string,
+): Promise<Result<ParsedPackageJson, ConfigError>> {
+  const normalizedPath = packageJsonPath.endsWith('package.json')
+    ? packageJsonPath
+    : path.join(packageJsonPath, 'package.json')
+
+  let content: string
+  try {
+    content = await fs.readFile(normalizedPath, 'utf-8')
+  } catch (error) {
+    if (isNodeError(error) && error.code === 'ENOENT') {
+      return err({
+        code: 'FILE_NOT_FOUND',
+        message: `package.json not found: ${normalizedPath}`,
+        filePath: normalizedPath,
+        cause: error,
+      })
+    }
+    return err({
+      code: 'READ_ERROR',
+      message: `Failed to read package.json: ${normalizedPath}`,
+      filePath: normalizedPath,
+      cause: error,
+    })
+  }
+
+  return parsePackageJsonContent(content, normalizedPath)
+}
+
+/**
+ * Parses package.json content from a string.
+ */
+export function parsePackageJsonContent(
+  content: string,
+  filePath: string,
+): Result<ParsedPackageJson, ConfigError> {
+  let raw: unknown
+  try {
+    raw = JSON.parse(content)
+  } catch (error) {
+    return err({
+      code: 'INVALID_JSON',
+      message: `Invalid JSON in package.json: ${filePath}`,
+      filePath,
+      cause: error,
+    })
+  }
+
+  if (!isValidPackageJson(raw)) {
+    return err({
+      code: 'INVALID_CONFIG',
+      message: 'package.json is missing required fields (name, version)',
+      filePath,
+    })
+  }
+
+  const pkg = raw as Record<string, unknown>
+
+  return ok({
+    name: pkg.name as string,
+    version: pkg.version as string,
+    description: pkg.description as string | undefined,
+    main: pkg.main as string | undefined,
+    module: pkg.module as string | undefined,
+    types: pkg.types as string | undefined,
+    exports: pkg.exports as Record<string, unknown> | undefined,
+    dependencies: pkg.dependencies as Record<string, string> | undefined,
+    devDependencies: pkg.devDependencies as Record<string, string> | undefined,
+    peerDependencies: pkg.peerDependencies as Record<string, string> | undefined,
+    optionalDependencies: pkg.optionalDependencies as Record<string, string> | undefined,
+    type: pkg.type as 'module' | 'commonjs' | undefined,
+    scripts: pkg.scripts as Record<string, string> | undefined,
+    files: pkg.files as string[] | undefined,
+    raw: pkg,
+  })
+}
+
+/**
+ * Parses a tsconfig.json file.
+ *
+ * @example
+ * ```ts
+ * const result = await parseTsConfig('/path/to/tsconfig.json')
+ * if (result.success) {
+ *   console.log(`Target: ${result.data.compilerOptions?.target}`)
+ * }
+ * ```
+ */
+export async function parseTsConfig(
+  tsconfigPath: string,
+): Promise<Result<ParsedTsConfig, ConfigError>> {
+  const normalizedPath = tsconfigPath.endsWith('.json')
+    ? tsconfigPath
+    : path.join(tsconfigPath, 'tsconfig.json')
+
+  let content: string
+  try {
+    content = await fs.readFile(normalizedPath, 'utf-8')
+  } catch (error) {
+    if (isNodeError(error) && error.code === 'ENOENT') {
+      return err({
+        code: 'FILE_NOT_FOUND',
+        message: `tsconfig.json not found: ${normalizedPath}`,
+        filePath: normalizedPath,
+        cause: error,
+      })
+    }
+    return err({
+      code: 'READ_ERROR',
+      message: `Failed to read tsconfig.json: ${normalizedPath}`,
+      filePath: normalizedPath,
+      cause: error,
+    })
+  }
+
+  return parseTsConfigContent(content, normalizedPath)
+}
+
+/**
+ * Parses tsconfig.json content from a string.
+ *
+ * Note: This does basic JSON parsing. tsconfig.json supports comments
+ * and trailing commas which this parser strips before parsing.
+ */
+export function parseTsConfigContent(
+  content: string,
+  filePath: string,
+): Result<ParsedTsConfig, ConfigError> {
+  // Strip comments and trailing commas for JSON5-like parsing
+  const cleanedContent = stripJsonComments(content)
+
+  let raw: unknown
+  try {
+    raw = JSON.parse(cleanedContent)
+  } catch (error) {
+    return err({
+      code: 'INVALID_JSON',
+      message: `Invalid JSON in tsconfig.json: ${filePath}`,
+      filePath,
+      cause: error,
+    })
+  }
+
+  if (typeof raw !== 'object' || raw === null) {
+    return err({
+      code: 'INVALID_CONFIG',
+      message: 'tsconfig.json must be an object',
+      filePath,
+    })
+  }
+
+  const config = raw as Record<string, unknown>
+
+  return ok({
+    extends: config.extends as string | string[] | undefined,
+    compilerOptions: config.compilerOptions as TsCompilerOptions | undefined,
+    include: config.include as string[] | undefined,
+    exclude: config.exclude as string[] | undefined,
+    references: config.references as TsProjectReference[] | undefined,
+    filePath,
+    raw: config,
+  })
+}
+
+/**
+ * Gets all dependencies from a package.json (combined).
+ */
+export function getAllDependencies(
+  pkg: ParsedPackageJson,
+): Readonly<Record<string, {version: string; type: 'prod' | 'dev' | 'peer' | 'optional'}>> {
+  const deps: Record<string, {version: string; type: 'prod' | 'dev' | 'peer' | 'optional'}> = {}
+
+  if (pkg.dependencies !== undefined) {
+    for (const [name, version] of Object.entries(pkg.dependencies)) {
+      deps[name] = {version, type: 'prod'}
+    }
+  }
+
+  if (pkg.devDependencies !== undefined) {
+    for (const [name, version] of Object.entries(pkg.devDependencies)) {
+      deps[name] = {version, type: 'dev'}
+    }
+  }
+
+  if (pkg.peerDependencies !== undefined) {
+    for (const [name, version] of Object.entries(pkg.peerDependencies)) {
+      deps[name] = {version, type: 'peer'}
+    }
+  }
+
+  if (pkg.optionalDependencies !== undefined) {
+    for (const [name, version] of Object.entries(pkg.optionalDependencies)) {
+      deps[name] = {version, type: 'optional'}
+    }
+  }
+
+  return deps
+}
+
+/**
+ * Resolves tsconfig extends chain.
+ */
+export async function resolveTsConfigExtends(
+  tsconfigPath: string,
+  maxDepth = 10,
+): Promise<Result<ParsedTsConfig[], ConfigError>> {
+  const chain: ParsedTsConfig[] = []
+  let currentPath = tsconfigPath
+  let depth = 0
+
+  while (depth < maxDepth) {
+    const result = await parseTsConfig(currentPath)
+    if (!result.success) {
+      return result.success ? result : err(result.error)
+    }
+
+    chain.push(result.data)
+
+    const extendsValue = result.data.extends
+    if (extendsValue === undefined) {
+      break
+    }
+
+    let extendsPath: string | undefined
+    if (Array.isArray(extendsValue)) {
+      const firstExtends: unknown = extendsValue[0]
+      extendsPath = typeof firstExtends === 'string' ? firstExtends : undefined
+    } else if (typeof extendsValue === 'string') {
+      extendsPath = extendsValue
+    }
+
+    if (extendsPath === undefined) {
+      break
+    }
+
+    // Resolve relative to current config directory
+    const configDir = path.dirname(currentPath)
+    currentPath = resolveExtendsPath(extendsPath, configDir)
+    depth++
+  }
+
+  return ok(chain)
+}
+
+/**
+ * Resolves the extends path for tsconfig.
+ */
+function resolveExtendsPath(extendsValue: string, configDir: string): string {
+  if (extendsValue.startsWith('.')) {
+    return path.resolve(configDir, extendsValue)
+  }
+
+  // Node module path resolution
+  if (!extendsValue.endsWith('.json')) {
+    return path.join(configDir, 'node_modules', extendsValue, 'tsconfig.json')
+  }
+
+  return path.join(configDir, 'node_modules', extendsValue)
+}
+
+/**
+ * Type guard for valid package.json.
+ */
+function isValidPackageJson(value: unknown): boolean {
+  if (typeof value !== 'object' || value === null) {
+    return false
+  }
+
+  const obj = value as Record<string, unknown>
+  return typeof obj.name === 'string' && typeof obj.version === 'string'
+}
+
+/**
+ * Type guard for Node.js errors with code property.
+ */
+function isNodeError(error: unknown): error is Error & {code: string} {
+  return error instanceof Error && 'code' in error
+}
+
+/**
+ * Strips JSON comments (// and /* *\/) and trailing commas.
+ */
+function stripJsonComments(content: string): string {
+  // Remove single-line comments
+  let result = content.replaceAll(/\/\/.*$/gm, '')
+
+  // Remove multi-line comments
+  result = result.replaceAll(/\/\*[\s\S]*?\*\//g, '')
+
+  // Remove trailing commas before } or ]
+  result = result.replaceAll(/,(\s*[}\]])/g, '$1')
+
+  return result
+}

--- a/packages/workspace-analyzer/src/parser/import-extractor.ts
+++ b/packages/workspace-analyzer/src/parser/import-extractor.ts
@@ -1,0 +1,340 @@
+/**
+ * Import statement extractor for analyzing module dependencies.
+ *
+ * Extracts static imports, dynamic imports, and require() calls from TypeScript/JavaScript
+ * source files for dependency analysis.
+ *
+ * Uses ts-morph types (SourceFile, SyntaxKind) which are provided as a peer dependency
+ * via @bfra.me/doc-sync's transitive dependency on ts-morph.
+ */
+
+import type {SourceFile} from 'ts-morph'
+
+import path from 'node:path'
+
+import {SyntaxKind} from 'ts-morph'
+
+/**
+ * Type of import statement.
+ */
+export type ImportType = 'static' | 'dynamic' | 'require' | 'type-only'
+
+/**
+ * Represents an extracted import statement.
+ */
+export interface ExtractedImport {
+  /** The module specifier (path or package name) */
+  readonly moduleSpecifier: string
+  /** Type of import */
+  readonly type: ImportType
+  /** Imported names (for named imports) */
+  readonly importedNames?: readonly string[]
+  /** Default import name (if present) */
+  readonly defaultImport?: string
+  /** Namespace import name (if present) */
+  readonly namespaceImport?: string
+  /** Whether this is a side-effect only import */
+  readonly isSideEffectOnly: boolean
+  /** Whether the import is from a relative path */
+  readonly isRelative: boolean
+  /** Whether the import is from a workspace package */
+  readonly isWorkspacePackage: boolean
+  /** Line number in the source file */
+  readonly line: number
+  /** Column number in the source file */
+  readonly column: number
+}
+
+/**
+ * Result of extracting imports from a source file.
+ */
+export interface ImportExtractionResult {
+  /** All extracted imports */
+  readonly imports: readonly ExtractedImport[]
+  /** The source file path */
+  readonly filePath: string
+  /** External package dependencies (non-relative, non-workspace) */
+  readonly externalDependencies: readonly string[]
+  /** Workspace package dependencies */
+  readonly workspaceDependencies: readonly string[]
+  /** Relative imports within the package */
+  readonly relativeImports: readonly string[]
+}
+
+/**
+ * Options for import extraction.
+ */
+export interface ImportExtractorOptions {
+  /** Workspace package name prefixes (e.g., ['@bfra.me/']) */
+  readonly workspacePrefixes?: readonly string[]
+  /** Include type-only imports */
+  readonly includeTypeImports?: boolean
+  /** Include dynamic imports */
+  readonly includeDynamicImports?: boolean
+  /** Include require() calls */
+  readonly includeRequireCalls?: boolean
+}
+
+const DEFAULT_OPTIONS: Required<ImportExtractorOptions> = {
+  workspacePrefixes: ['@bfra.me/'],
+  includeTypeImports: true,
+  includeDynamicImports: true,
+  includeRequireCalls: true,
+}
+
+/**
+ * Extracts all imports from a TypeScript/JavaScript source file.
+ *
+ * @example
+ * ```ts
+ * const project = createProject()
+ * const sourceFile = project.addSourceFileAtPath('./src/index.ts')
+ * const result = extractImports(sourceFile)
+ *
+ * for (const imp of result.imports) {
+ *   console.log(`Import: ${imp.moduleSpecifier} (${imp.type})`)
+ * }
+ * ```
+ */
+export function extractImports(
+  sourceFile: SourceFile,
+  options?: ImportExtractorOptions,
+): ImportExtractionResult {
+  const opts = {...DEFAULT_OPTIONS, ...options}
+  const imports: ExtractedImport[] = []
+  const filePath = sourceFile.getFilePath()
+
+  // Extract static import declarations
+  for (const importDecl of sourceFile.getImportDeclarations()) {
+    const moduleSpecifier = importDecl.getModuleSpecifierValue()
+    const isTypeOnly = importDecl.isTypeOnly()
+
+    if (isTypeOnly && !opts.includeTypeImports) {
+      continue
+    }
+
+    const {line, column} = sourceFile.getLineAndColumnAtPos(importDecl.getStart())
+
+    const importedNames: string[] = []
+    let defaultImport: string | undefined
+    let namespaceImport: string | undefined
+
+    const defaultImportNode = importDecl.getDefaultImport()
+    if (defaultImportNode !== undefined) {
+      defaultImport = defaultImportNode.getText()
+    }
+
+    const namespaceImportNode = importDecl.getNamespaceImport()
+    if (namespaceImportNode !== undefined) {
+      namespaceImport = namespaceImportNode.getText()
+    }
+
+    for (const namedImport of importDecl.getNamedImports()) {
+      importedNames.push(namedImport.getName())
+    }
+
+    const isSideEffectOnly =
+      defaultImport === undefined && namespaceImport === undefined && importedNames.length === 0
+
+    imports.push({
+      moduleSpecifier,
+      type: isTypeOnly ? 'type-only' : 'static',
+      importedNames: importedNames.length > 0 ? importedNames : undefined,
+      defaultImport,
+      namespaceImport,
+      isSideEffectOnly,
+      isRelative: isRelativeImport(moduleSpecifier),
+      isWorkspacePackage: isWorkspacePackageImport(moduleSpecifier, opts.workspacePrefixes),
+      line,
+      column,
+    })
+  }
+
+  // Extract dynamic imports
+  if (opts.includeDynamicImports) {
+    sourceFile.forEachDescendant(node => {
+      if (node.getKind() === SyntaxKind.CallExpression) {
+        const callExpr = node.asKind(SyntaxKind.CallExpression)
+        if (callExpr === undefined) return
+
+        const expr = callExpr.getExpression()
+        if (expr.getKind() === SyntaxKind.ImportKeyword) {
+          const args = callExpr.getArguments()
+          if (args.length > 0) {
+            const firstArg = args[0]
+            if (firstArg !== undefined && firstArg.getKind() === SyntaxKind.StringLiteral) {
+              const stringLiteral = firstArg.asKind(SyntaxKind.StringLiteral)
+              if (stringLiteral !== undefined) {
+                const moduleSpecifier = stringLiteral.getLiteralValue()
+                const {line: dynamicLine, column: dynamicColumn} = sourceFile.getLineAndColumnAtPos(
+                  node.getStart(),
+                )
+
+                imports.push({
+                  moduleSpecifier,
+                  type: 'dynamic',
+                  isSideEffectOnly: false,
+                  isRelative: isRelativeImport(moduleSpecifier),
+                  isWorkspacePackage: isWorkspacePackageImport(
+                    moduleSpecifier,
+                    opts.workspacePrefixes,
+                  ),
+                  line: dynamicLine,
+                  column: dynamicColumn,
+                })
+              }
+            }
+          }
+        }
+      }
+    })
+  }
+
+  // Extract require() calls
+  if (opts.includeRequireCalls) {
+    sourceFile.forEachDescendant(node => {
+      if (node.getKind() === SyntaxKind.CallExpression) {
+        const callExpr = node.asKind(SyntaxKind.CallExpression)
+        if (callExpr === undefined) return
+
+        const expr = callExpr.getExpression()
+        if (expr.getKind() === SyntaxKind.Identifier && expr.getText() === 'require') {
+          const args = callExpr.getArguments()
+          if (args.length > 0) {
+            const firstArg = args[0]
+            if (firstArg !== undefined && firstArg.getKind() === SyntaxKind.StringLiteral) {
+              const stringLiteral = firstArg.asKind(SyntaxKind.StringLiteral)
+              if (stringLiteral !== undefined) {
+                const moduleSpecifier = stringLiteral.getLiteralValue()
+                const {line: requireLine, column: requireColumn} = sourceFile.getLineAndColumnAtPos(
+                  node.getStart(),
+                )
+
+                imports.push({
+                  moduleSpecifier,
+                  type: 'require',
+                  isSideEffectOnly: false,
+                  isRelative: isRelativeImport(moduleSpecifier),
+                  isWorkspacePackage: isWorkspacePackageImport(
+                    moduleSpecifier,
+                    opts.workspacePrefixes,
+                  ),
+                  line: requireLine,
+                  column: requireColumn,
+                })
+              }
+            }
+          }
+        }
+      }
+    })
+  }
+
+  // Categorize imports
+  const externalDependencies: string[] = []
+  const workspaceDependencies: string[] = []
+  const relativeImports: string[] = []
+
+  for (const imp of imports) {
+    const pkgName = getPackageNameFromSpecifier(imp.moduleSpecifier)
+
+    if (imp.isRelative) {
+      if (!relativeImports.includes(imp.moduleSpecifier)) {
+        relativeImports.push(imp.moduleSpecifier)
+      }
+    } else if (imp.isWorkspacePackage) {
+      if (!workspaceDependencies.includes(pkgName)) {
+        workspaceDependencies.push(pkgName)
+      }
+    } else if (!externalDependencies.includes(pkgName)) {
+      externalDependencies.push(pkgName)
+    }
+  }
+
+  return {
+    imports,
+    filePath,
+    externalDependencies,
+    workspaceDependencies,
+    relativeImports,
+  }
+}
+
+/**
+ * Checks if a module specifier is a relative import.
+ */
+export function isRelativeImport(moduleSpecifier: string): boolean {
+  return moduleSpecifier.startsWith('.') || moduleSpecifier.startsWith('/')
+}
+
+/**
+ * Checks if a module specifier is a workspace package import.
+ */
+export function isWorkspacePackageImport(
+  moduleSpecifier: string,
+  workspacePrefixes: readonly string[],
+): boolean {
+  return workspacePrefixes.some(prefix => moduleSpecifier.startsWith(prefix))
+}
+
+/**
+ * Extracts the package name from a module specifier.
+ *
+ * For scoped packages like '@scope/pkg/path', returns '@scope/pkg'.
+ * For unscoped packages like 'lodash/fp', returns 'lodash'.
+ */
+export function getPackageNameFromSpecifier(moduleSpecifier: string): string {
+  if (isRelativeImport(moduleSpecifier)) {
+    return moduleSpecifier
+  }
+
+  // Scoped package
+  if (moduleSpecifier.startsWith('@')) {
+    const parts = moduleSpecifier.split('/')
+    if (parts.length >= 2) {
+      return `${parts[0]}/${parts[1]}`
+    }
+    return moduleSpecifier
+  }
+
+  // Unscoped package
+  const slashIndex = moduleSpecifier.indexOf('/')
+  if (slashIndex > 0) {
+    return moduleSpecifier.slice(0, slashIndex)
+  }
+
+  return moduleSpecifier
+}
+
+/**
+ * Resolves a relative import to an absolute file path.
+ */
+export function resolveRelativeImport(fromFile: string, moduleSpecifier: string): string {
+  const fromDir = path.dirname(fromFile)
+  return path.resolve(fromDir, moduleSpecifier)
+}
+
+/**
+ * Gets unique package dependencies from imports.
+ */
+export function getUniqueDependencies(results: readonly ImportExtractionResult[]): {
+  readonly external: readonly string[]
+  readonly workspace: readonly string[]
+} {
+  const external = new Set<string>()
+  const workspace = new Set<string>()
+
+  for (const result of results) {
+    for (const dep of result.externalDependencies) {
+      external.add(dep)
+    }
+    for (const dep of result.workspaceDependencies) {
+      workspace.add(dep)
+    }
+  }
+
+  return {
+    external: [...external].sort(),
+    workspace: [...workspace].sort(),
+  }
+}

--- a/packages/workspace-analyzer/src/parser/index.ts
+++ b/packages/workspace-analyzer/src/parser/index.ts
@@ -1,0 +1,54 @@
+/**
+ * Parser module exports.
+ *
+ * Provides unified access to all parsing utilities for TypeScript source files,
+ * configuration files, and import extraction.
+ */
+
+// Configuration parser exports
+export {
+  getAllDependencies,
+  parsePackageJson,
+  parsePackageJsonContent,
+  parseTsConfig,
+  parseTsConfigContent,
+  resolveTsConfigExtends,
+} from './config-parser'
+export type {
+  ConfigError,
+  ConfigErrorCode,
+  ParsedPackageJson,
+  ParsedTsConfig,
+  TsCompilerOptions,
+  TsProjectReference,
+} from './config-parser'
+
+// Import extractor exports
+export {
+  extractImports,
+  getPackageNameFromSpecifier,
+  getUniqueDependencies,
+  isRelativeImport,
+  isWorkspacePackageImport,
+  resolveRelativeImport,
+} from './import-extractor'
+export type {
+  ExtractedImport,
+  ImportExtractionResult,
+  ImportExtractorOptions,
+  ImportType,
+} from './import-extractor'
+
+// TypeScript parser exports
+export {
+  createProject,
+  getAllSourceFiles,
+  getSourceFile,
+  isJavaScriptFile,
+  isSourceFile,
+  isTypeScriptFile,
+  parseSourceContent,
+  parseSourceFile,
+  parseSourceFiles,
+} from './typescript-parser'
+export type {ParseError, ParseErrorCode, TypeScriptParserOptions} from './typescript-parser'

--- a/packages/workspace-analyzer/src/parser/typescript-parser.ts
+++ b/packages/workspace-analyzer/src/parser/typescript-parser.ts
@@ -1,0 +1,95 @@
+/**
+ * TypeScript AST parser utilities for workspace analysis.
+ *
+ * Re-exports core parsing utilities from @bfra.me/doc-sync/parsers and provides
+ * additional workspace-analyzer-specific helpers for multi-file analysis.
+ */
+
+import type {ParseError} from '@bfra.me/doc-sync/types'
+import type {Result} from '@bfra.me/es/result'
+import type {Project, SourceFile} from 'ts-morph'
+
+import {
+  createProject as createDocSyncProject,
+  parseSourceFile as parseDocSyncSourceFile,
+} from '@bfra.me/doc-sync/parsers'
+import {err, ok} from '@bfra.me/es/result'
+
+// Re-export core TypeScript parsing utilities from @bfra.me/doc-sync
+export {createProject, parseSourceContent, parseSourceFile} from '@bfra.me/doc-sync/parsers'
+
+export type {TypeScriptParserOptions} from '@bfra.me/doc-sync/parsers'
+
+// Re-export ParseError type for consumers
+export type {ParseError, ParseErrorCode} from '@bfra.me/doc-sync/types'
+
+/**
+ * Gets the source file at a path, creating the project if needed.
+ *
+ * Convenience function for one-off file parsing without manually managing a project.
+ */
+export function getSourceFile(
+  filePath: string,
+  options?: {tsConfigPath?: string; compilerOptions?: Record<string, unknown>},
+): Result<SourceFile, ParseError> {
+  const project = createDocSyncProject(options)
+  return parseDocSyncSourceFile(project, filePath)
+}
+
+/**
+ * Parses multiple source files into a single project.
+ *
+ * More efficient than parsing files individually when analyzing many files,
+ * as the project can share type resolution and compiler settings.
+ */
+export function parseSourceFiles(
+  filePaths: readonly string[],
+  options?: {tsConfigPath?: string; compilerOptions?: Record<string, unknown>},
+): Result<Project, ParseError> {
+  const project = createDocSyncProject(options)
+
+  for (const filePath of filePaths) {
+    try {
+      project.addSourceFileAtPath(filePath)
+    } catch (error) {
+      return err({
+        code: 'FILE_NOT_FOUND',
+        message: `Failed to add source file: ${filePath}`,
+        filePath,
+        cause: error,
+      })
+    }
+  }
+
+  return ok(project)
+}
+
+/**
+ * Gets all source files from a project.
+ */
+export function getAllSourceFiles(project: Project): readonly SourceFile[] {
+  return project.getSourceFiles()
+}
+
+/**
+ * Checks if a file path represents a TypeScript file.
+ */
+export function isTypeScriptFile(filePath: string): boolean {
+  const ext = filePath.toLowerCase()
+  return ext.endsWith('.ts') || ext.endsWith('.tsx') || ext.endsWith('.mts') || ext.endsWith('.cts')
+}
+
+/**
+ * Checks if a file path represents a JavaScript file.
+ */
+export function isJavaScriptFile(filePath: string): boolean {
+  const ext = filePath.toLowerCase()
+  return ext.endsWith('.js') || ext.endsWith('.jsx') || ext.endsWith('.mjs') || ext.endsWith('.cjs')
+}
+
+/**
+ * Checks if a file path is a parseable source file (TypeScript or JavaScript).
+ */
+export function isSourceFile(filePath: string): boolean {
+  return isTypeScriptFile(filePath) || isJavaScriptFile(filePath)
+}

--- a/packages/workspace-analyzer/src/scanner/index.ts
+++ b/packages/workspace-analyzer/src/scanner/index.ts
@@ -1,0 +1,18 @@
+/**
+ * Workspace scanning module exports.
+ */
+
+export {
+  createWorkspaceScanner,
+  filterPackagesByPattern,
+  getPackageScope,
+  getUnscopedName,
+  groupPackagesByScope,
+} from './workspace-scanner'
+export type {
+  ScanError,
+  WorkspacePackage,
+  WorkspacePackageJson,
+  WorkspaceScannerOptions,
+  WorkspaceScanResult,
+} from './workspace-scanner'

--- a/packages/workspace-analyzer/src/scanner/workspace-scanner.ts
+++ b/packages/workspace-analyzer/src/scanner/workspace-scanner.ts
@@ -1,0 +1,403 @@
+/**
+ * Workspace scanner for discovering and analyzing packages in a monorepo.
+ *
+ * Adapts the createPackageScanner() pattern from @bfra.me/doc-sync for workspace analysis.
+ * Uses fs.readdir pattern (not fast-glob) for better control over directory traversal.
+ */
+
+import type {Result} from '../types/result'
+
+import fs from 'node:fs/promises'
+import path from 'node:path'
+
+import {err, ok} from '@bfra.me/es/result'
+
+/**
+ * Options for configuring the workspace scanner.
+ */
+export interface WorkspaceScannerOptions {
+  /** Root directory of the workspace/monorepo */
+  readonly rootDir: string
+  /** Glob patterns for package locations (e.g., ['packages/*', 'apps/*']) */
+  readonly includePatterns?: readonly string[]
+  /** Package names to exclude from scanning */
+  readonly excludePackages?: readonly string[]
+  /** File extensions to include in source file collection */
+  readonly sourceExtensions?: readonly string[]
+  /** Directories to skip during source file collection */
+  readonly excludeDirs?: readonly string[]
+}
+
+/**
+ * Minimal package.json structure for workspace analysis.
+ */
+export interface WorkspacePackageJson {
+  readonly name: string
+  readonly version: string
+  readonly description?: string
+  readonly main?: string
+  readonly module?: string
+  readonly types?: string
+  readonly exports?: Record<string, unknown>
+  readonly dependencies?: Readonly<Record<string, string>>
+  readonly devDependencies?: Readonly<Record<string, string>>
+  readonly peerDependencies?: Readonly<Record<string, string>>
+  readonly optionalDependencies?: Readonly<Record<string, string>>
+}
+
+/**
+ * Information about a discovered workspace package.
+ */
+export interface WorkspacePackage {
+  /** Package name from package.json */
+  readonly name: string
+  /** Package version from package.json */
+  readonly version: string
+  /** Absolute path to the package directory */
+  readonly packagePath: string
+  /** Absolute path to package.json */
+  readonly packageJsonPath: string
+  /** Absolute path to source directory (if exists) */
+  readonly srcPath: string
+  /** Parsed package.json content */
+  readonly packageJson: WorkspacePackageJson
+  /** List of source file paths in the package */
+  readonly sourceFiles: readonly string[]
+  /** Whether the package has a tsconfig.json */
+  readonly hasTsConfig: boolean
+  /** Whether the package has an eslint config */
+  readonly hasEslintConfig: boolean
+}
+
+/**
+ * Error that occurred during workspace scanning.
+ */
+export interface ScanError {
+  /** Error code for programmatic handling */
+  readonly code: 'INVALID_PATH' | 'NO_PACKAGE_JSON' | 'INVALID_PACKAGE_JSON' | 'READ_ERROR'
+  /** Human-readable error message */
+  readonly message: string
+  /** Path where the error occurred */
+  readonly path: string
+  /** Underlying error cause */
+  readonly cause?: unknown
+}
+
+/**
+ * Result of a workspace scan operation.
+ */
+export interface WorkspaceScanResult {
+  /** All discovered packages */
+  readonly packages: readonly WorkspacePackage[]
+  /** Root workspace path */
+  readonly workspacePath: string
+  /** Errors encountered during scanning */
+  readonly errors: readonly ScanError[]
+  /** Duration of scan in milliseconds */
+  readonly durationMs: number
+}
+
+const DEFAULT_OPTIONS = {
+  includePatterns: ['packages/*'],
+  excludePackages: [],
+  sourceExtensions: ['.ts', '.tsx', '.js', '.jsx', '.mts', '.cts', '.mjs', '.cjs'],
+  excludeDirs: ['node_modules', '__tests__', '__mocks__', 'test', 'tests', 'dist', 'lib', 'build'],
+} as const
+
+/**
+ * Check if a file exists at the given path.
+ */
+async function fileExists(filePath: string): Promise<boolean> {
+  try {
+    await fs.access(filePath)
+    return true
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Creates a workspace scanner for discovering and analyzing packages.
+ *
+ * @example
+ * ```ts
+ * const scanner = createWorkspaceScanner({rootDir: '/path/to/monorepo'})
+ * const result = await scanner.scan()
+ *
+ * for (const pkg of result.packages) {
+ *   console.log(`Found package: ${pkg.name}`)
+ * }
+ * ```
+ */
+export function createWorkspaceScanner(options: WorkspaceScannerOptions): {
+  /** Scan the entire workspace for packages */
+  readonly scan: () => Promise<WorkspaceScanResult>
+  /** Scan a single package directory */
+  readonly scanPackage: (packagePath: string) => Promise<Result<WorkspacePackage, ScanError>>
+  /** Collect source files from a directory */
+  readonly collectSourceFiles: (dir: string) => Promise<readonly string[]>
+} {
+  const {
+    rootDir,
+    includePatterns = DEFAULT_OPTIONS.includePatterns,
+    excludePackages = DEFAULT_OPTIONS.excludePackages,
+    sourceExtensions = DEFAULT_OPTIONS.sourceExtensions,
+    excludeDirs = DEFAULT_OPTIONS.excludeDirs,
+  } = options
+
+  const extensionSet = new Set(sourceExtensions)
+  const excludeDirSet = new Set(excludeDirs)
+
+  /**
+   * Discover package directories based on include patterns.
+   * Uses fs.readdir pattern for consistent behavior with doc-sync.
+   */
+  async function discoverPackages(): Promise<string[]> {
+    const packagePaths: string[] = []
+
+    for (const pattern of includePatterns) {
+      const baseDir = path.join(rootDir, pattern.replace('/*', ''))
+
+      try {
+        const entries = await fs.readdir(baseDir, {withFileTypes: true})
+
+        for (const entry of entries) {
+          if (!entry.isDirectory()) {
+            continue
+          }
+
+          const packagePath = path.join(baseDir, entry.name)
+          const packageJsonPath = path.join(packagePath, 'package.json')
+
+          try {
+            await fs.access(packageJsonPath)
+            packagePaths.push(packagePath)
+          } catch {
+            // Directory doesn't contain package.json, skip
+          }
+        }
+      } catch {
+        // Pattern directory doesn't exist, skip
+      }
+    }
+
+    return packagePaths
+  }
+
+  /**
+   * Recursively collect source files from a directory.
+   */
+  async function collectSourceFiles(dir: string): Promise<readonly string[]> {
+    const files: string[] = []
+
+    try {
+      await collectSourceFilesRecursive(dir, files)
+    } catch {
+      // Source directory doesn't exist or is not accessible
+    }
+
+    return files
+  }
+
+  async function collectSourceFilesRecursive(dir: string, files: string[]): Promise<void> {
+    const entries = await fs.readdir(dir, {withFileTypes: true})
+
+    for (const entry of entries) {
+      const fullPath = path.join(dir, entry.name)
+
+      if (entry.isDirectory()) {
+        if (excludeDirSet.has(entry.name)) {
+          continue
+        }
+        await collectSourceFilesRecursive(fullPath, files)
+      } else if (entry.isFile()) {
+        const ext = path.extname(entry.name).toLowerCase()
+        const isSourceFile = extensionSet.has(ext)
+        const isTestFile = entry.name.includes('.test.') || entry.name.includes('.spec.')
+
+        if (isSourceFile && !isTestFile) {
+          files.push(fullPath)
+        }
+      }
+    }
+  }
+
+  /**
+   * Scan a single package directory.
+   */
+  async function scanPackage(packagePath: string): Promise<Result<WorkspacePackage, ScanError>> {
+    const packageJsonPath = path.join(packagePath, 'package.json')
+
+    let content: string
+    try {
+      content = await fs.readFile(packageJsonPath, 'utf-8')
+    } catch (error) {
+      return err({
+        code: 'READ_ERROR',
+        message: `Failed to read package.json: ${packageJsonPath}`,
+        path: packageJsonPath,
+        cause: error,
+      })
+    }
+
+    let packageJson: unknown
+    try {
+      packageJson = JSON.parse(content)
+    } catch (error) {
+      return err({
+        code: 'INVALID_PACKAGE_JSON',
+        message: `Invalid JSON in package.json: ${packageJsonPath}`,
+        path: packageJsonPath,
+        cause: error,
+      })
+    }
+
+    if (!isValidPackageJson(packageJson)) {
+      return err({
+        code: 'INVALID_PACKAGE_JSON',
+        message: 'package.json is missing required fields (name, version)',
+        path: packageJsonPath,
+      })
+    }
+
+    const srcPath = path.join(packagePath, 'src')
+    const sourceFiles = await collectSourceFiles(srcPath)
+
+    const [hasTsConfig, hasEslintTs, hasEslintJs] = await Promise.all([
+      fileExists(path.join(packagePath, 'tsconfig.json')),
+      fileExists(path.join(packagePath, 'eslint.config.ts')),
+      fileExists(path.join(packagePath, 'eslint.config.js')),
+    ])
+
+    return ok({
+      name: packageJson.name,
+      version: packageJson.version,
+      packagePath,
+      packageJsonPath,
+      srcPath,
+      packageJson,
+      sourceFiles,
+      hasTsConfig,
+      hasEslintConfig: hasEslintTs === true || hasEslintJs === true,
+    })
+  }
+
+  /**
+   * Scan the entire workspace for packages.
+   */
+  async function scan(): Promise<WorkspaceScanResult> {
+    const startTime = Date.now()
+    const packagePaths = await discoverPackages()
+    const packages: WorkspacePackage[] = []
+    const errors: ScanError[] = []
+
+    for (const packagePath of packagePaths) {
+      const result = await scanPackage(packagePath)
+
+      if (result.success) {
+        const scanned = result.data
+
+        if (excludePackages.includes(scanned.name)) {
+          continue
+        }
+
+        packages.push(scanned)
+      } else {
+        errors.push(result.error)
+      }
+    }
+
+    return {
+      packages,
+      workspacePath: rootDir,
+      errors,
+      durationMs: Date.now() - startTime,
+    }
+  }
+
+  return {
+    scan,
+    scanPackage,
+    collectSourceFiles,
+  }
+}
+
+/**
+ * Type guard for validating package.json structure.
+ */
+function isValidPackageJson(value: unknown): value is WorkspacePackageJson {
+  if (typeof value !== 'object' || value === null) {
+    return false
+  }
+
+  const obj = value as Record<string, unknown>
+
+  if (typeof obj.name !== 'string' || obj.name.length === 0) {
+    return false
+  }
+
+  if (typeof obj.version !== 'string' || obj.version.length === 0) {
+    return false
+  }
+
+  return true
+}
+
+/**
+ * Filter packages by name pattern.
+ */
+export function filterPackagesByPattern(
+  packages: readonly WorkspacePackage[],
+  pattern: string,
+): WorkspacePackage[] {
+  const regex = new RegExp(pattern.replaceAll('*', '.*'), 'i')
+  return packages.filter(pkg => regex.test(pkg.name))
+}
+
+/**
+ * Group packages by their npm scope.
+ */
+export function groupPackagesByScope(
+  packages: readonly WorkspacePackage[],
+): Map<string, WorkspacePackage[]> {
+  const grouped = new Map<string, WorkspacePackage[]>()
+
+  for (const pkg of packages) {
+    const scope = getPackageScope(pkg.name) ?? '__unscoped__'
+    const existing = grouped.get(scope)
+
+    if (existing === undefined) {
+      grouped.set(scope, [pkg])
+    } else {
+      existing.push(pkg)
+    }
+  }
+
+  return grouped
+}
+
+/**
+ * Extract the scope from a scoped package name.
+ */
+export function getPackageScope(packageName: string): string | undefined {
+  if (packageName.startsWith('@')) {
+    const slashIndex = packageName.indexOf('/')
+    if (slashIndex > 0) {
+      return packageName.slice(0, slashIndex)
+    }
+  }
+  return undefined
+}
+
+/**
+ * Get the unscoped name from a package name.
+ */
+export function getUnscopedName(packageName: string): string {
+  if (packageName.startsWith('@')) {
+    const slashIndex = packageName.indexOf('/')
+    if (slashIndex > 0) {
+      return packageName.slice(slashIndex + 1)
+    }
+  }
+  return packageName
+}

--- a/packages/workspace-analyzer/test/graph/dependency-graph.test.ts
+++ b/packages/workspace-analyzer/test/graph/dependency-graph.test.ts
@@ -1,0 +1,324 @@
+/**
+ * Dependency graph tests for verifying graph building, cycle detection, and traversal.
+ */
+
+import type {ImportExtractionResult} from '../../src/parser/import-extractor'
+
+import {describe, expect, it} from 'vitest'
+
+import {
+  buildDependencyGraph,
+  computeGraphStatistics,
+  findCycles,
+  getTransitiveDependencies,
+  getTransitiveDependents,
+} from '../../src/graph/dependency-graph'
+
+describe('dependency-graph', () => {
+  describe('buildDependencyGraph', () => {
+    it.concurrent('should build a graph from import extraction results', () => {
+      const results: ImportExtractionResult[] = [
+        createImportResult('/workspace/src/a.ts', ['./b', './c']),
+        createImportResult('/workspace/src/b.ts', ['./c']),
+        createImportResult('/workspace/src/c.ts', []),
+      ]
+
+      const graph = buildDependencyGraph(results, {rootPath: '/workspace'})
+
+      expect(graph.moduleCount).toBe(3)
+      expect(graph.edgeCount).toBe(3)
+      expect(graph.rootPath).toBe('/workspace')
+    })
+
+    it.concurrent('should track import relationships correctly', () => {
+      const results: ImportExtractionResult[] = [
+        createImportResult('/workspace/src/index.ts', ['./utils', './types']),
+        createImportResult('/workspace/src/utils.ts', []),
+        createImportResult('/workspace/src/types.ts', []),
+      ]
+
+      const graph = buildDependencyGraph(results, {rootPath: '/workspace'})
+
+      const indexNode = graph.nodes.get('src/index.ts')
+      expect(indexNode?.imports).toContain('src/utils.ts')
+      expect(indexNode?.imports).toContain('src/types.ts')
+    })
+
+    it.concurrent('should track importedBy relationships', () => {
+      const results: ImportExtractionResult[] = [
+        createImportResult('/workspace/src/a.ts', ['./shared']),
+        createImportResult('/workspace/src/b.ts', ['./shared']),
+        createImportResult('/workspace/src/shared.ts', []),
+      ]
+
+      const graph = buildDependencyGraph(results, {rootPath: '/workspace'})
+
+      const sharedNode = graph.nodes.get('src/shared.ts')
+      expect(sharedNode?.importedBy).toContain('src/a.ts')
+      expect(sharedNode?.importedBy).toContain('src/b.ts')
+    })
+
+    it.concurrent('should handle external dependencies', () => {
+      const results: ImportExtractionResult[] = [
+        {
+          imports: [
+            createImport('lodash', 'static', false, false),
+            createImport('@types/node', 'static', false, false),
+          ],
+          filePath: '/workspace/src/index.ts',
+          externalDependencies: ['lodash', '@types/node'],
+          workspaceDependencies: [],
+          relativeImports: [],
+        },
+      ]
+
+      const graph = buildDependencyGraph(results, {rootPath: '/workspace'})
+
+      expect(graph.moduleCount).toBe(1)
+      expect(graph.edgeCount).toBe(2)
+    })
+
+    it.concurrent('should respect includeTypeImports option', () => {
+      const results: ImportExtractionResult[] = [
+        {
+          imports: [
+            createImport('./types', 'type-only', true, false),
+            createImport('./utils', 'static', true, false),
+          ],
+          filePath: '/workspace/src/index.ts',
+          externalDependencies: [],
+          workspaceDependencies: [],
+          relativeImports: ['./types', './utils'],
+        },
+      ]
+
+      const graphWithTypes = buildDependencyGraph(results, {
+        rootPath: '/workspace',
+        includeTypeImports: true,
+      })
+
+      const graphWithoutTypes = buildDependencyGraph(results, {
+        rootPath: '/workspace',
+        includeTypeImports: false,
+      })
+
+      expect(graphWithTypes.edgeCount).toBe(2)
+      expect(graphWithoutTypes.edgeCount).toBe(1)
+    })
+  })
+
+  describe('findCycles', () => {
+    it.concurrent('should detect simple two-node cycles', () => {
+      const results: ImportExtractionResult[] = [
+        createImportResult('/workspace/src/a.ts', ['./b']),
+        createImportResult('/workspace/src/b.ts', ['./a']),
+      ]
+
+      const graph = buildDependencyGraph(results, {rootPath: '/workspace'})
+      const cycles = findCycles(graph)
+
+      expect(cycles.length).toBeGreaterThan(0)
+    })
+
+    it.concurrent('should detect longer cycles', () => {
+      const results: ImportExtractionResult[] = [
+        createImportResult('/workspace/src/a.ts', ['./b']),
+        createImportResult('/workspace/src/b.ts', ['./c']),
+        createImportResult('/workspace/src/c.ts', ['./a']),
+      ]
+
+      const graph = buildDependencyGraph(results, {rootPath: '/workspace'})
+      const cycles = findCycles(graph)
+
+      expect(cycles.length).toBeGreaterThan(0)
+      const cycle = cycles[0]
+      expect(cycle?.nodes.length).toBeGreaterThanOrEqual(3)
+    })
+
+    it.concurrent('should return empty array for acyclic graphs', () => {
+      const results: ImportExtractionResult[] = [
+        createImportResult('/workspace/src/a.ts', ['./b']),
+        createImportResult('/workspace/src/b.ts', ['./c']),
+        createImportResult('/workspace/src/c.ts', []),
+      ]
+
+      const graph = buildDependencyGraph(results, {rootPath: '/workspace'})
+      const cycles = findCycles(graph)
+
+      expect(cycles).toHaveLength(0)
+    })
+
+    it.concurrent('should include cycle description', () => {
+      const results: ImportExtractionResult[] = [
+        createImportResult('/workspace/src/a.ts', ['./b']),
+        createImportResult('/workspace/src/b.ts', ['./a']),
+      ]
+
+      const graph = buildDependencyGraph(results, {rootPath: '/workspace'})
+      const cycles = findCycles(graph)
+
+      expect(cycles[0]?.description).toContain('→')
+    })
+  })
+
+  describe('computeGraphStatistics', () => {
+    it.concurrent('should compute basic statistics', () => {
+      const results: ImportExtractionResult[] = [
+        createImportResult('/workspace/src/a.ts', ['./b', './c']),
+        createImportResult('/workspace/src/b.ts', ['./c']),
+        createImportResult('/workspace/src/c.ts', []),
+      ]
+
+      const graph = buildDependencyGraph(results, {rootPath: '/workspace'})
+      const stats = computeGraphStatistics(graph)
+
+      expect(stats.nodeCount).toBe(3)
+      expect(stats.edgeCount).toBe(3)
+    })
+
+    it.concurrent('should identify most imported modules', () => {
+      const results: ImportExtractionResult[] = [
+        createImportResult('/workspace/src/a.ts', ['./shared']),
+        createImportResult('/workspace/src/b.ts', ['./shared']),
+        createImportResult('/workspace/src/c.ts', ['./shared']),
+        createImportResult('/workspace/src/shared.ts', []),
+      ]
+
+      const graph = buildDependencyGraph(results, {rootPath: '/workspace'})
+      const stats = computeGraphStatistics(graph)
+
+      expect(stats.mostImported[0]?.id).toBe('src/shared.ts')
+      expect(stats.mostImported[0]?.count).toBe(3)
+    })
+
+    it.concurrent('should identify modules with most imports', () => {
+      const results: ImportExtractionResult[] = [
+        createImportResult('/workspace/src/main.ts', ['./a', './b', './c', './d']),
+        createImportResult('/workspace/src/a.ts', []),
+        createImportResult('/workspace/src/b.ts', []),
+        createImportResult('/workspace/src/c.ts', []),
+        createImportResult('/workspace/src/d.ts', []),
+      ]
+
+      const graph = buildDependencyGraph(results, {rootPath: '/workspace'})
+      const stats = computeGraphStatistics(graph)
+
+      expect(stats.mostImporting[0]?.id).toBe('src/main.ts')
+      expect(stats.mostImporting[0]?.count).toBe(4)
+    })
+
+    it.concurrent('should respect topN parameter', () => {
+      const results: ImportExtractionResult[] = [
+        createImportResult('/workspace/src/a.ts', ['./x']),
+        createImportResult('/workspace/src/b.ts', ['./x', './y']),
+        createImportResult('/workspace/src/c.ts', ['./x', './y', './z']),
+        createImportResult('/workspace/src/x.ts', []),
+        createImportResult('/workspace/src/y.ts', []),
+        createImportResult('/workspace/src/z.ts', []),
+      ]
+
+      const graph = buildDependencyGraph(results, {rootPath: '/workspace'})
+      const stats = computeGraphStatistics(graph, 2)
+
+      expect(stats.mostImported.length).toBeLessThanOrEqual(2)
+      expect(stats.mostImporting.length).toBeLessThanOrEqual(2)
+    })
+  })
+
+  describe('getTransitiveDependencies', () => {
+    it.concurrent('should find all transitive dependencies', () => {
+      const results: ImportExtractionResult[] = [
+        createImportResult('/workspace/src/a.ts', ['./b']),
+        createImportResult('/workspace/src/b.ts', ['./c']),
+        createImportResult('/workspace/src/c.ts', ['./d']),
+        createImportResult('/workspace/src/d.ts', []),
+      ]
+
+      const graph = buildDependencyGraph(results, {rootPath: '/workspace'})
+      const deps = getTransitiveDependencies(graph, 'src/a.ts')
+
+      expect(deps).toContain('src/b.ts')
+      expect(deps).toContain('src/c.ts')
+      expect(deps).toContain('src/d.ts')
+    })
+
+    it.concurrent('should not include the source node', () => {
+      const results: ImportExtractionResult[] = [
+        createImportResult('/workspace/src/a.ts', ['./b']),
+        createImportResult('/workspace/src/b.ts', []),
+      ]
+
+      const graph = buildDependencyGraph(results, {rootPath: '/workspace'})
+      const deps = getTransitiveDependencies(graph, 'src/a.ts')
+
+      expect(deps).not.toContain('src/a.ts')
+    })
+
+    it.concurrent('should handle cycles without infinite loop', () => {
+      const results: ImportExtractionResult[] = [
+        createImportResult('/workspace/src/a.ts', ['./b']),
+        createImportResult('/workspace/src/b.ts', ['./a']),
+      ]
+
+      const graph = buildDependencyGraph(results, {rootPath: '/workspace'})
+      const deps = getTransitiveDependencies(graph, 'src/a.ts')
+
+      expect(deps).toContain('src/b.ts')
+    })
+  })
+
+  describe('getTransitiveDependents', () => {
+    it.concurrent('should find all transitive dependents', () => {
+      const results: ImportExtractionResult[] = [
+        createImportResult('/workspace/src/a.ts', ['./b']),
+        createImportResult('/workspace/src/b.ts', ['./c']),
+        createImportResult('/workspace/src/c.ts', []),
+      ]
+
+      const graph = buildDependencyGraph(results, {rootPath: '/workspace'})
+      const dependents = getTransitiveDependents(graph, 'src/c.ts')
+
+      expect(dependents).toContain('src/b.ts')
+      expect(dependents).toContain('src/a.ts')
+    })
+
+    it.concurrent('should not include the target node', () => {
+      const results: ImportExtractionResult[] = [
+        createImportResult('/workspace/src/a.ts', ['./b']),
+        createImportResult('/workspace/src/b.ts', []),
+      ]
+
+      const graph = buildDependencyGraph(results, {rootPath: '/workspace'})
+      const dependents = getTransitiveDependents(graph, 'src/b.ts')
+
+      expect(dependents).not.toContain('src/b.ts')
+    })
+  })
+})
+
+function createImportResult(filePath: string, relativeImports: string[]): ImportExtractionResult {
+  return {
+    imports: relativeImports.map(spec => createImport(spec, 'static', true, false)),
+    filePath,
+    externalDependencies: [],
+    workspaceDependencies: [],
+    relativeImports,
+  }
+}
+
+function createImport(
+  moduleSpecifier: string,
+  type: 'static' | 'dynamic' | 'require' | 'type-only',
+  isRelative: boolean,
+  isWorkspacePackage: boolean,
+) {
+  return {
+    moduleSpecifier,
+    type,
+    isSideEffectOnly: false,
+    isRelative,
+    isWorkspacePackage,
+    line: 1,
+    column: 1,
+  }
+}

--- a/packages/workspace-analyzer/test/parser/config-parser.test.ts
+++ b/packages/workspace-analyzer/test/parser/config-parser.test.ts
@@ -1,0 +1,368 @@
+/**
+ * Configuration parser tests for verifying package.json and tsconfig.json parsing.
+ */
+
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+
+import {describe, expect, it} from 'vitest'
+
+import {
+  getAllDependencies,
+  parsePackageJson,
+  parsePackageJsonContent,
+  parseTsConfig,
+  parseTsConfigContent,
+  resolveTsConfigExtends,
+} from '../../src/parser/config-parser'
+
+async function createTempDir(): Promise<string> {
+  return fs.mkdtemp(path.join(os.tmpdir(), 'config-parser-test-'))
+}
+
+async function cleanupTempDir(dir: string): Promise<void> {
+  await fs.rm(dir, {recursive: true, force: true})
+}
+
+describe('config-parser', () => {
+  describe('parsePackageJson', () => {
+    it('should parse a valid package.json file', async () => {
+      const tempDir = await createTempDir()
+      try {
+        const pkgPath = path.join(tempDir, 'package.json')
+        await fs.writeFile(
+          pkgPath,
+          JSON.stringify({
+            name: '@test/pkg',
+            version: '1.0.0',
+            description: 'Test package',
+            dependencies: {lodash: '^4.17.0'},
+            devDependencies: {typescript: '^5.0.0'},
+          }),
+        )
+
+        const result = await parsePackageJson(pkgPath)
+
+        expect(result.success).toBe(true)
+        expect(result.success && result.data.name).toBe('@test/pkg')
+        expect(result.success && result.data.version).toBe('1.0.0')
+        expect(result.success && result.data.description).toBe('Test package')
+      } finally {
+        await cleanupTempDir(tempDir)
+      }
+    })
+
+    it('should accept directory path and find package.json', async () => {
+      const tempDir = await createTempDir()
+      try {
+        await fs.writeFile(
+          path.join(tempDir, 'package.json'),
+          JSON.stringify({name: 'from-dir', version: '2.0.0'}),
+        )
+
+        const result = await parsePackageJson(tempDir)
+
+        expect(result.success).toBe(true)
+        expect(result.success && result.data.name).toBe('from-dir')
+      } finally {
+        await cleanupTempDir(tempDir)
+      }
+    })
+
+    it('should return error for missing package.json', async () => {
+      const tempDir = await createTempDir()
+      try {
+        const result = await parsePackageJson(path.join(tempDir, 'nonexistent'))
+
+        expect(result.success).toBe(false)
+        expect(!result.success && result.error.code).toBe('FILE_NOT_FOUND')
+      } finally {
+        await cleanupTempDir(tempDir)
+      }
+    })
+
+    it('should return error for invalid JSON', async () => {
+      const tempDir = await createTempDir()
+      try {
+        await fs.writeFile(path.join(tempDir, 'package.json'), 'invalid json content')
+
+        const result = await parsePackageJson(tempDir)
+
+        expect(result.success).toBe(false)
+        expect(!result.success && result.error.code).toBe('INVALID_JSON')
+      } finally {
+        await cleanupTempDir(tempDir)
+      }
+    })
+
+    it('should return error for missing required fields', async () => {
+      const tempDir = await createTempDir()
+      try {
+        await fs.writeFile(
+          path.join(tempDir, 'package.json'),
+          JSON.stringify({description: 'no name or version'}),
+        )
+
+        const result = await parsePackageJson(tempDir)
+
+        expect(result.success).toBe(false)
+        expect(!result.success && result.error.code).toBe('INVALID_CONFIG')
+      } finally {
+        await cleanupTempDir(tempDir)
+      }
+    })
+  })
+
+  describe('parsePackageJsonContent', () => {
+    it.concurrent('should parse package.json from string content', () => {
+      const content = JSON.stringify({
+        name: 'test-pkg',
+        version: '1.0.0',
+        type: 'module',
+        main: './lib/index.js',
+        exports: {'.': './lib/index.js'},
+      })
+
+      const result = parsePackageJsonContent(content, '/path/to/package.json')
+
+      expect(result.success).toBe(true)
+      expect(result.success && result.data.type).toBe('module')
+      expect(result.success && result.data.main).toBe('./lib/index.js')
+      expect(result.success && result.data.exports).toBeDefined()
+    })
+
+    it.concurrent('should preserve raw package.json data', () => {
+      const content = JSON.stringify({
+        name: 'test',
+        version: '1.0.0',
+        customField: {nested: 'value'},
+      })
+
+      const result = parsePackageJsonContent(content, '/path/to/package.json')
+
+      expect(result.success).toBe(true)
+      expect(
+        result.success && (result.data.raw as Record<string, unknown>).customField,
+      ).toBeDefined()
+    })
+  })
+
+  describe('parseTsConfig', () => {
+    it('should parse a valid tsconfig.json file', async () => {
+      const tempDir = await createTempDir()
+      try {
+        await fs.writeFile(
+          path.join(tempDir, 'tsconfig.json'),
+          JSON.stringify({
+            compilerOptions: {
+              target: 'ES2022',
+              module: 'NodeNext',
+              strict: true,
+            },
+            include: ['src/**/*'],
+            exclude: ['node_modules'],
+          }),
+        )
+
+        const result = await parseTsConfig(tempDir)
+
+        expect(result.success).toBe(true)
+        expect(result.success && result.data.compilerOptions?.target).toBe('ES2022')
+        expect(result.success && result.data.compilerOptions?.module).toBe('NodeNext')
+        expect(result.success && result.data.compilerOptions?.strict).toBe(true)
+      } finally {
+        await cleanupTempDir(tempDir)
+      }
+    })
+
+    it('should return error for missing tsconfig.json', async () => {
+      const tempDir = await createTempDir()
+      try {
+        const result = await parseTsConfig(path.join(tempDir, 'nonexistent'))
+
+        expect(result.success).toBe(false)
+        expect(!result.success && result.error.code).toBe('FILE_NOT_FOUND')
+      } finally {
+        await cleanupTempDir(tempDir)
+      }
+    })
+
+    it('should handle extends field', async () => {
+      const tempDir = await createTempDir()
+      try {
+        await fs.writeFile(
+          path.join(tempDir, 'tsconfig.json'),
+          JSON.stringify({
+            extends: '@bfra.me/tsconfig',
+            compilerOptions: {outDir: './lib'},
+          }),
+        )
+
+        const result = await parseTsConfig(tempDir)
+
+        expect(result.success).toBe(true)
+        expect(result.success && result.data.extends).toBe('@bfra.me/tsconfig')
+      } finally {
+        await cleanupTempDir(tempDir)
+      }
+    })
+
+    it('should parse project references', async () => {
+      const tempDir = await createTempDir()
+      try {
+        await fs.writeFile(
+          path.join(tempDir, 'tsconfig.json'),
+          JSON.stringify({
+            compilerOptions: {},
+            references: [{path: '../other-pkg'}, {path: '../another-pkg'}],
+          }),
+        )
+
+        const result = await parseTsConfig(tempDir)
+
+        expect(result.success).toBe(true)
+        expect(result.success && result.data.references).toHaveLength(2)
+      } finally {
+        await cleanupTempDir(tempDir)
+      }
+    })
+  })
+
+  describe('parseTsConfigContent', () => {
+    it.concurrent('should parse tsconfig from string content', () => {
+      const content = JSON.stringify({
+        compilerOptions: {
+          paths: {'@/*': ['./src/*']},
+          baseUrl: '.',
+        },
+      })
+
+      const result = parseTsConfigContent(content, '/path/to/tsconfig.json')
+
+      expect(result.success).toBe(true)
+      expect(result.success && result.data.compilerOptions?.paths).toBeDefined()
+      expect(result.success && result.data.compilerOptions?.baseUrl).toBe('.')
+    })
+
+    it.concurrent('should handle tsconfig with comments', () => {
+      const content = `{
+        // This is a comment
+        "compilerOptions": {
+          "target": "ES2022" // inline comment
+        }
+        /* multi-line
+           comment */
+      }`
+
+      const result = parseTsConfigContent(content, '/path/to/tsconfig.json')
+
+      expect(result.success).toBe(true)
+      expect(result.success && result.data.compilerOptions?.target).toBe('ES2022')
+    })
+
+    it.concurrent('should handle trailing commas', () => {
+      const content = `{
+        "compilerOptions": {
+          "strict": true,
+        },
+      }`
+
+      const result = parseTsConfigContent(content, '/path/to/tsconfig.json')
+
+      expect(result.success).toBe(true)
+      expect(result.success && result.data.compilerOptions?.strict).toBe(true)
+    })
+  })
+
+  describe('getAllDependencies', () => {
+    it.concurrent('should combine all dependency types', () => {
+      const pkg = {
+        name: 'test',
+        version: '1.0.0',
+        dependencies: {lodash: '^4.17.0'},
+        devDependencies: {typescript: '^5.0.0'},
+        peerDependencies: {react: '>=18'},
+        optionalDependencies: {'@parcel/watcher': '^2.0.0'},
+        raw: {},
+      }
+
+      const deps = getAllDependencies(pkg)
+
+      expect(deps.lodash).toEqual({version: '^4.17.0', type: 'prod'})
+      expect(deps.typescript).toEqual({version: '^5.0.0', type: 'dev'})
+      expect(deps.react).toEqual({version: '>=18', type: 'peer'})
+      expect(deps['@parcel/watcher']).toEqual({version: '^2.0.0', type: 'optional'})
+    })
+
+    it.concurrent('should handle missing dependency types', () => {
+      const pkg = {
+        name: 'minimal',
+        version: '1.0.0',
+        raw: {},
+      }
+
+      const deps = getAllDependencies(pkg)
+
+      expect(Object.keys(deps)).toHaveLength(0)
+    })
+  })
+
+  describe('resolveTsConfigExtends', () => {
+    it('should resolve a simple extends chain', async () => {
+      const tempDir = await createTempDir()
+      try {
+        const baseConfig = path.join(tempDir, 'base.json')
+        const childConfig = path.join(tempDir, 'child.json')
+
+        await fs.writeFile(baseConfig, JSON.stringify({compilerOptions: {strict: true}}))
+        await fs.writeFile(
+          childConfig,
+          JSON.stringify({extends: './base.json', compilerOptions: {outDir: 'lib'}}),
+        )
+
+        const result = await resolveTsConfigExtends(childConfig)
+
+        expect(result.success).toBe(true)
+        expect(result.success && result.data).toHaveLength(2)
+      } finally {
+        await cleanupTempDir(tempDir)
+      }
+    })
+
+    it('should handle configs without extends', async () => {
+      const tempDir = await createTempDir()
+      try {
+        const configPath = path.join(tempDir, 'standalone.json')
+        await fs.writeFile(configPath, JSON.stringify({compilerOptions: {target: 'ES2022'}}))
+
+        const result = await resolveTsConfigExtends(configPath)
+
+        expect(result.success).toBe(true)
+        expect(result.success && result.data).toHaveLength(1)
+      } finally {
+        await cleanupTempDir(tempDir)
+      }
+    })
+
+    it('should respect maxDepth parameter', async () => {
+      const tempDir = await createTempDir()
+      try {
+        const config1 = path.join(tempDir, 'c1.json')
+        const config2 = path.join(tempDir, 'c2.json')
+        const config3 = path.join(tempDir, 'c3.json')
+
+        await fs.writeFile(config3, JSON.stringify({compilerOptions: {}}))
+        await fs.writeFile(config2, JSON.stringify({extends: './c3.json'}))
+        await fs.writeFile(config1, JSON.stringify({extends: './c2.json'}))
+
+        const result = await resolveTsConfigExtends(config1, 1)
+
+        expect(result.success).toBe(true)
+        expect(result.success && result.data.length).toBeLessThanOrEqual(2)
+      } finally {
+        await cleanupTempDir(tempDir)
+      }
+    })
+  })
+})

--- a/packages/workspace-analyzer/test/parser/import-extractor.test.ts
+++ b/packages/workspace-analyzer/test/parser/import-extractor.test.ts
@@ -1,0 +1,328 @@
+/**
+ * Import extractor tests for verifying import statement extraction from TypeScript/JavaScript files.
+ */
+
+import {createProject} from '@bfra.me/doc-sync/parsers'
+import {describe, expect, it} from 'vitest'
+
+import {
+  extractImports,
+  getPackageNameFromSpecifier,
+  getUniqueDependencies,
+  isRelativeImport,
+  isWorkspacePackageImport,
+  resolveRelativeImport,
+} from '../../src/parser/import-extractor'
+
+describe('import-extractor', () => {
+  describe('extractImports', () => {
+    it.concurrent('should extract static imports', () => {
+      const project = createProject()
+      const sourceFile = project.createSourceFile(
+        'test.ts',
+        `
+import {foo, bar} from 'some-package'
+import type {SomeType} from 'type-package'
+import defaultExport from 'default-pkg'
+import * as namespace from 'namespace-pkg'
+import './relative-module'
+import '@bfra.me/workspace-pkg'
+`.trim(),
+      )
+
+      const result = extractImports(sourceFile)
+
+      expect(result.imports).toHaveLength(6)
+      expect(result.externalDependencies).toContain('some-package')
+      expect(result.externalDependencies).toContain('type-package')
+      expect(result.externalDependencies).toContain('default-pkg')
+      expect(result.externalDependencies).toContain('namespace-pkg')
+      expect(result.relativeImports).toContain('./relative-module')
+      expect(result.workspaceDependencies).toContain('@bfra.me/workspace-pkg')
+    })
+
+    it.concurrent('should extract named imports', () => {
+      const project = createProject()
+      const sourceFile = project.createSourceFile(
+        'test.ts',
+        `import {foo, bar, baz} from 'package'`,
+      )
+
+      const result = extractImports(sourceFile)
+      const imp = result.imports[0]
+
+      expect(imp?.importedNames).toEqual(['foo', 'bar', 'baz'])
+    })
+
+    it.concurrent('should extract default imports', () => {
+      const project = createProject()
+      const sourceFile = project.createSourceFile('test.ts', `import React from 'react'`)
+
+      const result = extractImports(sourceFile)
+      const imp = result.imports[0]
+
+      expect(imp?.defaultImport).toBe('React')
+    })
+
+    it.concurrent('should extract namespace imports', () => {
+      const project = createProject()
+      const sourceFile = project.createSourceFile('test.ts', `import * as path from 'node:path'`)
+
+      const result = extractImports(sourceFile)
+      const imp = result.imports[0]
+
+      expect(imp?.namespaceImport).toBe('path')
+    })
+
+    it.concurrent('should identify type-only imports', () => {
+      const project = createProject()
+      const sourceFile = project.createSourceFile(
+        'test.ts',
+        `import type {SomeType} from 'types-pkg'`,
+      )
+
+      const result = extractImports(sourceFile)
+      const imp = result.imports[0]
+
+      expect(imp?.type).toBe('type-only')
+    })
+
+    it.concurrent('should identify side-effect only imports', () => {
+      const project = createProject()
+      const sourceFile = project.createSourceFile('test.ts', `import 'side-effect-module'`)
+
+      const result = extractImports(sourceFile)
+      const imp = result.imports[0]
+
+      expect(imp?.isSideEffectOnly).toBe(true)
+    })
+
+    it.concurrent('should extract dynamic imports', () => {
+      const project = createProject()
+      const sourceFile = project.createSourceFile(
+        'test.ts',
+        `
+const module = await import('dynamic-module')
+const lazy = import('./lazy-component')
+`.trim(),
+      )
+
+      const result = extractImports(sourceFile)
+      const dynamicImports = result.imports.filter(i => i.type === 'dynamic')
+
+      expect(dynamicImports).toHaveLength(2)
+      expect(dynamicImports[0]?.moduleSpecifier).toBe('dynamic-module')
+      expect(dynamicImports[1]?.moduleSpecifier).toBe('./lazy-component')
+    })
+
+    it.concurrent('should extract require() calls', () => {
+      const project = createProject()
+      const sourceFile = project.createSourceFile(
+        'test.ts',
+        `
+const fs = require('fs')
+const localModule = require('./local')
+`.trim(),
+      )
+
+      const result = extractImports(sourceFile)
+      const requireImports = result.imports.filter(i => i.type === 'require')
+
+      expect(requireImports).toHaveLength(2)
+    })
+
+    it.concurrent('should respect includeTypeImports option', () => {
+      const project = createProject()
+      const sourceFile = project.createSourceFile(
+        'test.ts',
+        `
+import type {TypeA} from 'types'
+import {value} from 'values'
+`.trim(),
+      )
+
+      const resultWithTypes = extractImports(sourceFile, {includeTypeImports: true})
+      const resultWithoutTypes = extractImports(sourceFile, {includeTypeImports: false})
+
+      expect(resultWithTypes.imports).toHaveLength(2)
+      expect(resultWithoutTypes.imports).toHaveLength(1)
+    })
+
+    it.concurrent('should respect includeDynamicImports option', () => {
+      const project = createProject()
+      const sourceFile = project.createSourceFile(
+        'test.ts',
+        `
+import {foo} from 'static'
+const bar = await import('dynamic')
+`.trim(),
+      )
+
+      const resultWithDynamic = extractImports(sourceFile, {includeDynamicImports: true})
+      const resultWithoutDynamic = extractImports(sourceFile, {includeDynamicImports: false})
+
+      expect(resultWithDynamic.imports).toHaveLength(2)
+      expect(resultWithoutDynamic.imports).toHaveLength(1)
+    })
+
+    it.concurrent('should respect includeRequireCalls option', () => {
+      const project = createProject()
+      const sourceFile = project.createSourceFile(
+        'test.ts',
+        `
+import {foo} from 'static'
+const bar = require('cjs-module')
+`.trim(),
+      )
+
+      const resultWithRequire = extractImports(sourceFile, {includeRequireCalls: true})
+      const resultWithoutRequire = extractImports(sourceFile, {includeRequireCalls: false})
+
+      expect(resultWithRequire.imports).toHaveLength(2)
+      expect(resultWithoutRequire.imports).toHaveLength(1)
+    })
+
+    it.concurrent('should include line and column information', () => {
+      const project = createProject()
+      const sourceFile = project.createSourceFile('test.ts', `import {foo} from 'package'`)
+
+      const result = extractImports(sourceFile)
+      const imp = result.imports[0]
+
+      expect(imp?.line).toBe(1)
+      expect(imp?.column).toBeGreaterThan(0)
+    })
+
+    it.concurrent('should support custom workspace prefixes', () => {
+      const project = createProject()
+      const sourceFile = project.createSourceFile(
+        'test.ts',
+        `
+import {a} from '@custom/pkg'
+import {b} from '@bfra.me/pkg'
+import {c} from 'external'
+`.trim(),
+      )
+
+      const result = extractImports(sourceFile, {
+        workspacePrefixes: ['@custom/', '@bfra.me/'],
+      })
+
+      expect(result.workspaceDependencies).toContain('@custom/pkg')
+      expect(result.workspaceDependencies).toContain('@bfra.me/pkg')
+      expect(result.externalDependencies).toContain('external')
+    })
+  })
+
+  describe('isRelativeImport', () => {
+    it.concurrent('should identify relative imports starting with ./', () => {
+      expect(isRelativeImport('./module')).toBe(true)
+      expect(isRelativeImport('./deep/path')).toBe(true)
+    })
+
+    it.concurrent('should identify relative imports starting with ../', () => {
+      expect(isRelativeImport('../parent')).toBe(true)
+      expect(isRelativeImport('../../grandparent')).toBe(true)
+    })
+
+    it.concurrent('should identify absolute path imports', () => {
+      expect(isRelativeImport('/absolute/path')).toBe(true)
+    })
+
+    it.concurrent('should identify non-relative imports', () => {
+      expect(isRelativeImport('lodash')).toBe(false)
+      expect(isRelativeImport('@scope/pkg')).toBe(false)
+      expect(isRelativeImport('node:fs')).toBe(false)
+    })
+  })
+
+  describe('isWorkspacePackageImport', () => {
+    it.concurrent('should identify workspace packages by prefix', () => {
+      expect(isWorkspacePackageImport('@bfra.me/es', ['@bfra.me/'])).toBe(true)
+      expect(isWorkspacePackageImport('@bfra.me/doc-sync', ['@bfra.me/'])).toBe(true)
+    })
+
+    it.concurrent('should not identify external packages as workspace packages', () => {
+      expect(isWorkspacePackageImport('lodash', ['@bfra.me/'])).toBe(false)
+      expect(isWorkspacePackageImport('@types/node', ['@bfra.me/'])).toBe(false)
+    })
+
+    it.concurrent('should support multiple workspace prefixes', () => {
+      expect(isWorkspacePackageImport('@custom/pkg', ['@bfra.me/', '@custom/'])).toBe(true)
+    })
+  })
+
+  describe('getPackageNameFromSpecifier', () => {
+    it.concurrent('should extract scoped package name', () => {
+      expect(getPackageNameFromSpecifier('@scope/pkg')).toBe('@scope/pkg')
+      expect(getPackageNameFromSpecifier('@scope/pkg/subpath')).toBe('@scope/pkg')
+      expect(getPackageNameFromSpecifier('@scope/pkg/deep/path')).toBe('@scope/pkg')
+    })
+
+    it.concurrent('should extract unscoped package name', () => {
+      expect(getPackageNameFromSpecifier('lodash')).toBe('lodash')
+      expect(getPackageNameFromSpecifier('lodash/fp')).toBe('lodash')
+      expect(getPackageNameFromSpecifier('lodash/collection/map')).toBe('lodash')
+    })
+
+    it.concurrent('should return relative imports unchanged', () => {
+      expect(getPackageNameFromSpecifier('./relative')).toBe('./relative')
+      expect(getPackageNameFromSpecifier('../parent')).toBe('../parent')
+    })
+  })
+
+  describe('resolveRelativeImport', () => {
+    it.concurrent('should resolve relative imports to absolute paths', () => {
+      const result = resolveRelativeImport('/workspace/src/index.ts', './utils')
+      expect(result).toContain('/workspace/src/utils')
+    })
+
+    it.concurrent('should resolve parent directory imports', () => {
+      const result = resolveRelativeImport('/workspace/src/deep/module.ts', '../helpers')
+      expect(result).toContain('/workspace/src/helpers')
+    })
+  })
+
+  describe('getUniqueDependencies', () => {
+    it.concurrent('should aggregate unique dependencies from multiple files', () => {
+      const results = [
+        {
+          imports: [],
+          filePath: '/a.ts',
+          externalDependencies: ['lodash', 'express'],
+          workspaceDependencies: ['@bfra.me/es'],
+          relativeImports: [],
+        },
+        {
+          imports: [],
+          filePath: '/b.ts',
+          externalDependencies: ['lodash', 'axios'],
+          workspaceDependencies: ['@bfra.me/es', '@bfra.me/doc-sync'],
+          relativeImports: [],
+        },
+      ]
+
+      const unique = getUniqueDependencies(results)
+
+      expect(unique.external).toEqual(['axios', 'express', 'lodash'])
+      expect(unique.workspace).toEqual(['@bfra.me/doc-sync', '@bfra.me/es'])
+    })
+
+    it.concurrent('should return sorted arrays', () => {
+      const results = [
+        {
+          imports: [],
+          filePath: '/test.ts',
+          externalDependencies: ['z-pkg', 'a-pkg', 'm-pkg'],
+          workspaceDependencies: ['@z/pkg', '@a/pkg'],
+          relativeImports: [],
+        },
+      ]
+
+      const unique = getUniqueDependencies(results)
+
+      expect(unique.external).toEqual(['a-pkg', 'm-pkg', 'z-pkg'])
+      expect(unique.workspace).toEqual(['@a/pkg', '@z/pkg'])
+    })
+  })
+})

--- a/packages/workspace-analyzer/test/scanner/workspace-scanner.test.ts
+++ b/packages/workspace-analyzer/test/scanner/workspace-scanner.test.ts
@@ -1,0 +1,374 @@
+/**
+ * Workspace scanner tests verifying package discovery and source file collection.
+ */
+
+import type {WorkspacePackage} from '../../src/scanner/workspace-scanner'
+
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+
+import {describe, expect, it} from 'vitest'
+
+import {
+  createWorkspaceScanner,
+  filterPackagesByPattern,
+  getPackageScope,
+  getUnscopedName,
+  groupPackagesByScope,
+} from '../../src/scanner/workspace-scanner'
+
+async function createTempDir(): Promise<string> {
+  return fs.mkdtemp(path.join(os.tmpdir(), 'workspace-analyzer-test-'))
+}
+
+async function cleanupTempDir(dir: string): Promise<void> {
+  await fs.rm(dir, {recursive: true, force: true})
+}
+
+async function createPackage(
+  name: string,
+  version: string,
+  baseDir: string,
+  options: {hasTsConfig?: boolean; hasEslint?: boolean; sourceFiles?: string[]} = {},
+): Promise<string> {
+  const packageDir = path.join(baseDir, 'packages', name.replace('@', '').replace('/', '-'))
+  await fs.mkdir(packageDir, {recursive: true})
+
+  await fs.writeFile(
+    path.join(packageDir, 'package.json'),
+    JSON.stringify({name, version}, null, 2),
+  )
+
+  if (options.hasTsConfig !== false) {
+    await fs.writeFile(
+      path.join(packageDir, 'tsconfig.json'),
+      JSON.stringify({compilerOptions: {target: 'ES2022'}}, null, 2),
+    )
+  }
+
+  if (options.hasEslint !== false) {
+    await fs.writeFile(path.join(packageDir, 'eslint.config.ts'), 'export default {}')
+  }
+
+  const srcDir = path.join(packageDir, 'src')
+  await fs.mkdir(srcDir, {recursive: true})
+
+  const files = options.sourceFiles ?? ['index.ts']
+  for (const file of files) {
+    const filePath = path.join(srcDir, file)
+    const fileDir = path.dirname(filePath)
+    await fs.mkdir(fileDir, {recursive: true})
+    await fs.writeFile(filePath, `// ${file}`)
+  }
+
+  return packageDir
+}
+
+describe('workspace-scanner', () => {
+  describe('createWorkspaceScanner', () => {
+    it('should discover packages in the workspace', async () => {
+      const tempDir = await createTempDir()
+      try {
+        await createPackage('@test/pkg-a', '1.0.0', tempDir)
+        await createPackage('@test/pkg-b', '2.0.0', tempDir)
+
+        const scanner = createWorkspaceScanner({rootDir: tempDir})
+        const result = await scanner.scan()
+
+        expect(result.packages).toHaveLength(2)
+        expect(result.errors).toHaveLength(0)
+        expect(result.workspacePath).toBe(tempDir)
+        expect(result.durationMs).toBeGreaterThanOrEqual(0)
+      } finally {
+        await cleanupTempDir(tempDir)
+      }
+    })
+
+    it('should collect source files from packages', async () => {
+      const tempDir = await createTempDir()
+      try {
+        await createPackage('@test/pkg', '1.0.0', tempDir, {
+          sourceFiles: ['index.ts', 'utils/helpers.ts', 'types.ts'],
+        })
+
+        const scanner = createWorkspaceScanner({rootDir: tempDir})
+        const result = await scanner.scan()
+
+        expect(result.packages).toHaveLength(1)
+        const pkg = result.packages[0] as WorkspacePackage
+        expect(pkg.sourceFiles).toHaveLength(3)
+      } finally {
+        await cleanupTempDir(tempDir)
+      }
+    })
+
+    it('should exclude specified packages', async () => {
+      const tempDir = await createTempDir()
+      try {
+        await createPackage('@test/include-me', '1.0.0', tempDir)
+        await createPackage('@test/exclude-me', '1.0.0', tempDir)
+
+        const scanner = createWorkspaceScanner({
+          rootDir: tempDir,
+          excludePackages: ['@test/exclude-me'],
+        })
+        const result = await scanner.scan()
+
+        expect(result.packages).toHaveLength(1)
+        expect(result.packages[0]?.name).toBe('@test/include-me')
+      } finally {
+        await cleanupTempDir(tempDir)
+      }
+    })
+
+    it('should detect tsconfig.json presence', async () => {
+      const tempDir = await createTempDir()
+      try {
+        await createPackage('@test/with-tsconfig', '1.0.0', tempDir, {hasTsConfig: true})
+        await createPackage('@test/without-tsconfig', '1.0.0', tempDir, {hasTsConfig: false})
+
+        const scanner = createWorkspaceScanner({rootDir: tempDir})
+        const result = await scanner.scan()
+
+        const withTsconfig = result.packages.find(p => p.name === '@test/with-tsconfig')
+        const withoutTsconfig = result.packages.find(p => p.name === '@test/without-tsconfig')
+
+        expect(withTsconfig?.hasTsConfig).toBe(true)
+        expect(withoutTsconfig?.hasTsConfig).toBe(false)
+      } finally {
+        await cleanupTempDir(tempDir)
+      }
+    })
+
+    it('should detect eslint config presence', async () => {
+      const tempDir = await createTempDir()
+      try {
+        await createPackage('@test/with-eslint', '1.0.0', tempDir, {hasEslint: true})
+        await createPackage('@test/without-eslint', '1.0.0', tempDir, {hasEslint: false})
+
+        const scanner = createWorkspaceScanner({rootDir: tempDir})
+        const result = await scanner.scan()
+
+        const withEslint = result.packages.find(p => p.name === '@test/with-eslint')
+        const withoutEslint = result.packages.find(p => p.name === '@test/without-eslint')
+
+        expect(withEslint?.hasEslintConfig).toBe(true)
+        expect(withoutEslint?.hasEslintConfig).toBe(false)
+      } finally {
+        await cleanupTempDir(tempDir)
+      }
+    })
+
+    it('should handle invalid package.json gracefully', async () => {
+      const tempDir = await createTempDir()
+      try {
+        await createPackage('@test/valid', '1.0.0', tempDir)
+
+        const invalidPkgDir = path.join(tempDir, 'packages', 'invalid')
+        await fs.mkdir(invalidPkgDir, {recursive: true})
+        await fs.writeFile(path.join(invalidPkgDir, 'package.json'), 'invalid json')
+
+        const scanner = createWorkspaceScanner({rootDir: tempDir})
+        const result = await scanner.scan()
+
+        expect(result.packages).toHaveLength(1)
+        expect(result.errors).toHaveLength(1)
+        expect(result.errors[0]?.code).toBe('INVALID_PACKAGE_JSON')
+      } finally {
+        await cleanupTempDir(tempDir)
+      }
+    })
+
+    it('should exclude test files from source collection', async () => {
+      const tempDir = await createTempDir()
+      try {
+        const pkgDir = await createPackage('@test/pkg', '1.0.0', tempDir, {
+          sourceFiles: ['index.ts', 'helper.ts'],
+        })
+
+        await fs.writeFile(path.join(pkgDir, 'src', 'index.test.ts'), '// test')
+        await fs.writeFile(path.join(pkgDir, 'src', 'helper.spec.ts'), '// spec')
+
+        const scanner = createWorkspaceScanner({rootDir: tempDir})
+        const result = await scanner.scan()
+
+        const pkg = result.packages[0] as WorkspacePackage
+        expect(pkg.sourceFiles.some(f => f.includes('.test.'))).toBe(false)
+        expect(pkg.sourceFiles.some(f => f.includes('.spec.'))).toBe(false)
+      } finally {
+        await cleanupTempDir(tempDir)
+      }
+    })
+
+    it('should support custom include patterns', async () => {
+      const tempDir = await createTempDir()
+      try {
+        const appsDir = path.join(tempDir, 'apps')
+        await fs.mkdir(path.join(appsDir, 'test-app', 'src'), {recursive: true})
+        await fs.writeFile(
+          path.join(appsDir, 'test-app', 'package.json'),
+          JSON.stringify({name: '@test/app', version: '1.0.0'}),
+        )
+        await fs.writeFile(path.join(appsDir, 'test-app', 'src', 'index.ts'), '// app')
+
+        const scanner = createWorkspaceScanner({
+          rootDir: tempDir,
+          includePatterns: ['apps/*'],
+        })
+        const result = await scanner.scan()
+
+        expect(result.packages).toHaveLength(1)
+        expect(result.packages[0]?.name).toBe('@test/app')
+      } finally {
+        await cleanupTempDir(tempDir)
+      }
+    })
+  })
+
+  describe('scanPackage', () => {
+    it('should scan a single package directory', async () => {
+      const tempDir = await createTempDir()
+      try {
+        const pkgDir = await createPackage('@test/single', '3.0.0', tempDir)
+
+        const scanner = createWorkspaceScanner({rootDir: tempDir})
+        const result = await scanner.scanPackage(pkgDir)
+
+        expect(result.success).toBe(true)
+        expect(result.success && result.data.name).toBe('@test/single')
+        expect(result.success && result.data.version).toBe('3.0.0')
+      } finally {
+        await cleanupTempDir(tempDir)
+      }
+    })
+
+    it('should return error for missing package.json', async () => {
+      const tempDir = await createTempDir()
+      try {
+        const emptyDir = path.join(tempDir, 'empty')
+        await fs.mkdir(emptyDir, {recursive: true})
+
+        const scanner = createWorkspaceScanner({rootDir: tempDir})
+        const result = await scanner.scanPackage(emptyDir)
+
+        expect(result.success).toBe(false)
+        expect(!result.success && result.error.code).toBe('READ_ERROR')
+      } finally {
+        await cleanupTempDir(tempDir)
+      }
+    })
+  })
+
+  describe('collectSourceFiles', () => {
+    it('should recursively collect source files', async () => {
+      const tempDir = await createTempDir()
+      try {
+        const pkgDir = await createPackage('@test/deep', '1.0.0', tempDir, {
+          sourceFiles: ['index.ts', 'utils/index.ts', 'utils/deep/nested.ts'],
+        })
+
+        const scanner = createWorkspaceScanner({rootDir: tempDir})
+        const files = await scanner.collectSourceFiles(path.join(pkgDir, 'src'))
+
+        expect(files).toHaveLength(3)
+      } finally {
+        await cleanupTempDir(tempDir)
+      }
+    })
+
+    it('should exclude node_modules directories', async () => {
+      const tempDir = await createTempDir()
+      try {
+        const pkgDir = await createPackage('@test/pkg', '1.0.0', tempDir)
+
+        const nodeModulesDir = path.join(pkgDir, 'src', 'node_modules')
+        await fs.mkdir(nodeModulesDir, {recursive: true})
+        await fs.writeFile(path.join(nodeModulesDir, 'some-dep.js'), '// dep')
+
+        const scanner = createWorkspaceScanner({rootDir: tempDir})
+        const files = await scanner.collectSourceFiles(path.join(pkgDir, 'src'))
+
+        expect(files.some(f => f.includes('node_modules'))).toBe(false)
+      } finally {
+        await cleanupTempDir(tempDir)
+      }
+    })
+  })
+
+  describe('helper functions', () => {
+    describe('filterPackagesByPattern', () => {
+      it.concurrent('should filter packages by name pattern', () => {
+        const packages: WorkspacePackage[] = [
+          createMockPackage('@scope/utils'),
+          createMockPackage('@scope/core'),
+          createMockPackage('@other/lib'),
+        ]
+
+        const filtered = filterPackagesByPattern(packages, '@scope/*')
+        expect(filtered).toHaveLength(2)
+      })
+
+      it.concurrent('should support case-insensitive matching', () => {
+        const packages: WorkspacePackage[] = [createMockPackage('@Scope/Utils')]
+
+        const filtered = filterPackagesByPattern(packages, '@scope/*')
+        expect(filtered).toHaveLength(1)
+      })
+    })
+
+    describe('groupPackagesByScope', () => {
+      it.concurrent('should group packages by npm scope', () => {
+        const packages: WorkspacePackage[] = [
+          createMockPackage('@scope-a/utils'),
+          createMockPackage('@scope-a/core'),
+          createMockPackage('@scope-b/lib'),
+          createMockPackage('unscoped'),
+        ]
+
+        const grouped = groupPackagesByScope(packages)
+
+        expect(grouped.get('@scope-a')).toHaveLength(2)
+        expect(grouped.get('@scope-b')).toHaveLength(1)
+        expect(grouped.get('__unscoped__')).toHaveLength(1)
+      })
+    })
+
+    describe('getPackageScope', () => {
+      it.concurrent('should extract scope from scoped package name', () => {
+        expect(getPackageScope('@scope/pkg')).toBe('@scope')
+        expect(getPackageScope('@bfra.me/utils')).toBe('@bfra.me')
+      })
+
+      it.concurrent('should return undefined for unscoped packages', () => {
+        expect(getPackageScope('lodash')).toBeUndefined()
+        expect(getPackageScope('express')).toBeUndefined()
+      })
+    })
+
+    describe('getUnscopedName', () => {
+      it.concurrent('should extract unscoped name from scoped package', () => {
+        expect(getUnscopedName('@scope/pkg')).toBe('pkg')
+        expect(getUnscopedName('@bfra.me/workspace-analyzer')).toBe('workspace-analyzer')
+      })
+
+      it.concurrent('should return name unchanged for unscoped packages', () => {
+        expect(getUnscopedName('lodash')).toBe('lodash')
+      })
+    })
+  })
+})
+
+function createMockPackage(name: string): WorkspacePackage {
+  return {
+    name,
+    version: '1.0.0',
+    packagePath: `/workspace/${name}`,
+    packageJsonPath: `/workspace/${name}/package.json`,
+    srcPath: `/workspace/${name}/src`,
+    packageJson: {name, version: '1.0.0'},
+    sourceFiles: [],
+    hasTsConfig: true,
+    hasEslintConfig: true,
+  }
+}

--- a/packages/workspace-analyzer/tsconfig.json
+++ b/packages/workspace-analyzer/tsconfig.json
@@ -3,6 +3,8 @@
   "extends": "../tsconfig/tsconfig.json",
   "compilerOptions": {
     "paths": {
+      "@bfra.me/doc-sync": ["../doc-sync/src"],
+      "@bfra.me/doc-sync/*": ["../doc-sync/src/*"],
       "@bfra.me/es": ["../es/src"],
       "@bfra.me/es/*": ["../es/src/*"]
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -400,6 +400,9 @@ importers:
 
   packages/workspace-analyzer:
     dependencies:
+      '@bfra.me/doc-sync':
+        specifier: workspace:*
+        version: link:../doc-sync
       '@bfra.me/es':
         specifier: workspace:*
         version: link:../es
@@ -412,16 +415,19 @@ importers:
       consola:
         specifier: 3.4.2
         version: 3.4.2
-      ts-morph:
-        specifier: 27.0.2
-        version: 27.0.2
     devDependencies:
       '@bfra.me/works':
         specifier: workspace:*
         version: link:../..
       memfs:
-        specifier: ^4.17.2
+        specifier: 4.51.1
         version: 4.51.1
+      ts-morph:
+        specifier: 27.0.2
+        version: 27.0.2
+      typescript:
+        specifier: 5.9.3
+        version: 5.9.3
 
   scripts:
     dependencies:


### PR DESCRIPTION
- Add dependency graph module for analyzing package dependencies.
- Introduce configuration parser for package.json and tsconfig.json.
- Implement import extractor for analyzing module dependencies.
- Create workspace scanner for discovering and analyzing packages.
- Update tsconfig to include paths for local packages.
- Modify pnpm-lock.yaml to link local dependencies.

Closes #2405.