### PR TITLE
feat(workspace-analyzer): add duplicate, peer, and unused dependency analyzers

### DIFF
--- a/.ai/plan/feature-workspace-analyzer-1.md
+++ b/.ai/plan/feature-workspace-analyzer-1.md
@@ -122,13 +122,13 @@ Create a new `@bfra.me/workspace-analyzer` package in the bfra.me/works monorepo
 
 | Task | Description | Completed | Date |
 |------|-------------|-----------|------|
-| TASK-028 | Implement `UnusedDependencyAnalyzer` in `src/analyzers/unused-dependency-analyzer.ts` using import extraction | | |
-| TASK-029 | Handle dynamic imports and require() calls in dependency detection | | |
-| TASK-030 | Implement dev vs production dependency classification | | |
-| TASK-031 | Implement `CircularImportAnalyzer` in `src/analyzers/circular-import-analyzer.ts` with Tarjan's algorithm | | |
-| TASK-032 | Generate cycle visualization data for reporting | | |
-| TASK-033 | Implement peer dependency validation for workspace packages | | |
-| TASK-034 | Add duplicate dependency detection across workspace packages | | |
+| TASK-028 | Implement `UnusedDependencyAnalyzer` in `src/analyzers/unused-dependency-analyzer.ts` using import extraction | ✅ | 2025-12-06 |
+| TASK-029 | Handle dynamic imports and require() calls in dependency detection | ✅ | 2025-12-06 |
+| TASK-030 | Implement dev vs production dependency classification | ✅ | 2025-12-06 |
+| TASK-031 | Implement `CircularImportAnalyzer` in `src/analyzers/circular-import-analyzer.ts` with Tarjan's algorithm | ✅ | 2025-12-06 |
+| TASK-032 | Generate cycle visualization data for reporting | ✅ | 2025-12-06 |
+| TASK-033 | Implement peer dependency validation for workspace packages | ✅ | 2025-12-06 |
+| TASK-034 | Add duplicate dependency detection across workspace packages | ✅ | 2025-12-06 |
 
 ### Implementation Phase 5: Architectural Analysis
 

--- a/packages/workspace-analyzer/src/analyzers/circular-import-analyzer.ts
+++ b/packages/workspace-analyzer/src/analyzers/circular-import-analyzer.ts
@@ -1,0 +1,463 @@
+/**
+ * CircularImportAnalyzer - Detects circular import chains in workspace packages.
+ *
+ * Uses the dependency graph builder and Tarjan's algorithm to identify
+ * circular dependencies, providing full path reporting and cycle visualization.
+ *
+ * Reports:
+ * - Direct cycles (A → B → A)
+ * - Transitive cycles (A → B → C → A)
+ * - Self-imports (A → A)
+ * - Cycle severity based on depth and involvement
+ */
+
+import type {DependencyCycle, DependencyGraph} from '../graph/dependency-graph'
+import type {ImportExtractionResult, ImportExtractorOptions} from '../parser/import-extractor'
+import type {WorkspacePackage} from '../scanner/workspace-scanner'
+import type {Issue, IssueLocation, Severity} from '../types/index'
+import type {Result} from '../types/result'
+import type {AnalysisContext, Analyzer, AnalyzerError, AnalyzerMetadata} from './analyzer'
+
+import path from 'node:path'
+
+import {createProject} from '@bfra.me/doc-sync/parsers'
+import {ok} from '@bfra.me/es/result'
+
+import {buildDependencyGraph, findCycles} from '../graph/dependency-graph'
+import {extractImports} from '../parser/import-extractor'
+import {createIssue, filterIssues} from './analyzer'
+
+/**
+ * Configuration options specific to CircularImportAnalyzer.
+ */
+export interface CircularImportAnalyzerOptions {
+  /** Maximum cycle length to report (helps avoid reporting very large cycles) */
+  readonly maxCycleLength?: number
+  /** Whether to include type-only imports in cycle detection */
+  readonly includeTypeImports?: boolean
+  /** Severity for direct (2-node) cycles */
+  readonly directCycleSeverity?: Severity
+  /** Severity for transitive cycles */
+  readonly transitiveCycleSeverity?: Severity
+  /** File patterns to exclude from analysis */
+  readonly excludePatterns?: readonly string[]
+  /** Workspace package prefixes */
+  readonly workspacePrefixes?: readonly string[]
+}
+
+const DEFAULT_OPTIONS: Required<CircularImportAnalyzerOptions> = {
+  maxCycleLength: 20,
+  includeTypeImports: false,
+  directCycleSeverity: 'error',
+  transitiveCycleSeverity: 'warning',
+  excludePatterns: ['**/*.test.ts', '**/*.spec.ts', '**/__tests__/**', '**/__mocks__/**'],
+  workspacePrefixes: ['@bfra.me/'],
+}
+
+export const circularImportAnalyzerMetadata: AnalyzerMetadata = {
+  id: 'circular-import',
+  name: 'Circular Import Analyzer',
+  description: 'Detects circular import chains using dependency graph analysis',
+  categories: ['circular-import'],
+  defaultSeverity: 'warning',
+}
+
+/**
+ * Creates a CircularImportAnalyzer instance.
+ *
+ * @example
+ * ```ts
+ * const analyzer = createCircularImportAnalyzer({
+ *   maxCycleLength: 10,
+ *   directCycleSeverity: 'error',
+ * })
+ * const result = await analyzer.analyze(context)
+ * ```
+ */
+export function createCircularImportAnalyzer(
+  options: CircularImportAnalyzerOptions = {},
+): Analyzer {
+  const resolvedOptions = {...DEFAULT_OPTIONS, ...options}
+
+  return {
+    metadata: circularImportAnalyzerMetadata,
+    analyze: async (context: AnalysisContext): Promise<Result<readonly Issue[], AnalyzerError>> => {
+      const issues: Issue[] = []
+
+      for (const pkg of context.packages) {
+        context.reportProgress?.(`Analyzing circular imports in ${pkg.name}...`)
+
+        const packageIssues = await analyzePackageCircularImports(
+          pkg,
+          context.workspacePath,
+          resolvedOptions,
+        )
+        issues.push(...packageIssues)
+      }
+
+      return ok(filterIssues(issues, context.config))
+    },
+  }
+}
+
+/**
+ * Visualization data for a detected cycle.
+ */
+export interface CycleVisualization {
+  /** Nodes in the cycle with display names */
+  readonly nodes: readonly CycleNode[]
+  /** Edges in the cycle */
+  readonly edges: readonly CycleEdge[]
+  /** ASCII art representation of the cycle */
+  readonly ascii: string
+  /** Mermaid diagram code for rendering */
+  readonly mermaid: string
+}
+
+/**
+ * A node in the cycle visualization.
+ */
+export interface CycleNode {
+  /** Unique identifier */
+  readonly id: string
+  /** Display name */
+  readonly name: string
+  /** Full file path */
+  readonly filePath: string
+  /** Whether this node starts the cycle */
+  readonly isStart: boolean
+}
+
+/**
+ * An edge in the cycle visualization.
+ */
+export interface CycleEdge {
+  /** Source node ID */
+  readonly from: string
+  /** Target node ID */
+  readonly to: string
+  /** Import type */
+  readonly importType: string
+}
+
+/**
+ * Analyzes a single package for circular imports.
+ */
+async function analyzePackageCircularImports(
+  pkg: WorkspacePackage,
+  workspacePath: string,
+  options: Required<CircularImportAnalyzerOptions>,
+): Promise<Issue[]> {
+  const issues: Issue[] = []
+
+  const sourceFiles = filterSourceFiles(pkg.sourceFiles, options.excludePatterns)
+  if (sourceFiles.length === 0) {
+    return issues
+  }
+
+  const importResults = await extractAllImports(sourceFiles, options)
+  if (importResults.length === 0) {
+    return issues
+  }
+
+  const graph = buildDependencyGraph(importResults, {
+    rootPath: workspacePath,
+    includeTypeImports: options.includeTypeImports,
+    resolveRelativeImports: true,
+  })
+
+  const cycles = findCycles(graph)
+
+  const filteredCycles = cycles.filter(cycle => cycle.nodes.length <= options.maxCycleLength)
+
+  const seenCycles = new Set<string>()
+  for (const cycle of filteredCycles) {
+    const cycleKey = normalizeCycleKey(cycle)
+    if (seenCycles.has(cycleKey)) {
+      continue
+    }
+    seenCycles.add(cycleKey)
+
+    const visualization = generateCycleVisualization(cycle, graph, workspacePath)
+    issues.push(createCycleIssue(pkg, cycle, visualization, options, workspacePath))
+  }
+
+  return issues
+}
+
+/**
+ * Filters source files based on exclude patterns.
+ */
+function filterSourceFiles(
+  sourceFiles: readonly string[],
+  excludePatterns: readonly string[],
+): string[] {
+  return sourceFiles.filter(filePath => {
+    const fileName = path.basename(filePath)
+    const relativePath = filePath
+
+    return !excludePatterns.some(pattern => {
+      if (pattern.includes('**')) {
+        const parts = pattern.split('**')
+        if (parts.length === 2 && parts[0] !== undefined && parts[1] !== undefined) {
+          const prefix = parts[0].replaceAll('/', '')
+          const suffix = parts[1].replaceAll('/', '')
+          return (
+            (prefix.length === 0 || relativePath.includes(prefix)) &&
+            (suffix.length === 0 || relativePath.endsWith(suffix))
+          )
+        }
+      }
+      return fileName.includes(pattern.replaceAll('*', '')) || relativePath.includes(pattern)
+    })
+  })
+}
+
+/**
+ * Extracts imports from all source files.
+ */
+async function extractAllImports(
+  sourceFiles: readonly string[],
+  options: Required<CircularImportAnalyzerOptions>,
+): Promise<ImportExtractionResult[]> {
+  const results: ImportExtractionResult[] = []
+  const project = createProject()
+
+  const extractorOptions: ImportExtractorOptions = {
+    workspacePrefixes: options.workspacePrefixes,
+    includeTypeImports: options.includeTypeImports,
+    includeDynamicImports: true,
+    includeRequireCalls: true,
+  }
+
+  for (const filePath of sourceFiles) {
+    try {
+      const sourceFile = project.addSourceFileAtPath(filePath)
+      const result = extractImports(sourceFile, extractorOptions)
+      results.push(result)
+    } catch {
+      // Skip files that can't be parsed
+    }
+  }
+
+  return results
+}
+
+/**
+ * Creates a normalized key for a cycle to detect duplicates.
+ * Sorts nodes to ensure A→B→C→A is considered the same as B→C→A→B.
+ */
+function normalizeCycleKey(cycle: DependencyCycle): string {
+  const sorted = [...cycle.nodes].sort()
+  return sorted.join('|')
+}
+
+/**
+ * Generates visualization data for a cycle.
+ */
+export function generateCycleVisualization(
+  cycle: DependencyCycle,
+  _graph: DependencyGraph,
+  workspacePath: string,
+): CycleVisualization {
+  const nodes: CycleNode[] = cycle.nodes.map((nodeId, index) => ({
+    id: nodeId,
+    name: getShortName(nodeId),
+    filePath: path.join(workspacePath, nodeId),
+    isStart: index === 0,
+  }))
+
+  const edges: CycleEdge[] = cycle.edges.map(edge => ({
+    from: edge.from,
+    to: edge.to,
+    importType: edge.type,
+  }))
+
+  const ascii = generateAsciiDiagram(cycle)
+  const mermaid = generateMermaidDiagram(nodes, edges)
+
+  return {nodes, edges, ascii, mermaid}
+}
+
+/**
+ * Gets a short display name for a node.
+ */
+function getShortName(nodeId: string): string {
+  const parts = nodeId.split('/')
+  return parts.at(-1) ?? nodeId
+}
+
+/**
+ * Generates an ASCII art diagram of the cycle.
+ */
+function generateAsciiDiagram(cycle: DependencyCycle): string {
+  const nodes = cycle.nodes
+  const lines: string[] = []
+
+  let isFirst = true
+  for (const node of nodes) {
+    const current = getShortName(node)
+
+    if (isFirst) {
+      lines.push(`┌─> ${current}`)
+      isFirst = false
+    } else {
+      lines.push(`│   ${current}`)
+    }
+    lines.push(`│     ↓`)
+  }
+
+  lines[lines.length - 1] = `└─────┘`
+
+  return lines.join('\n')
+}
+
+/**
+ * Generates a Mermaid diagram for the cycle.
+ */
+function generateMermaidDiagram(nodes: readonly CycleNode[], edges: readonly CycleEdge[]): string {
+  const lines: string[] = ['graph LR']
+
+  for (const node of nodes) {
+    const sanitizedId = node.id.replaceAll('/', '_').replaceAll('.', '_')
+    lines.push(`  ${sanitizedId}["${node.name}"]`)
+  }
+
+  for (const edge of edges) {
+    const fromId = edge.from.replaceAll('/', '_').replaceAll('.', '_')
+    const toId = edge.to.replaceAll('/', '_').replaceAll('.', '_')
+    lines.push(`  ${fromId} --> ${toId}`)
+  }
+
+  return lines.join('\n')
+}
+
+/**
+ * Creates an issue for a detected cycle.
+ */
+function createCycleIssue(
+  pkg: WorkspacePackage,
+  cycle: DependencyCycle,
+  visualization: CycleVisualization,
+  options: Required<CircularImportAnalyzerOptions>,
+  workspacePath: string,
+): Issue {
+  const cycleLength = cycle.nodes.length
+  const isDirectCycle = cycleLength === 2
+  const severity = isDirectCycle ? options.directCycleSeverity : options.transitiveCycleSeverity
+
+  const firstNode = cycle.nodes[0]
+  const location: IssueLocation = {
+    filePath: firstNode === undefined ? pkg.packagePath : path.join(workspacePath, firstNode),
+  }
+
+  const relatedLocations: IssueLocation[] = cycle.nodes.slice(1).map(nodeId => ({
+    filePath: path.join(workspacePath, nodeId),
+  }))
+
+  const cycleDescription =
+    cycleLength === 2
+      ? `Direct circular import between ${getShortName(cycle.nodes[0] ?? '')} and ${getShortName(cycle.nodes[1] ?? '')}`
+      : `Circular import chain of ${cycleLength} files`
+
+  return createIssue({
+    id: 'circular-import',
+    title: cycleDescription,
+    description: `Detected circular import: ${cycle.description}`,
+    severity,
+    category: 'circular-import',
+    location,
+    relatedLocations,
+    suggestion: generateFixSuggestion(cycle, cycleLength),
+    metadata: {
+      packageName: pkg.name,
+      cycleLength,
+      cycleNodes: cycle.nodes,
+      cycleDescription: cycle.description,
+      visualization: {
+        ascii: visualization.ascii,
+        mermaid: visualization.mermaid,
+      },
+    },
+  })
+}
+
+/**
+ * Generates a fix suggestion based on cycle characteristics.
+ */
+function generateFixSuggestion(_cycle: DependencyCycle, cycleLength: number): string {
+  if (cycleLength === 2) {
+    return 'Consider extracting shared types/interfaces to a separate module, or restructuring to break the bidirectional dependency'
+  }
+
+  if (cycleLength <= 4) {
+    return 'Identify the most general module in the cycle and ensure other modules depend on it, not vice versa'
+  }
+
+  return 'This is a complex circular dependency. Consider using dependency inversion, extracting interfaces, or restructuring the module hierarchy'
+}
+
+/**
+ * Statistics about circular imports in a package.
+ */
+export interface CircularImportStats {
+  /** Total number of cycles detected */
+  readonly totalCycles: number
+  /** Number of direct (2-node) cycles */
+  readonly directCycles: number
+  /** Number of transitive cycles */
+  readonly transitiveCycles: number
+  /** Files involved in cycles */
+  readonly affectedFiles: readonly string[]
+  /** Average cycle length */
+  readonly averageCycleLength: number
+  /** Maximum cycle length found */
+  readonly maxCycleLength: number
+}
+
+/**
+ * Computes statistics about detected cycles.
+ */
+export function computeCycleStats(cycles: readonly DependencyCycle[]): CircularImportStats {
+  if (cycles.length === 0) {
+    return {
+      totalCycles: 0,
+      directCycles: 0,
+      transitiveCycles: 0,
+      affectedFiles: [],
+      averageCycleLength: 0,
+      maxCycleLength: 0,
+    }
+  }
+
+  let directCycles = 0
+  let transitiveCycles = 0
+  let totalLength = 0
+  let maxLength = 0
+  const affectedFiles = new Set<string>()
+
+  for (const cycle of cycles) {
+    const length = cycle.nodes.length
+    totalLength += length
+    maxLength = Math.max(maxLength, length)
+
+    if (length === 2) {
+      directCycles++
+    } else {
+      transitiveCycles++
+    }
+
+    for (const node of cycle.nodes) {
+      affectedFiles.add(node)
+    }
+  }
+
+  return {
+    totalCycles: cycles.length,
+    directCycles,
+    transitiveCycles,
+    affectedFiles: [...affectedFiles].sort(),
+    averageCycleLength: totalLength / cycles.length,
+    maxCycleLength: maxLength,
+  }
+}

--- a/packages/workspace-analyzer/src/analyzers/duplicate-dependency-analyzer.ts
+++ b/packages/workspace-analyzer/src/analyzers/duplicate-dependency-analyzer.ts
@@ -1,0 +1,381 @@
+/**
+ * DuplicateDependencyAnalyzer - Detects duplicate and inconsistent dependencies across workspace packages.
+ *
+ * Identifies:
+ * - Same dependency with different versions across packages
+ * - Dependencies that could be hoisted to workspace root
+ * - Redundant devDependencies that match production dependencies
+ * - Version conflicts that may cause runtime issues
+ */
+
+import type {WorkspacePackage} from '../scanner/workspace-scanner'
+import type {Issue, IssueLocation, Severity} from '../types/index'
+import type {Result} from '../types/result'
+import type {AnalysisContext, Analyzer, AnalyzerError, AnalyzerMetadata} from './analyzer'
+
+import {ok} from '@bfra.me/es/result'
+
+import {createIssue, filterIssues} from './analyzer'
+
+/**
+ * Configuration options specific to DuplicateDependencyAnalyzer.
+ */
+export interface DuplicateDependencyAnalyzerOptions {
+  /** Ignore version differences for these packages */
+  readonly ignorePackages?: readonly string[]
+  /** Severity for version conflicts */
+  readonly conflictSeverity?: Severity
+  /** Whether to suggest hoisting common dependencies */
+  readonly suggestHoisting?: boolean
+  /** Minimum number of packages using a dependency to suggest hoisting */
+  readonly hoistingThreshold?: number
+  /** Check for redundant dev dependencies */
+  readonly checkRedundantDev?: boolean
+}
+
+const DEFAULT_OPTIONS: Required<DuplicateDependencyAnalyzerOptions> = {
+  ignorePackages: [],
+  conflictSeverity: 'warning',
+  suggestHoisting: true,
+  hoistingThreshold: 3,
+  checkRedundantDev: true,
+}
+
+export const duplicateDependencyAnalyzerMetadata: AnalyzerMetadata = {
+  id: 'duplicate-dependency',
+  name: 'Duplicate Dependency Analyzer',
+  description: 'Detects duplicate and version-inconsistent dependencies across workspace packages',
+  categories: ['dependency'],
+  defaultSeverity: 'warning',
+}
+
+/**
+ * Information about a dependency occurrence.
+ */
+interface DependencyOccurrence {
+  readonly packageName: string
+  readonly version: string
+  readonly type: 'dependencies' | 'devDependencies' | 'peerDependencies' | 'optionalDependencies'
+  readonly packageJsonPath: string
+}
+
+/**
+ * Aggregated dependency information across all packages.
+ */
+interface DependencyInfo {
+  readonly dependencyName: string
+  readonly occurrences: readonly DependencyOccurrence[]
+  readonly versions: readonly string[]
+  readonly hasConflict: boolean
+}
+
+/**
+ * Creates a DuplicateDependencyAnalyzer instance.
+ *
+ * @example
+ * ```ts
+ * const analyzer = createDuplicateDependencyAnalyzer({
+ *   conflictSeverity: 'error',
+ *   suggestHoisting: true,
+ * })
+ * const result = await analyzer.analyze(context)
+ * ```
+ */
+export function createDuplicateDependencyAnalyzer(
+  options: DuplicateDependencyAnalyzerOptions = {},
+): Analyzer {
+  const resolvedOptions = {...DEFAULT_OPTIONS, ...options}
+
+  return {
+    metadata: duplicateDependencyAnalyzerMetadata,
+    analyze: async (context: AnalysisContext): Promise<Result<readonly Issue[], AnalyzerError>> => {
+      const issues: Issue[] = []
+
+      context.reportProgress?.('Collecting dependency information across workspace...')
+
+      const dependencyMap = collectDependencies(context.packages)
+
+      context.reportProgress?.('Analyzing for duplicates and conflicts...')
+
+      // Check for version conflicts
+      for (const [depName, info] of dependencyMap) {
+        if (isIgnored(depName, resolvedOptions.ignorePackages)) {
+          continue
+        }
+
+        if (info.hasConflict) {
+          issues.push(createVersionConflictIssue(info, resolvedOptions))
+        }
+
+        // Suggest hoisting if same version used in multiple packages
+        if (
+          resolvedOptions.suggestHoisting &&
+          info.occurrences.length >= resolvedOptions.hoistingThreshold &&
+          !info.hasConflict
+        ) {
+          issues.push(createHoistingSuggestion(info, resolvedOptions))
+        }
+      }
+
+      // Check for redundant dev dependencies
+      if (resolvedOptions.checkRedundantDev) {
+        for (const pkg of context.packages) {
+          issues.push(...checkRedundantDevDependencies(pkg))
+        }
+      }
+
+      return ok(filterIssues(issues, context.config))
+    },
+  }
+}
+
+/**
+ * Collects all dependencies from all packages into a unified map.
+ */
+function collectDependencies(packages: readonly WorkspacePackage[]): Map<string, DependencyInfo> {
+  const depMap = new Map<string, DependencyOccurrence[]>()
+
+  for (const pkg of packages) {
+    const pkgJson = pkg.packageJson
+
+    collectFromObject(depMap, pkg, pkgJson.dependencies, 'dependencies')
+    collectFromObject(depMap, pkg, pkgJson.devDependencies, 'devDependencies')
+    collectFromObject(depMap, pkg, pkgJson.peerDependencies, 'peerDependencies')
+    collectFromObject(depMap, pkg, pkgJson.optionalDependencies, 'optionalDependencies')
+  }
+
+  const result = new Map<string, DependencyInfo>()
+
+  for (const [depName, occurrences] of depMap) {
+    const versions = [...new Set(occurrences.map(o => normalizeVersion(o.version)))].sort()
+    const hasConflict = versions.length > 1
+
+    result.set(depName, {
+      dependencyName: depName,
+      occurrences,
+      versions,
+      hasConflict,
+    })
+  }
+
+  return result
+}
+
+/**
+ * Collects dependencies from a dependency object.
+ */
+function collectFromObject(
+  depMap: Map<string, DependencyOccurrence[]>,
+  pkg: WorkspacePackage,
+  deps: Readonly<Record<string, string>> | undefined,
+  type: DependencyOccurrence['type'],
+): void {
+  if (deps === undefined) {
+    return
+  }
+
+  for (const [depName, version] of Object.entries(deps)) {
+    const occurrence: DependencyOccurrence = {
+      packageName: pkg.name,
+      version,
+      type,
+      packageJsonPath: pkg.packageJsonPath,
+    }
+
+    const existing = depMap.get(depName)
+    if (existing === undefined) {
+      depMap.set(depName, [occurrence])
+    } else {
+      existing.push(occurrence)
+    }
+  }
+}
+
+/**
+ * Normalizes a version string for comparison.
+ * Removes workspace: prefix and leading ^ or ~ for basic comparison.
+ */
+function normalizeVersion(version: string): string {
+  let normalized = version
+
+  // Handle workspace protocol
+  if (normalized.startsWith('workspace:')) {
+    normalized = normalized.slice('workspace:'.length)
+  }
+
+  // Keep the original if it's a range operator we want to compare
+  // Only normalize simple prefixes for exact matching
+  if (normalized.startsWith('^') || normalized.startsWith('~')) {
+    return normalized
+  }
+
+  return normalized
+}
+
+/**
+ * Checks if a dependency should be ignored.
+ */
+function isIgnored(depName: string, ignorePackages: readonly string[]): boolean {
+  return ignorePackages.some(pattern => {
+    if (pattern.includes('*')) {
+      const regex = new RegExp(`^${pattern.replaceAll('*', '.*')}$`)
+      return regex.test(depName)
+    }
+    return depName === pattern
+  })
+}
+
+/**
+ * Creates an issue for a version conflict.
+ */
+function createVersionConflictIssue(
+  info: DependencyInfo,
+  options: Required<DuplicateDependencyAnalyzerOptions>,
+): Issue {
+  const firstOccurrence = info.occurrences[0]
+  const location: IssueLocation = {
+    filePath: firstOccurrence?.packageJsonPath ?? '',
+  }
+
+  const relatedLocations: IssueLocation[] = info.occurrences.slice(1).map(o => ({
+    filePath: o.packageJsonPath,
+  }))
+
+  const versionList = info.occurrences
+    .map(o => `  - ${o.packageName}: ${o.version} (${o.type})`)
+    .join('\n')
+
+  return createIssue({
+    id: 'version-conflict',
+    title: `Version conflict: ${info.dependencyName}`,
+    description: `Dependency "${info.dependencyName}" has ${info.versions.length} different versions across packages:\n${versionList}`,
+    severity: options.conflictSeverity,
+    category: 'dependency',
+    location,
+    relatedLocations,
+    suggestion: `Align all packages to use the same version of "${info.dependencyName}" to avoid potential runtime issues`,
+    metadata: {
+      dependencyName: info.dependencyName,
+      versions: info.versions,
+      packages: info.occurrences.map(o => o.packageName),
+    },
+  })
+}
+
+/**
+ * Creates a suggestion to hoist a dependency.
+ */
+function createHoistingSuggestion(
+  info: DependencyInfo,
+  _options: Required<DuplicateDependencyAnalyzerOptions>,
+): Issue {
+  const firstOccurrence = info.occurrences[0]
+  const location: IssueLocation = {
+    filePath: firstOccurrence?.packageJsonPath ?? '',
+  }
+
+  const packageCount = info.occurrences.length
+  const packageNames = info.occurrences.map(o => o.packageName).join(', ')
+
+  return createIssue({
+    id: 'hoisting-candidate',
+    title: `Hoisting candidate: ${info.dependencyName}`,
+    description: `Dependency "${info.dependencyName}" is used in ${packageCount} packages (${packageNames}) with the same version`,
+    severity: 'info',
+    category: 'dependency',
+    location,
+    suggestion: `Consider hoisting "${info.dependencyName}" to the workspace root package.json to reduce duplication`,
+    metadata: {
+      dependencyName: info.dependencyName,
+      version: info.versions[0],
+      packageCount,
+      packages: info.occurrences.map(o => o.packageName),
+    },
+  })
+}
+
+/**
+ * Checks for redundant dev dependencies (same package in both deps and devDeps).
+ */
+function checkRedundantDevDependencies(pkg: WorkspacePackage): Issue[] {
+  const issues: Issue[] = []
+  const pkgJson = pkg.packageJson
+
+  if (pkgJson.dependencies === undefined || pkgJson.devDependencies === undefined) {
+    return issues
+  }
+
+  for (const [depName, devVersion] of Object.entries(pkgJson.devDependencies)) {
+    if (depName in pkgJson.dependencies) {
+      const prodVersion = pkgJson.dependencies[depName]
+
+      issues.push(
+        createIssue({
+          id: 'redundant-dev-dependency',
+          title: `Redundant dev dependency: ${depName}`,
+          description: `Package "${pkg.name}" has "${depName}" in both dependencies (${prodVersion}) and devDependencies (${devVersion})`,
+          severity: 'info',
+          category: 'dependency',
+          location: {filePath: pkg.packageJsonPath},
+          suggestion: `Remove "${depName}" from devDependencies as it's already in dependencies`,
+          metadata: {
+            packageName: pkg.name,
+            dependencyName: depName,
+            prodVersion,
+            devVersion,
+          },
+        }),
+      )
+    }
+  }
+
+  return issues
+}
+
+/**
+ * Aggregates duplicate dependency statistics.
+ */
+export interface DuplicateDependencyStats {
+  /** Total unique dependencies across workspace */
+  readonly totalUniqueDependencies: number
+  /** Number of dependencies with version conflicts */
+  readonly conflictingDependencies: number
+  /** Number of packages with redundant dev dependencies */
+  readonly packagesWithRedundantDev: number
+  /** Dependencies appearing in most packages */
+  readonly mostCommon: readonly {readonly name: string; readonly count: number}[]
+  /** Dependencies with the most version variants */
+  readonly mostVariants: readonly {readonly name: string; readonly versionCount: number}[]
+}
+
+/**
+ * Computes statistics about dependency duplicates.
+ */
+export function computeDuplicateStats(
+  dependencyMap: ReadonlyMap<string, DependencyInfo>,
+  topN = 10,
+): DuplicateDependencyStats {
+  let conflictingDependencies = 0
+  const commonDeps: {name: string; count: number}[] = []
+  const variantDeps: {name: string; versionCount: number}[] = []
+
+  for (const [name, info] of dependencyMap) {
+    if (info.hasConflict) {
+      conflictingDependencies++
+    }
+
+    commonDeps.push({name, count: info.occurrences.length})
+    variantDeps.push({name, versionCount: info.versions.length})
+  }
+
+  commonDeps.sort((a, b) => b.count - a.count)
+  variantDeps.sort((a, b) => b.versionCount - a.versionCount)
+
+  return {
+    totalUniqueDependencies: dependencyMap.size,
+    conflictingDependencies,
+    packagesWithRedundantDev: 0, // Computed separately per-package
+    mostCommon: commonDeps.slice(0, topN),
+    mostVariants: variantDeps.filter(d => d.versionCount > 1).slice(0, topN),
+  }
+}

--- a/packages/workspace-analyzer/src/analyzers/peer-dependency-analyzer.ts
+++ b/packages/workspace-analyzer/src/analyzers/peer-dependency-analyzer.ts
@@ -1,0 +1,273 @@
+/**
+ * PeerDependencyAnalyzer - Validates peer dependency declarations in workspace packages.
+ *
+ * Ensures workspace packages correctly declare peer dependencies for:
+ * - Packages that should be provided by consumers
+ * - Plugin architectures where host version matters
+ * - Framework dependencies that consumers must provide
+ *
+ * Reports:
+ * - Missing peer dependency declarations
+ * - Peer dependency version mismatches
+ * - Invalid peer dependency ranges
+ * - Workspace packages not declared as peers when they should be
+ */
+
+import type {WorkspacePackage} from '../scanner/workspace-scanner'
+import type {Issue, IssueLocation} from '../types/index'
+import type {Result} from '../types/result'
+import type {AnalysisContext, Analyzer, AnalyzerError, AnalyzerMetadata} from './analyzer'
+
+import {ok} from '@bfra.me/es/result'
+
+import {createIssue, filterIssues} from './analyzer'
+
+/**
+ * Configuration options specific to PeerDependencyAnalyzer.
+ */
+export interface PeerDependencyAnalyzerOptions {
+  /** Packages that should always be declared as peer dependencies */
+  readonly requiredPeers?: readonly string[]
+  /** Packages that should never be peer dependencies */
+  readonly disallowedPeers?: readonly string[]
+  /** Whether to check for workspace packages that should be peers */
+  readonly checkWorkspacePeers?: boolean
+  /** Workspace package prefixes */
+  readonly workspacePrefixes?: readonly string[]
+  /** Check for peer dependencies that are also in dependencies (dual declaration) */
+  readonly checkDualDeclarations?: boolean
+}
+
+const DEFAULT_OPTIONS: Required<PeerDependencyAnalyzerOptions> = {
+  requiredPeers: [],
+  disallowedPeers: [],
+  checkWorkspacePeers: true,
+  workspacePrefixes: ['@bfra.me/'],
+  checkDualDeclarations: true,
+}
+
+export const peerDependencyAnalyzerMetadata: AnalyzerMetadata = {
+  id: 'peer-dependency',
+  name: 'Peer Dependency Analyzer',
+  description: 'Validates peer dependency declarations for proper package consumption',
+  categories: ['dependency'],
+  defaultSeverity: 'warning',
+}
+
+/**
+ * Creates a PeerDependencyAnalyzer instance.
+ *
+ * @example
+ * ```ts
+ * const analyzer = createPeerDependencyAnalyzer({
+ *   requiredPeers: ['react', 'typescript'],
+ *   checkDualDeclarations: true,
+ * })
+ * const result = await analyzer.analyze(context)
+ * ```
+ */
+export function createPeerDependencyAnalyzer(
+  options: PeerDependencyAnalyzerOptions = {},
+): Analyzer {
+  const resolvedOptions = {...DEFAULT_OPTIONS, ...options}
+
+  return {
+    metadata: peerDependencyAnalyzerMetadata,
+    analyze: async (context: AnalysisContext): Promise<Result<readonly Issue[], AnalyzerError>> => {
+      const issues: Issue[] = []
+
+      const workspacePackageNames = new Set(context.packages.map(pkg => pkg.name))
+
+      for (const pkg of context.packages) {
+        context.reportProgress?.(`Analyzing peer dependencies for ${pkg.name}...`)
+
+        const packageIssues = analyzePackagePeerDependencies(
+          pkg,
+          workspacePackageNames,
+          resolvedOptions,
+        )
+        issues.push(...packageIssues)
+      }
+
+      return ok(filterIssues(issues, context.config))
+    },
+  }
+}
+
+/**
+ * Analyzes peer dependencies for a single package.
+ */
+function analyzePackagePeerDependencies(
+  pkg: WorkspacePackage,
+  workspacePackageNames: Set<string>,
+  options: Required<PeerDependencyAnalyzerOptions>,
+): Issue[] {
+  const issues: Issue[] = []
+  const pkgJson = pkg.packageJson
+
+  const dependencies = pkgJson.dependencies ?? {}
+  const peerDependencies = pkgJson.peerDependencies ?? {}
+  const devDependencies = pkgJson.devDependencies ?? {}
+
+  // Check for required peer dependencies that are missing
+  for (const requiredPeer of options.requiredPeers) {
+    const isDep = requiredPeer in dependencies
+    const isDevDep = requiredPeer in devDependencies
+    const isPeer = requiredPeer in peerDependencies
+
+    if ((isDep || isDevDep) && !isPeer) {
+      issues.push(
+        createIssue({
+          id: 'missing-peer-declaration',
+          title: `Missing peer dependency: ${requiredPeer}`,
+          description: `Package "${pkg.name}" uses "${requiredPeer}" but does not declare it as a peer dependency`,
+          severity: 'warning',
+          category: 'dependency',
+          location: createLocation(pkg),
+          suggestion: `Add "${requiredPeer}" to peerDependencies with an appropriate version range`,
+          metadata: {
+            packageName: pkg.name,
+            missingPeer: requiredPeer,
+          },
+        }),
+      )
+    }
+  }
+
+  // Check for disallowed peer dependencies
+  for (const disallowed of options.disallowedPeers) {
+    if (disallowed in peerDependencies) {
+      issues.push(
+        createIssue({
+          id: 'disallowed-peer-dependency',
+          title: `Disallowed peer dependency: ${disallowed}`,
+          description: `Package "${pkg.name}" should not declare "${disallowed}" as a peer dependency`,
+          severity: 'error',
+          category: 'dependency',
+          location: createLocation(pkg),
+          suggestion: `Remove "${disallowed}" from peerDependencies`,
+          metadata: {
+            packageName: pkg.name,
+            disallowedPeer: disallowed,
+          },
+        }),
+      )
+    }
+  }
+
+  // Check for dual declarations (dependency + peer dependency)
+  if (options.checkDualDeclarations) {
+    for (const peerName of Object.keys(peerDependencies)) {
+      if (peerName in dependencies) {
+        issues.push(
+          createIssue({
+            id: 'dual-dependency-declaration',
+            title: `Dual declaration: ${peerName}`,
+            description: `Package "${pkg.name}" declares "${peerName}" in both dependencies and peerDependencies`,
+            severity: 'info',
+            category: 'dependency',
+            location: createLocation(pkg),
+            suggestion: `Remove "${peerName}" from dependencies if consumers should provide it, or from peerDependencies if you bundle it`,
+            metadata: {
+              packageName: pkg.name,
+              dualDependency: peerName,
+              dependencyVersion: dependencies[peerName],
+              peerVersion: peerDependencies[peerName],
+            },
+          }),
+        )
+      }
+    }
+  }
+
+  // Check workspace packages used as dependencies that might need to be peers
+  if (options.checkWorkspacePeers) {
+    for (const [depName, depVersion] of Object.entries(dependencies)) {
+      const isWorkspaceDep =
+        workspacePackageNames.has(depName) ||
+        options.workspacePrefixes.some(prefix => depName.startsWith(prefix))
+      const isWorkspaceVersion = depVersion.startsWith('workspace:')
+      const isPeer = depName in peerDependencies
+
+      // Workspace dependencies with non-workspace versions might indicate a peer dep need
+      if (isWorkspaceDep && !isWorkspaceVersion && !isPeer) {
+        issues.push(
+          createIssue({
+            id: 'workspace-peer-candidate',
+            title: `Workspace package should be peer: ${depName}`,
+            description: `Package "${pkg.name}" uses workspace package "${depName}" with version "${depVersion}" instead of workspace: protocol`,
+            severity: 'info',
+            category: 'dependency',
+            location: createLocation(pkg),
+            suggestion: `Consider using "workspace:*" for internal packages or declaring as peerDependency if consumers should provide it`,
+            metadata: {
+              packageName: pkg.name,
+              dependencyName: depName,
+              currentVersion: depVersion,
+            },
+          }),
+        )
+      }
+    }
+  }
+
+  // Check peer dependency version ranges for validity
+  for (const [peerName, peerVersion] of Object.entries(peerDependencies)) {
+    if (!isValidVersionRange(peerVersion)) {
+      issues.push(
+        createIssue({
+          id: 'invalid-peer-version',
+          title: `Invalid peer version range: ${peerName}`,
+          description: `Package "${pkg.name}" has an invalid version range "${peerVersion}" for peer dependency "${peerName}"`,
+          severity: 'error',
+          category: 'dependency',
+          location: createLocation(pkg),
+          suggestion: `Use a valid semver range like ">=1.0.0", "^2.0.0", or ">=1.0.0 <3.0.0"`,
+          metadata: {
+            packageName: pkg.name,
+            peerName,
+            invalidVersion: peerVersion,
+          },
+        }),
+      )
+    }
+  }
+
+  return issues
+}
+
+/**
+ * Creates a location pointing to the package.json file.
+ */
+function createLocation(pkg: WorkspacePackage): IssueLocation {
+  return {
+    filePath: pkg.packageJsonPath,
+  }
+}
+
+/**
+ * Basic validation for semver version ranges.
+ */
+function isValidVersionRange(version: string): boolean {
+  if (version.length === 0) {
+    return false
+  }
+
+  // workspace: protocol is valid
+  if (version.startsWith('workspace:')) {
+    return true
+  }
+
+  // Common invalid patterns
+  if (version === 'latest' || version === '*' || version === '') {
+    return false
+  }
+
+  // Basic semver-like patterns (use non-capturing groups for validation only)
+  const semverPattern =
+    /^[\^~>=<]?\d+(?:\.\d+)?(?:\.\d+)?(?:-[\w.]+)?(?:\+[\w.]+)?(?:\s*(?:&&|\|\|)\s*[\^~>=<]?\d+(?:\.\d+)?(?:\.\d+)?(?:-[\w.]+)?(?:\+[\w.]+)?)*$/
+  const rangePattern = /^>=?\d+(?:\.\d+)?(?:\.\d+)?\s+<?=?\d+(?:\.\d+)?(?:\.\d+)?$/
+  const xRangePattern = /^\d+(?:\.\d+)?\.x$/
+
+  return semverPattern.test(version) || rangePattern.test(version) || xRangePattern.test(version)
+}

--- a/packages/workspace-analyzer/src/analyzers/unused-dependency-analyzer.ts
+++ b/packages/workspace-analyzer/src/analyzers/unused-dependency-analyzer.ts
@@ -1,0 +1,356 @@
+/**
+ * UnusedDependencyAnalyzer - Detects unused dependencies in workspace packages.
+ *
+ * Compares declared dependencies in package.json against actual imports
+ * found in source files to identify unused packages that can be removed.
+ *
+ * Handles:
+ * - Static imports (import { x } from 'pkg')
+ * - Dynamic imports (await import('pkg'))
+ * - require() calls (const x = require('pkg'))
+ * - Type-only imports (import type { T } from 'pkg')
+ * - Dev vs production dependency classification
+ */
+
+import type {ImportExtractionResult, ImportExtractorOptions} from '../parser/import-extractor'
+import type {WorkspacePackage} from '../scanner/workspace-scanner'
+import type {Issue, IssueLocation} from '../types/index'
+import type {Result} from '../types/result'
+import type {AnalysisContext, Analyzer, AnalyzerError, AnalyzerMetadata} from './analyzer'
+
+import {createProject} from '@bfra.me/doc-sync/parsers'
+import {ok} from '@bfra.me/es/result'
+
+import {extractImports, getPackageNameFromSpecifier} from '../parser/import-extractor'
+import {createIssue, filterIssues} from './analyzer'
+
+/**
+ * Configuration options specific to UnusedDependencyAnalyzer.
+ */
+export interface UnusedDependencyAnalyzerOptions {
+  /** Include devDependencies in analysis */
+  readonly checkDevDependencies?: boolean
+  /** Include peerDependencies in analysis */
+  readonly checkPeerDependencies?: boolean
+  /** Include optionalDependencies in analysis */
+  readonly checkOptionalDependencies?: boolean
+  /** Package names to ignore (regex patterns) */
+  readonly ignorePatterns?: readonly string[]
+  /** Packages known to be used implicitly (e.g., type packages, build tools) */
+  readonly implicitlyUsed?: readonly string[]
+  /** Workspace package prefixes for identifying workspace dependencies */
+  readonly workspacePrefixes?: readonly string[]
+}
+
+const DEFAULT_OPTIONS: Required<UnusedDependencyAnalyzerOptions> = {
+  checkDevDependencies: true,
+  checkPeerDependencies: false,
+  checkOptionalDependencies: false,
+  ignorePatterns: [],
+  implicitlyUsed: [
+    // Common packages that are used implicitly or at build time
+    'typescript',
+    '@types/*',
+    'eslint',
+    'prettier',
+    'vitest',
+    '@vitest/*',
+    'tsup',
+    'vite',
+    '@vitejs/*',
+  ],
+  workspacePrefixes: ['@bfra.me/'],
+}
+
+export const unusedDependencyAnalyzerMetadata: AnalyzerMetadata = {
+  id: 'unused-dependency',
+  name: 'Unused Dependency Analyzer',
+  description: 'Detects dependencies declared in package.json that are not imported in source code',
+  categories: ['dependency'],
+  defaultSeverity: 'warning',
+}
+
+/**
+ * Creates an UnusedDependencyAnalyzer instance.
+ *
+ * @example
+ * ```ts
+ * const analyzer = createUnusedDependencyAnalyzer({
+ *   checkDevDependencies: true,
+ *   ignorePatterns: ['@types/*'],
+ * })
+ * const result = await analyzer.analyze(context)
+ * ```
+ */
+export function createUnusedDependencyAnalyzer(
+  options: UnusedDependencyAnalyzerOptions = {},
+): Analyzer {
+  const resolvedOptions = {...DEFAULT_OPTIONS, ...options}
+
+  return {
+    metadata: unusedDependencyAnalyzerMetadata,
+    analyze: async (context: AnalysisContext): Promise<Result<readonly Issue[], AnalyzerError>> => {
+      const issues: Issue[] = []
+
+      for (const pkg of context.packages) {
+        context.reportProgress?.(`Analyzing dependencies for ${pkg.name}...`)
+
+        const packageIssues = await analyzePackageDependencies(pkg, resolvedOptions)
+        issues.push(...packageIssues)
+      }
+
+      return ok(filterIssues(issues, context.config))
+    },
+  }
+}
+
+/**
+ * Dependency classification for proper issue severity and messaging.
+ */
+type DependencyType =
+  | 'dependencies'
+  | 'devDependencies'
+  | 'peerDependencies'
+  | 'optionalDependencies'
+
+interface DeclaredDependency {
+  readonly name: string
+  readonly version: string
+  readonly type: DependencyType
+}
+
+/**
+ * Analyzes a single package for unused dependencies.
+ */
+async function analyzePackageDependencies(
+  pkg: WorkspacePackage,
+  options: Required<UnusedDependencyAnalyzerOptions>,
+): Promise<Issue[]> {
+  const issues: Issue[] = []
+
+  const declaredDeps = collectDeclaredDependencies(pkg, options)
+  if (declaredDeps.length === 0) {
+    return issues
+  }
+
+  const usedPackages = await collectUsedPackages(pkg, options)
+
+  for (const dep of declaredDeps) {
+    if (isIgnored(dep.name, options)) {
+      continue
+    }
+
+    if (isImplicitlyUsed(dep.name, options.implicitlyUsed)) {
+      continue
+    }
+
+    if (!usedPackages.has(dep.name)) {
+      issues.push(createUnusedDependencyIssue(pkg, dep))
+    }
+  }
+
+  return issues
+}
+
+/**
+ * Collects all declared dependencies from package.json based on configuration.
+ */
+function collectDeclaredDependencies(
+  pkg: WorkspacePackage,
+  options: Required<UnusedDependencyAnalyzerOptions>,
+): DeclaredDependency[] {
+  const deps: DeclaredDependency[] = []
+  const pkgJson = pkg.packageJson
+
+  // Always check production dependencies
+  if (pkgJson.dependencies !== undefined) {
+    for (const [name, version] of Object.entries(pkgJson.dependencies)) {
+      deps.push({name, version, type: 'dependencies'})
+    }
+  }
+
+  if (options.checkDevDependencies && pkgJson.devDependencies !== undefined) {
+    for (const [name, version] of Object.entries(pkgJson.devDependencies)) {
+      deps.push({name, version, type: 'devDependencies'})
+    }
+  }
+
+  if (options.checkPeerDependencies && pkgJson.peerDependencies !== undefined) {
+    for (const [name, version] of Object.entries(pkgJson.peerDependencies)) {
+      deps.push({name, version, type: 'peerDependencies'})
+    }
+  }
+
+  if (options.checkOptionalDependencies && pkgJson.optionalDependencies !== undefined) {
+    for (const [name, version] of Object.entries(pkgJson.optionalDependencies)) {
+      deps.push({name, version, type: 'optionalDependencies'})
+    }
+  }
+
+  return deps
+}
+
+/**
+ * Collects all packages actually used in source files.
+ */
+async function collectUsedPackages(
+  pkg: WorkspacePackage,
+  options: Required<UnusedDependencyAnalyzerOptions>,
+): Promise<Set<string>> {
+  const usedPackages = new Set<string>()
+
+  if (pkg.sourceFiles.length === 0) {
+    return usedPackages
+  }
+
+  const project = createProject()
+
+  const extractorOptions: ImportExtractorOptions = {
+    workspacePrefixes: options.workspacePrefixes,
+    includeTypeImports: true,
+    includeDynamicImports: true,
+    includeRequireCalls: true,
+  }
+
+  for (const filePath of pkg.sourceFiles) {
+    try {
+      const sourceFile = project.addSourceFileAtPath(filePath)
+      const result = extractImports(sourceFile, extractorOptions)
+
+      for (const imp of result.imports) {
+        const packageName = getPackageNameFromSpecifier(imp.moduleSpecifier)
+        if (!isRelativeSpecifier(imp.moduleSpecifier)) {
+          usedPackages.add(packageName)
+        }
+      }
+    } catch {
+      // Skip files that can't be parsed (may be invalid syntax or not TypeScript)
+    }
+  }
+
+  return usedPackages
+}
+
+/**
+ * Checks if a module specifier is a relative import.
+ */
+function isRelativeSpecifier(specifier: string): boolean {
+  return specifier.startsWith('.') || specifier.startsWith('/')
+}
+
+/**
+ * Checks if a dependency should be ignored based on patterns.
+ */
+function isIgnored(depName: string, options: Required<UnusedDependencyAnalyzerOptions>): boolean {
+  return options.ignorePatterns.some(pattern => {
+    if (pattern.includes('*')) {
+      const regex = new RegExp(`^${pattern.replaceAll('*', '.*')}$`)
+      return regex.test(depName)
+    }
+    return depName === pattern
+  })
+}
+
+/**
+ * Checks if a dependency is implicitly used (build tools, type definitions, etc.).
+ */
+function isImplicitlyUsed(depName: string, implicitlyUsed: readonly string[]): boolean {
+  return implicitlyUsed.some(pattern => {
+    if (pattern.includes('*')) {
+      const regex = new RegExp(`^${pattern.replaceAll('*', '.*')}$`)
+      return regex.test(depName)
+    }
+    return depName === pattern
+  })
+}
+
+/**
+ * Creates an issue for an unused dependency.
+ */
+function createUnusedDependencyIssue(pkg: WorkspacePackage, dep: DeclaredDependency): Issue {
+  const location: IssueLocation = {
+    filePath: pkg.packageJsonPath,
+  }
+
+  const severityMap: Record<DependencyType, 'warning' | 'info'> = {
+    dependencies: 'warning',
+    devDependencies: 'info',
+    peerDependencies: 'info',
+    optionalDependencies: 'info',
+  }
+
+  const typeDescription = getDependencyTypeDescription(dep.type)
+
+  return createIssue({
+    id: 'unused-dependency',
+    title: `Unused ${typeDescription}: ${dep.name}`,
+    description: `Package "${pkg.name}" declares "${dep.name}" in ${dep.type} but it is not imported in any source file`,
+    severity: severityMap[dep.type],
+    category: 'dependency',
+    location,
+    suggestion: `Remove "${dep.name}" from ${dep.type} in package.json, or verify it is used at runtime/build time`,
+    metadata: {
+      packageName: pkg.name,
+      dependencyName: dep.name,
+      dependencyVersion: dep.version,
+      dependencyType: dep.type,
+    },
+  })
+}
+
+/**
+ * Gets a human-readable description for a dependency type.
+ */
+function getDependencyTypeDescription(type: DependencyType): string {
+  switch (type) {
+    case 'dependencies':
+      return 'dependency'
+    case 'devDependencies':
+      return 'dev dependency'
+    case 'peerDependencies':
+      return 'peer dependency'
+    case 'optionalDependencies':
+      return 'optional dependency'
+  }
+}
+
+/**
+ * Aggregates import information from multiple packages for workspace-wide analysis.
+ */
+export function aggregatePackageImports(
+  packages: readonly WorkspacePackage[],
+  importResults: ReadonlyMap<string, readonly ImportExtractionResult[]>,
+): {
+  readonly externalByPackage: ReadonlyMap<string, Set<string>>
+  readonly workspaceByPackage: ReadonlyMap<string, Set<string>>
+} {
+  const externalByPackage = new Map<string, Set<string>>()
+  const workspaceByPackage = new Map<string, Set<string>>()
+
+  for (const pkg of packages) {
+    const results = importResults.get(pkg.name)
+    if (results === undefined) {
+      continue
+    }
+
+    const external = new Set<string>()
+    const workspace = new Set<string>()
+
+    for (const result of results) {
+      for (const dep of result.externalDependencies) {
+        external.add(dep)
+      }
+      for (const dep of result.workspaceDependencies) {
+        workspace.add(dep)
+      }
+    }
+
+    externalByPackage.set(pkg.name, external)
+    workspaceByPackage.set(pkg.name, workspace)
+  }
+
+  return {
+    externalByPackage,
+    workspaceByPackage,
+  }
+}

--- a/packages/workspace-analyzer/src/index.ts
+++ b/packages/workspace-analyzer/src/index.ts
@@ -22,19 +22,28 @@
 
 // Analyzer utilities
 export {
+  // Dependency analyzers (Phase 4)
+  aggregatePackageImports,
   BUILTIN_ANALYZER_IDS,
   builtinAnalyzers,
+  computeCycleStats,
+  computeDuplicateStats,
   createAnalyzerRegistry,
   createBuildConfigAnalyzer,
+  createCircularImportAnalyzer,
   createConfigConsistencyAnalyzer,
   createDefaultRegistry,
+  createDuplicateDependencyAnalyzer,
   createEslintConfigAnalyzer,
   createExportsFieldAnalyzer,
   createIssue,
   createPackageJsonAnalyzer,
+  createPeerDependencyAnalyzer,
   createTsconfigAnalyzer,
+  createUnusedDependencyAnalyzer,
   createVersionAlignmentAnalyzer,
   filterIssues,
+  generateCycleVisualization,
   meetsMinSeverity,
   shouldAnalyzeCategory,
 } from './analyzers/index'
@@ -49,11 +58,21 @@ export type {
   AnalyzerRegistration,
   AnalyzerRegistry,
   BuildConfigAnalyzerOptions,
+  // Dependency analyzer types (Phase 4)
+  CircularImportAnalyzerOptions,
+  CircularImportStats,
   ConfigConsistencyAnalyzerOptions,
+  CycleEdge,
+  CycleNode,
+  CycleVisualization,
+  DuplicateDependencyAnalyzerOptions,
+  DuplicateDependencyStats,
   EslintConfigAnalyzerOptions,
   ExportsFieldAnalyzerOptions,
   PackageJsonAnalyzerOptions,
+  PeerDependencyAnalyzerOptions,
   TsconfigAnalyzerOptions,
+  UnusedDependencyAnalyzerOptions,
   VersionAlignmentAnalyzerOptions,
 } from './analyzers/index'
 // Dependency graph utilities


### PR DESCRIPTION
- Introduce DuplicateDependencyAnalyzer to detect duplicate and inconsistent dependencies across workspace packages.
- Implement PeerDependencyAnalyzer to validate peer dependency declarations and report issues.
- Add UnusedDependencyAnalyzer to identify unused dependencies in workspace packages.
- Update analyzer registry to include new analyzers for dependency analysis.
- Enhance documentation for new analyzers with usage examples and configuration options.

Closes #2402.