### PR TITLE
feat(workspace-analyzer): add architectural analysis rules and engine

### DIFF
--- a/.ai/plan/feature-workspace-analyzer-1.md
+++ b/.ai/plan/feature-workspace-analyzer-1.md
@@ -136,16 +136,16 @@ Create a new `@bfra.me/workspace-analyzer` package in the bfra.me/works monorepo
 
 | Task | Description | Completed | Date |
 |------|-------------|-----------|------|
-| TASK-035 | Create architectural rule engine in `src/rules/rule-engine.ts` | | |
-| TASK-036 | Define built-in rule set in `src/rules/builtin-rules.ts` | | |
-| TASK-037 | Implement `LayerViolationRule` for detecting cross-layer imports | | |
-| TASK-038 | Implement `BarrelExportRule` for detecting `export *` misuse in application code | | |
-| TASK-039 | Implement `PublicApiRule` for validating explicit public API surface using export-analyzer pattern | | |
-| TASK-040 | Implement `SideEffectRule` for detecting side effects in module initialization | | |
-| TASK-041 | Create `ArchitecturalAnalyzer` in `src/analyzers/architectural-analyzer.ts` | | |
-| TASK-042 | Add configurable layer definition (domain, application, infrastructure, presentation) | | |
-| TASK-043 | Implement import path alias validation against tsconfig paths | | |
-| TASK-044 | Add monorepo package boundary enforcement rules | | |
+| TASK-035 | Create architectural rule engine in `src/rules/rule-engine.ts` | ✅ | 2025-12-06 |
+| TASK-036 | Define built-in rule set in `src/rules/builtin-rules.ts` | ✅ | 2025-12-06 |
+| TASK-037 | Implement `LayerViolationRule` for detecting cross-layer imports | ✅ | 2025-12-06 |
+| TASK-038 | Implement `BarrelExportRule` for detecting `export *` misuse in application code | ✅ | 2025-12-06 |
+| TASK-039 | Implement `PublicApiRule` for validating explicit public API surface using export-analyzer pattern | ✅ | 2025-12-06 |
+| TASK-040 | Implement `SideEffectRule` for detecting side effects in module initialization | ✅ | 2025-12-06 |
+| TASK-041 | Create `ArchitecturalAnalyzer` in `src/analyzers/architectural-analyzer.ts` | ✅ | 2025-12-06 |
+| TASK-042 | Add configurable layer definition (domain, application, infrastructure, presentation) | ✅ | 2025-12-06 |
+| TASK-043 | Implement import path alias validation against tsconfig paths | ✅ | 2025-12-06 |
+| TASK-044 | Add monorepo package boundary enforcement rules | ✅ | 2025-12-06 |
 
 ### Implementation Phase 6: Performance Analysis
 

--- a/packages/workspace-analyzer/src/analyzers/architectural-analyzer.ts
+++ b/packages/workspace-analyzer/src/analyzers/architectural-analyzer.ts
@@ -1,0 +1,304 @@
+/**
+ * ArchitecturalAnalyzer - Validates architectural patterns and enforces best practices.
+ *
+ * Integrates multiple architectural rules to detect:
+ * - Layer boundary violations
+ * - Barrel export (export *) misuse
+ * - Public API surface issues
+ * - Side effects in module initialization
+ * - Import path alias violations
+ * - Monorepo package boundary violations
+ */
+
+import type {LayerConfiguration, RuleContext} from '../rules/rule-engine'
+import type {WorkspacePackage} from '../scanner/workspace-scanner'
+import type {Issue, Severity} from '../types/index'
+import type {Result} from '../types/result'
+import type {
+  AnalysisContext,
+  Analyzer,
+  AnalyzerError,
+  AnalyzerMetadata,
+  AnalyzerOptions,
+} from './analyzer'
+
+import path from 'node:path'
+
+import {createProject} from '@bfra.me/doc-sync/parsers'
+import {ok} from '@bfra.me/es/result'
+
+import {getAllSourceFiles} from '../parser/typescript-parser'
+import {
+  createBarrelExportRule,
+  createLayerViolationRule,
+  createPackageBoundaryRule,
+  createPathAliasRule,
+  createPublicApiRule,
+  createSideEffectRule,
+} from '../rules/builtin-rules'
+import {createRuleEngine, DEFAULT_LAYER_CONFIG} from '../rules/rule-engine'
+import {matchAnyPattern} from '../utils/pattern-matcher'
+import {createIssue, filterIssues} from './analyzer'
+
+/**
+ * Configuration options for the ArchitecturalAnalyzer.
+ */
+export interface ArchitecturalAnalyzerOptions extends AnalyzerOptions {
+  /** Layer configuration for architectural boundary enforcement */
+  readonly layerConfig?: LayerConfiguration
+  /** tsconfig.json paths for alias validation */
+  readonly tsconfigPaths?: Readonly<Record<string, readonly string[]>>
+  /** Enable layer violation detection */
+  readonly checkLayerViolations?: boolean
+  /** Enable barrel export detection */
+  readonly checkBarrelExports?: boolean
+  /** Enable public API validation */
+  readonly checkPublicApi?: boolean
+  /** Enable side effect detection */
+  readonly checkSideEffects?: boolean
+  /** Enable path alias validation */
+  readonly checkPathAliases?: boolean
+  /** Enable package boundary enforcement */
+  readonly checkPackageBoundaries?: boolean
+  /** File patterns for entry points */
+  readonly entryPointPatterns?: readonly string[]
+  /** Patterns allowed for barrel exports */
+  readonly allowedBarrelPatterns?: readonly string[]
+  /** Shared packages that can be imported from anywhere */
+  readonly sharedPackages?: readonly string[]
+  /** Severity for layer violations */
+  readonly layerViolationSeverity?: Severity
+  /** Severity for barrel export issues */
+  readonly barrelExportSeverity?: Severity
+  /** Severity for public API issues */
+  readonly publicApiSeverity?: Severity
+  /** Severity for side effect issues */
+  readonly sideEffectSeverity?: Severity
+}
+
+const DEFAULT_OPTIONS: Required<
+  Omit<ArchitecturalAnalyzerOptions, keyof AnalyzerOptions | 'tsconfigPaths'>
+> = {
+  layerConfig: DEFAULT_LAYER_CONFIG,
+  checkLayerViolations: true,
+  checkBarrelExports: true,
+  checkPublicApi: true,
+  checkSideEffects: true,
+  checkPathAliases: true,
+  checkPackageBoundaries: true,
+  entryPointPatterns: ['**/index.ts', '**/index.js'],
+  allowedBarrelPatterns: ['**/index.ts'],
+  sharedPackages: ['@bfra.me/es', '@bfra.me/tsconfig'],
+  layerViolationSeverity: 'warning',
+  barrelExportSeverity: 'warning',
+  publicApiSeverity: 'info',
+  sideEffectSeverity: 'warning',
+}
+
+export const architecturalAnalyzerMetadata: AnalyzerMetadata = {
+  id: 'architectural',
+  name: 'Architectural Analyzer',
+  description:
+    'Validates architectural patterns including layer boundaries, exports, and package structure',
+  categories: ['architecture'],
+  defaultSeverity: 'warning',
+}
+
+/**
+ * Creates an ArchitecturalAnalyzer instance with all built-in rules.
+ *
+ * @example
+ * ```ts
+ * const analyzer = createArchitecturalAnalyzer({
+ *   checkLayerViolations: true,
+ *   checkBarrelExports: true,
+ *   layerConfig: {
+ *     layers: [
+ *       {name: 'domain', allowedDependencies: []},
+ *       {name: 'application', allowedDependencies: ['domain']},
+ *     ],
+ *     patterns: [
+ *       {pattern: '**\/domain\/**', layer: 'domain'},
+ *       {pattern: '**\/application\/**', layer: 'application'},
+ *     ],
+ *   },
+ * })
+ *
+ * const result = await analyzer.analyze(context)
+ * ```
+ */
+export function createArchitecturalAnalyzer(options: ArchitecturalAnalyzerOptions = {}): Analyzer {
+  const resolvedOptions = {...DEFAULT_OPTIONS, ...options}
+
+  const engine = createRuleEngine()
+
+  if (resolvedOptions.checkLayerViolations) {
+    engine.register('layer-violation', {
+      rule: createLayerViolationRule({
+        severity: resolvedOptions.layerViolationSeverity,
+        options: {layerConfig: resolvedOptions.layerConfig},
+      }),
+      enabled: true,
+      priority: 10,
+    })
+  }
+
+  if (resolvedOptions.checkBarrelExports) {
+    engine.register('barrel-export', {
+      rule: createBarrelExportRule({
+        severity: resolvedOptions.barrelExportSeverity,
+        options: {
+          allowedPatterns: resolvedOptions.allowedBarrelPatterns,
+          allowWorkspaceReexports: false,
+        },
+      }),
+      enabled: true,
+      priority: 20,
+    })
+  }
+
+  if (resolvedOptions.checkPublicApi) {
+    engine.register('public-api', {
+      rule: createPublicApiRule({
+        severity: resolvedOptions.publicApiSeverity,
+        options: {
+          entryPoints: resolvedOptions.entryPointPatterns as string[],
+          requireReexport: false,
+        },
+      }),
+      enabled: true,
+      priority: 30,
+    })
+  }
+
+  if (resolvedOptions.checkSideEffects) {
+    engine.register('side-effect', {
+      rule: createSideEffectRule({
+        severity: resolvedOptions.sideEffectSeverity,
+        options: {
+          checkConsoleCalls: true,
+          checkGlobalAssignments: true,
+        },
+      }),
+      enabled: true,
+      priority: 40,
+    })
+  }
+
+  if (resolvedOptions.checkPathAliases) {
+    engine.register('path-alias', {
+      rule: createPathAliasRule({
+        options: {
+          requireAliasForDeepImports: true,
+          deepImportThreshold: 3,
+        },
+      }),
+      enabled: true,
+      priority: 50,
+    })
+  }
+
+  if (resolvedOptions.checkPackageBoundaries) {
+    engine.register('package-boundary', {
+      rule: createPackageBoundaryRule({
+        options: {
+          sharedPackages: resolvedOptions.sharedPackages as string[],
+          enforceEntryPointImports: true,
+        },
+      }),
+      enabled: true,
+      priority: 60,
+    })
+  }
+
+  return {
+    metadata: architecturalAnalyzerMetadata,
+    analyze: async (context: AnalysisContext): Promise<Result<readonly Issue[], AnalyzerError>> => {
+      const issues: Issue[] = []
+
+      for (const pkg of context.packages) {
+        context.reportProgress?.(`Analyzing architecture in ${pkg.name}...`)
+
+        const packageIssues = await analyzePackageArchitecture(
+          pkg,
+          context.workspacePath,
+          context.packages,
+          engine,
+          resolvedOptions,
+        )
+        issues.push(...packageIssues)
+      }
+
+      return ok(filterIssues(issues, context.config))
+    },
+  }
+}
+
+/**
+ * Analyzes a single package's architectural patterns.
+ */
+async function analyzePackageArchitecture(
+  pkg: WorkspacePackage,
+  workspacePath: string,
+  allPackages: readonly WorkspacePackage[],
+  engine: ReturnType<typeof createRuleEngine>,
+  options: typeof DEFAULT_OPTIONS & ArchitecturalAnalyzerOptions,
+): Promise<Issue[]> {
+  const issues: Issue[] = []
+  const tsconfigPath = path.join(pkg.packagePath, 'tsconfig.json')
+
+  try {
+    const project = createProject({
+      tsConfigPath: tsconfigPath,
+    })
+
+    const sourceFiles = getAllSourceFiles(project)
+
+    for (const sourceFile of sourceFiles) {
+      const filePath = sourceFile.getFilePath()
+
+      if (shouldSkipFile(filePath, options.exclude)) {
+        continue
+      }
+
+      const ruleContext: RuleContext = {
+        sourceFile,
+        pkg,
+        workspacePath,
+        allPackages,
+        layerConfig: options.layerConfig,
+        tsconfigPaths: options.tsconfigPaths,
+      }
+
+      const result = await engine.evaluateFile(ruleContext)
+
+      if (result.success) {
+        issues.push(...result.data)
+      }
+    }
+  } catch {
+    issues.push(
+      createIssue({
+        id: 'architectural-analysis-error',
+        title: `Failed to analyze architecture in ${pkg.name}`,
+        description: `Could not parse TypeScript project for architectural analysis`,
+        severity: 'warning',
+        category: 'architecture',
+        location: {filePath: tsconfigPath},
+      }),
+    )
+  }
+
+  return issues
+}
+
+/**
+ * Determines if a file should be skipped based on exclude patterns.
+ */
+function shouldSkipFile(filePath: string, excludePatterns: readonly string[] | undefined): boolean {
+  if (excludePatterns === undefined || excludePatterns.length === 0) {
+    return false
+  }
+
+  return matchAnyPattern(filePath, excludePatterns)
+}

--- a/packages/workspace-analyzer/src/analyzers/index.ts
+++ b/packages/workspace-analyzer/src/analyzers/index.ts
@@ -7,6 +7,7 @@
 
 import type {Analyzer, AnalyzerRegistration} from './analyzer'
 
+import {createArchitecturalAnalyzer} from './architectural-analyzer'
 import {createBuildConfigAnalyzer} from './build-config-analyzer'
 import {createCircularImportAnalyzer} from './circular-import-analyzer'
 import {createConfigConsistencyAnalyzer} from './config-consistency-analyzer'
@@ -29,6 +30,9 @@ export type {
   AnalyzerRegistration,
 } from './analyzer'
 export {createIssue, filterIssues, meetsMinSeverity, shouldAnalyzeCategory} from './analyzer'
+
+export type {ArchitecturalAnalyzerOptions} from './architectural-analyzer'
+export {architecturalAnalyzerMetadata, createArchitecturalAnalyzer} from './architectural-analyzer'
 
 export type {BuildConfigAnalyzerOptions} from './build-config-analyzer'
 export {buildConfigAnalyzerMetadata, createBuildConfigAnalyzer} from './build-config-analyzer'
@@ -187,6 +191,8 @@ export const BUILTIN_ANALYZER_IDS = {
   CIRCULAR_IMPORT: 'circular-import',
   PEER_DEPENDENCY: 'peer-dependency',
   DUPLICATE_DEPENDENCY: 'duplicate-dependency',
+  // Architectural analyzer
+  ARCHITECTURAL: 'architectural',
 } as const
 
 /**
@@ -277,6 +283,13 @@ export function createDefaultRegistry(): AnalyzerRegistry {
     priority: 110,
   })
 
+  // Architectural analyzer
+  registry.register(BUILTIN_ANALYZER_IDS.ARCHITECTURAL, {
+    analyzer: createArchitecturalAnalyzer(),
+    enabled: true,
+    priority: 120,
+  })
+
   return registry
 }
 
@@ -296,4 +309,6 @@ export const builtinAnalyzers = {
   circularImport: createCircularImportAnalyzer,
   peerDependency: createPeerDependencyAnalyzer,
   duplicateDependency: createDuplicateDependencyAnalyzer,
+  // Architectural analyzer
+  architectural: createArchitecturalAnalyzer,
 } as const

--- a/packages/workspace-analyzer/src/index.ts
+++ b/packages/workspace-analyzer/src/index.ts
@@ -24,11 +24,14 @@
 export {
   // Dependency analyzers (Phase 4)
   aggregatePackageImports,
+  // Architectural analyzer (Phase 5)
+  architecturalAnalyzerMetadata,
   BUILTIN_ANALYZER_IDS,
   builtinAnalyzers,
   computeCycleStats,
   computeDuplicateStats,
   createAnalyzerRegistry,
+  createArchitecturalAnalyzer,
   createBuildConfigAnalyzer,
   createCircularImportAnalyzer,
   createConfigConsistencyAnalyzer,
@@ -57,6 +60,8 @@ export type {
   AnalyzerOptions,
   AnalyzerRegistration,
   AnalyzerRegistry,
+  // Architectural analyzer types (Phase 5)
+  ArchitecturalAnalyzerOptions,
   BuildConfigAnalyzerOptions,
   // Dependency analyzer types (Phase 4)
   CircularImportAnalyzerOptions,
@@ -133,6 +138,49 @@ export type {
   TypeScriptParserOptions,
 } from './parser/index'
 
+// Rules engine and built-in rules (Phase 5)
+export {
+  barrelExportRuleMetadata,
+  BUILTIN_RULE_IDS,
+  createBarrelExportRule,
+  createLayerViolationRule,
+  createPackageBoundaryRule,
+  createPathAliasRule,
+  createPublicApiRule,
+  createRuleEngine,
+  createSideEffectRule,
+  DEFAULT_LAYER_CONFIG,
+  getFileLayer,
+  isLayerImportAllowed,
+  layerViolationRuleMetadata,
+  packageBoundaryRuleMetadata,
+  pathAliasRuleMetadata,
+  publicApiRuleMetadata,
+  sideEffectRuleMetadata,
+} from './rules/index'
+
+export type {
+  BarrelExportRuleOptions,
+  LayerConfiguration,
+  LayerDefinition,
+  LayerPattern,
+  LayerViolationRuleOptions,
+  PackageBoundaryRuleOptions,
+  PathAliasRuleOptions,
+  PublicApiRuleOptions,
+  Rule,
+  RuleContext,
+  RuleEngine,
+  RuleEngineError,
+  RuleFactory,
+  RuleMetadata,
+  RuleOptions,
+  RuleRegistration,
+  RuleResult,
+  RuleViolation,
+  SideEffectRuleOptions,
+} from './rules/index'
+
 // Scanner utilities
 export {
   createWorkspaceScanner,
@@ -179,7 +227,10 @@ export {
   unwrap,
   unwrapOr,
 } from './types/index'
+
 export type {Err, Ok, Result} from './types/index'
+// Utility functions
+export {matchAnyPattern, matchPattern, normalizePath} from './utils/index'
 
 // Placeholder for main API entry point (will be implemented in Phase 9)
 // export {analyzeWorkspace} from './api/analyze-workspace'

--- a/packages/workspace-analyzer/src/rules/builtin-rules.ts
+++ b/packages/workspace-analyzer/src/rules/builtin-rules.ts
@@ -1,0 +1,708 @@
+/**
+ * Built-in architectural rules for workspace analysis.
+ *
+ * Provides rules for detecting common architectural anti-patterns:
+ * - Layer violations (cross-layer imports)
+ * - Barrel export misuse (export * in application code)
+ * - Public API validation (explicit exports)
+ * - Side effects in module initialization
+ * - Import path alias violations
+ * - Package boundary enforcement
+ */
+
+import type {SourceFile} from 'ts-morph'
+
+import type {
+  LayerConfiguration,
+  Rule,
+  RuleContext,
+  RuleMetadata,
+  RuleOptions,
+  RuleResult,
+  RuleViolation,
+} from './rule-engine'
+
+import {SyntaxKind} from 'ts-morph'
+
+import {extractImports, isRelativeImport} from '../parser/import-extractor'
+import {matchAnyPattern} from '../utils/pattern-matcher'
+
+import {
+  BUILTIN_RULE_IDS,
+  DEFAULT_LAYER_CONFIG,
+  getFileLayer,
+  isLayerImportAllowed,
+} from './rule-engine'
+
+/**
+ * Options for LayerViolationRule.
+ */
+export interface LayerViolationRuleOptions extends RuleOptions {
+  readonly options?: {
+    /** Custom layer configuration */
+    readonly layerConfig?: LayerConfiguration
+    /** Whether to report violations for unrecognized layers */
+    readonly reportUnknownLayers?: boolean
+  }
+}
+
+export const layerViolationRuleMetadata: RuleMetadata = {
+  id: BUILTIN_RULE_IDS.LAYER_VIOLATION,
+  name: 'Layer Violation',
+  description: 'Detects imports that violate architectural layer boundaries',
+  defaultSeverity: 'warning',
+  category: 'layer-violation',
+}
+
+/**
+ * Creates a rule that detects layer boundary violations.
+ *
+ * @example
+ * ```ts
+ * const rule = createLayerViolationRule({
+ *   options: {
+ *     layerConfig: {
+ *       layers: [
+ *         {name: 'domain', allowedDependencies: []},
+ *         {name: 'application', allowedDependencies: ['domain']},
+ *       ],
+ *       patterns: [
+ *         {pattern: '**\/domain\/**', layer: 'domain'},
+ *       ],
+ *     },
+ *   },
+ * })
+ * ```
+ */
+export function createLayerViolationRule(options: LayerViolationRuleOptions = {}): Rule {
+  const layerConfig = options.options?.layerConfig ?? DEFAULT_LAYER_CONFIG
+  const reportUnknownLayers = options.options?.reportUnknownLayers ?? false
+
+  return {
+    metadata: layerViolationRuleMetadata,
+    evaluate: async (context: RuleContext): Promise<RuleResult> => {
+      const violations: RuleViolation[] = []
+      const {sourceFile} = context
+      const filePath = sourceFile.getFilePath()
+      const config = context.layerConfig ?? layerConfig
+
+      const sourceLayer = getFileLayer(filePath, config)
+
+      if (sourceLayer === undefined) {
+        if (reportUnknownLayers) {
+          return {
+            violations: [
+              {
+                ruleId: BUILTIN_RULE_IDS.LAYER_VIOLATION,
+                location: {filePath, line: 1, column: 1},
+                message: 'File does not belong to any recognized architectural layer',
+                suggestion: 'Organize file into an appropriate layer directory',
+              },
+            ],
+            success: true,
+          }
+        }
+        return {violations: [], success: true}
+      }
+
+      const importResult = extractImports(sourceFile, {
+        workspacePrefixes: ['@bfra.me/'],
+        includeTypeImports: false,
+      })
+
+      for (const imp of importResult.imports) {
+        if (!imp.isRelative) continue
+
+        const resolvedPath = resolveRelativeImportPath(filePath, imp.moduleSpecifier)
+        const targetLayer = getFileLayer(resolvedPath, config)
+
+        if (targetLayer !== undefined && !isLayerImportAllowed(sourceLayer, targetLayer, config)) {
+          violations.push({
+            ruleId: BUILTIN_RULE_IDS.LAYER_VIOLATION,
+            location: {
+              filePath,
+              line: imp.line,
+              column: imp.column,
+            },
+            message: `Layer violation: '${sourceLayer}' cannot import from '${targetLayer}' (via '${imp.moduleSpecifier}')`,
+            suggestion: `Move shared code to a common layer or invert the dependency direction`,
+            relatedLocations: [{filePath: resolvedPath}],
+            metadata: {
+              sourceLayer,
+              targetLayer,
+              moduleSpecifier: imp.moduleSpecifier,
+            },
+          })
+        }
+      }
+
+      return {violations, success: true}
+    },
+  }
+}
+
+/**
+ * Options for BarrelExportRule.
+ */
+export interface BarrelExportRuleOptions extends RuleOptions {
+  readonly options?: {
+    /** Allow export * in these file patterns (e.g., index.ts in libs) */
+    readonly allowedPatterns?: readonly string[]
+    /** Whether to allow export * from workspace packages */
+    readonly allowWorkspaceReexports?: boolean
+  }
+}
+
+export const barrelExportRuleMetadata: RuleMetadata = {
+  id: BUILTIN_RULE_IDS.BARREL_EXPORT,
+  name: 'Barrel Export',
+  description: 'Detects `export *` usage which can break tree-shaking and obscure the public API',
+  defaultSeverity: 'warning',
+  category: 'barrel-export',
+}
+
+/**
+ * Creates a rule that detects export * (barrel export) misuse.
+ *
+ * @example
+ * ```ts
+ * const rule = createBarrelExportRule({
+ *   options: {
+ *     allowedPatterns: ['**\/index.ts'],
+ *     allowWorkspaceReexports: false,
+ *   },
+ * })
+ * ```
+ */
+export function createBarrelExportRule(options: BarrelExportRuleOptions = {}): Rule {
+  const allowedPatterns = options.options?.allowedPatterns ?? []
+  const allowWorkspaceReexports = options.options?.allowWorkspaceReexports ?? false
+
+  return {
+    metadata: barrelExportRuleMetadata,
+    evaluate: async (context: RuleContext): Promise<RuleResult> => {
+      const violations: RuleViolation[] = []
+      const {sourceFile} = context
+      const filePath = sourceFile.getFilePath()
+
+      if (matchAnyPattern(filePath, allowedPatterns)) {
+        return {violations: [], success: true}
+      }
+
+      for (const exportDecl of sourceFile.getExportDeclarations()) {
+        if (!exportDecl.isNamespaceExport()) continue
+
+        const moduleSpecifier = exportDecl.getModuleSpecifierValue()
+        if (moduleSpecifier === undefined) continue
+
+        if (allowWorkspaceReexports && isWorkspacePackage(moduleSpecifier)) {
+          continue
+        }
+
+        const {line, column} = sourceFile.getLineAndColumnAtPos(exportDecl.getStart())
+
+        violations.push({
+          ruleId: BUILTIN_RULE_IDS.BARREL_EXPORT,
+          location: {filePath, line, column},
+          message: `Avoid \`export * from '${moduleSpecifier}'\` - it breaks tree-shaking and obscures the public API`,
+          suggestion: 'Use explicit named exports to maintain a clear public API surface',
+          metadata: {
+            moduleSpecifier,
+            exportType: 'namespace',
+          },
+        })
+      }
+
+      return {violations, success: true}
+    },
+  }
+}
+
+/**
+ * Options for PublicApiRule.
+ */
+export interface PublicApiRuleOptions extends RuleOptions {
+  readonly options?: {
+    /** Entry point files that define the public API */
+    readonly entryPoints?: readonly string[]
+    /** Require all exports to be re-exported from entry points */
+    readonly requireReexport?: boolean
+  }
+}
+
+export const publicApiRuleMetadata: RuleMetadata = {
+  id: BUILTIN_RULE_IDS.PUBLIC_API,
+  name: 'Public API',
+  description: 'Validates that the public API surface is explicitly defined via entry points',
+  defaultSeverity: 'info',
+  category: 'public-api',
+}
+
+/**
+ * Creates a rule that validates public API surface definition.
+ *
+ * @example
+ * ```ts
+ * const rule = createPublicApiRule({
+ *   options: {
+ *     entryPoints: ['src/index.ts'],
+ *     requireReexport: true,
+ *   },
+ * })
+ * ```
+ */
+export function createPublicApiRule(options: PublicApiRuleOptions = {}): Rule {
+  const entryPoints = options.options?.entryPoints ?? ['src/index.ts', 'index.ts']
+  const requireReexport = options.options?.requireReexport ?? false
+
+  return {
+    metadata: publicApiRuleMetadata,
+    evaluate: async (context: RuleContext): Promise<RuleResult> => {
+      const violations: RuleViolation[] = []
+      const {sourceFile} = context
+      const filePath = sourceFile.getFilePath()
+
+      const isEntryPoint = entryPoints.some(ep => filePath.endsWith(ep))
+
+      if (isEntryPoint) {
+        const hasExportStar = sourceFile.getExportDeclarations().some(e => e.isNamespaceExport())
+
+        if (hasExportStar) {
+          const exportStarDecl = sourceFile.getExportDeclarations().find(e => e.isNamespaceExport())
+          if (exportStarDecl !== undefined) {
+            const {line, column} = sourceFile.getLineAndColumnAtPos(exportStarDecl.getStart())
+            violations.push({
+              ruleId: BUILTIN_RULE_IDS.PUBLIC_API,
+              location: {filePath, line, column},
+              message: 'Entry point should use explicit named exports instead of `export *`',
+              suggestion:
+                'Replace `export *` with explicit named exports to document the public API',
+            })
+          }
+        }
+      }
+
+      if (requireReexport && !isEntryPoint) {
+        const exports = sourceFile.getExportedDeclarations()
+
+        for (const [name, declarations] of exports) {
+          for (const decl of declarations) {
+            if (decl.getSourceFile() === sourceFile) {
+              const {line, column} = sourceFile.getLineAndColumnAtPos(decl.getStart())
+              violations.push({
+                ruleId: BUILTIN_RULE_IDS.PUBLIC_API,
+                location: {filePath, line, column},
+                message: `Export '${name}' should be re-exported from an entry point file`,
+                suggestion: `Add this export to one of the entry points: ${entryPoints.join(', ')}`,
+                metadata: {exportName: name},
+              })
+            }
+          }
+        }
+      }
+
+      return {violations, success: true}
+    },
+  }
+}
+
+/**
+ * Options for SideEffectRule.
+ */
+export interface SideEffectRuleOptions extends RuleOptions {
+  readonly options?: {
+    /** Allow side effects in these file patterns */
+    readonly allowedPatterns?: readonly string[]
+    /** Check for console.log/warn/error at module level */
+    readonly checkConsoleCalls?: boolean
+    /** Check for assignments to global objects */
+    readonly checkGlobalAssignments?: boolean
+  }
+}
+
+export const sideEffectRuleMetadata: RuleMetadata = {
+  id: BUILTIN_RULE_IDS.SIDE_EFFECT,
+  name: 'Side Effect',
+  description: 'Detects side effects in module initialization that can break tree-shaking',
+  defaultSeverity: 'warning',
+  category: 'side-effect',
+}
+
+/**
+ * Creates a rule that detects side effects at module initialization.
+ *
+ * @example
+ * ```ts
+ * const rule = createSideEffectRule({
+ *   options: {
+ *     allowedPatterns: ['**\/polyfills.ts'],
+ *     checkConsoleCalls: true,
+ *   },
+ * })
+ * ```
+ */
+export function createSideEffectRule(options: SideEffectRuleOptions = {}): Rule {
+  const allowedPatterns = options.options?.allowedPatterns ?? []
+  const checkConsoleCalls = options.options?.checkConsoleCalls ?? true
+  const checkGlobalAssignments = options.options?.checkGlobalAssignments ?? true
+
+  return {
+    metadata: sideEffectRuleMetadata,
+    evaluate: async (context: RuleContext): Promise<RuleResult> => {
+      const violations: RuleViolation[] = []
+      const {sourceFile} = context
+      const filePath = sourceFile.getFilePath()
+
+      if (matchAnyPattern(filePath, allowedPatterns)) {
+        return {violations: [], success: true}
+      }
+
+      checkTopLevelSideEffects(sourceFile, filePath, violations, {
+        checkConsoleCalls,
+        checkGlobalAssignments,
+      })
+
+      return {violations, success: true}
+    },
+  }
+}
+
+/**
+ * Options for PathAliasRule.
+ */
+export interface PathAliasRuleOptions extends RuleOptions {
+  readonly options?: {
+    /** Require path aliases for deep imports */
+    readonly requireAliasForDeepImports?: boolean
+    /** Depth threshold for requiring aliases */
+    readonly deepImportThreshold?: number
+  }
+}
+
+export const pathAliasRuleMetadata: RuleMetadata = {
+  id: BUILTIN_RULE_IDS.PATH_ALIAS,
+  name: 'Path Alias',
+  description: 'Validates import paths against tsconfig path aliases',
+  defaultSeverity: 'info',
+  category: 'layer-violation',
+}
+
+/**
+ * Creates a rule that validates import path aliases against tsconfig.
+ *
+ * @example
+ * ```ts
+ * const rule = createPathAliasRule({
+ *   options: {
+ *     requireAliasForDeepImports: true,
+ *     deepImportThreshold: 3,
+ *   },
+ * })
+ * ```
+ */
+export function createPathAliasRule(options: PathAliasRuleOptions = {}): Rule {
+  const requireAliasForDeepImports = options.options?.requireAliasForDeepImports ?? false
+  const deepImportThreshold = options.options?.deepImportThreshold ?? 3
+
+  return {
+    metadata: pathAliasRuleMetadata,
+    evaluate: async (context: RuleContext): Promise<RuleResult> => {
+      const violations: RuleViolation[] = []
+      const {sourceFile, tsconfigPaths} = context
+      const filePath = sourceFile.getFilePath()
+
+      if (tsconfigPaths === undefined) {
+        return {violations: [], success: true}
+      }
+
+      const importResult = extractImports(sourceFile, {
+        workspacePrefixes: ['@bfra.me/'],
+        includeTypeImports: true,
+      })
+
+      for (const imp of importResult.imports) {
+        if (!imp.isRelative) continue
+
+        const pathDepth = imp.moduleSpecifier.split('/').filter(p => p === '..').length
+
+        if (requireAliasForDeepImports && pathDepth >= deepImportThreshold) {
+          const {line, column} = {line: imp.line, column: imp.column}
+
+          const suggestedAlias = findMatchingAlias(imp.moduleSpecifier, tsconfigPaths)
+
+          violations.push({
+            ruleId: BUILTIN_RULE_IDS.PATH_ALIAS,
+            location: {filePath, line, column},
+            message: `Deep relative import '${imp.moduleSpecifier}' (${pathDepth} levels up) should use a path alias`,
+            suggestion:
+              suggestedAlias === undefined
+                ? 'Consider adding a path alias in tsconfig.json'
+                : `Use path alias '${suggestedAlias}' instead`,
+            metadata: {
+              moduleSpecifier: imp.moduleSpecifier,
+              pathDepth,
+              suggestedAlias,
+            },
+          })
+        }
+
+        if (!isValidPathAlias(imp.moduleSpecifier, tsconfigPaths)) {
+          const invalidAlias = imp.moduleSpecifier.split('/')[0]
+          if (
+            invalidAlias !== undefined &&
+            !imp.isRelative &&
+            invalidAlias.startsWith('@') &&
+            !imp.isWorkspacePackage
+          ) {
+            violations.push({
+              ruleId: BUILTIN_RULE_IDS.PATH_ALIAS,
+              location: {filePath, line: imp.line, column: imp.column},
+              message: `Import '${imp.moduleSpecifier}' uses an undefined path alias`,
+              suggestion: `Define '${invalidAlias}' in tsconfig.json paths or use a valid import path`,
+              metadata: {
+                moduleSpecifier: imp.moduleSpecifier,
+                invalidAlias,
+              },
+            })
+          }
+        }
+      }
+
+      return {violations, success: true}
+    },
+  }
+}
+
+/**
+ * Options for PackageBoundaryRule.
+ */
+export interface PackageBoundaryRuleOptions extends RuleOptions {
+  readonly options?: {
+    /** Allowed cross-package import patterns */
+    readonly allowedCrossPackagePatterns?: readonly string[]
+    /** Packages that can be imported from anywhere */
+    readonly sharedPackages?: readonly string[]
+    /** Enforce importing only from package entry points */
+    readonly enforceEntryPointImports?: boolean
+  }
+}
+
+export const packageBoundaryRuleMetadata: RuleMetadata = {
+  id: BUILTIN_RULE_IDS.PACKAGE_BOUNDARY,
+  name: 'Package Boundary',
+  description: 'Enforces proper package boundaries in monorepo imports',
+  defaultSeverity: 'warning',
+  category: 'boundary',
+}
+
+/**
+ * Creates a rule that enforces monorepo package boundaries.
+ *
+ * @example
+ * ```ts
+ * const rule = createPackageBoundaryRule({
+ *   options: {
+ *     sharedPackages: ['@bfra.me/es', '@bfra.me/tsconfig'],
+ *     enforceEntryPointImports: true,
+ *   },
+ * })
+ * ```
+ */
+export function createPackageBoundaryRule(options: PackageBoundaryRuleOptions = {}): Rule {
+  const sharedPackages = options.options?.sharedPackages ?? []
+  const enforceEntryPointImports = options.options?.enforceEntryPointImports ?? true
+
+  return {
+    metadata: packageBoundaryRuleMetadata,
+    evaluate: async (context: RuleContext): Promise<RuleResult> => {
+      const violations: RuleViolation[] = []
+      const {sourceFile, pkg, allPackages} = context
+      const filePath = sourceFile.getFilePath()
+
+      const importResult = extractImports(sourceFile, {
+        workspacePrefixes: ['@bfra.me/'],
+        includeTypeImports: true,
+      })
+
+      for (const imp of importResult.imports) {
+        if (!imp.isWorkspacePackage) continue
+
+        const packageName = getPackageNameFromImport(imp.moduleSpecifier)
+        if (packageName === undefined) continue
+
+        if (sharedPackages.includes(packageName)) continue
+
+        if (enforceEntryPointImports) {
+          const hasSubpath = imp.moduleSpecifier !== packageName
+
+          if (hasSubpath) {
+            const importedPkg = allPackages.find(p => p.name === packageName)
+
+            if (importedPkg !== undefined) {
+              const subpath = imp.moduleSpecifier.slice(packageName.length + 1)
+              const isValidExport = isExportedSubpath(importedPkg, subpath)
+
+              if (!isValidExport) {
+                violations.push({
+                  ruleId: BUILTIN_RULE_IDS.PACKAGE_BOUNDARY,
+                  location: {filePath, line: imp.line, column: imp.column},
+                  message: `Import '${imp.moduleSpecifier}' accesses internal module - use a documented export`,
+                  suggestion: `Import from '${packageName}' entry point or request the subpath be exported`,
+                  metadata: {
+                    sourcePackage: pkg.name,
+                    targetPackage: packageName,
+                    subpath,
+                  },
+                })
+              }
+            }
+          }
+        }
+      }
+
+      return {violations, success: true}
+    },
+  }
+}
+
+function resolveRelativeImportPath(fromPath: string, specifier: string): string {
+  const dir = fromPath.slice(0, Math.max(0, fromPath.lastIndexOf('/')))
+  const parts = [...dir.split('/')]
+
+  for (const segment of specifier.split('/')) {
+    if (segment === '..') {
+      parts.pop()
+    } else if (segment !== '.') {
+      parts.push(segment)
+    }
+  }
+
+  return parts.join('/')
+}
+
+function isWorkspacePackage(specifier: string): boolean {
+  return specifier.startsWith('@bfra.me/')
+}
+
+function checkTopLevelSideEffects(
+  sourceFile: SourceFile,
+  filePath: string,
+  violations: RuleViolation[],
+  options: {checkConsoleCalls: boolean; checkGlobalAssignments: boolean},
+): void {
+  const statements = sourceFile.getStatements()
+
+  for (const stmt of statements) {
+    if (stmt.getKind() === SyntaxKind.ExpressionStatement) {
+      const expr = stmt.getChildAtIndex(0)
+      if (expr === undefined) continue
+
+      if (options.checkConsoleCalls && expr.getKind() === SyntaxKind.CallExpression) {
+        const text = expr.getText()
+        if (
+          text.startsWith('console.') ||
+          text.includes('console.log') ||
+          text.includes('console.warn') ||
+          text.includes('console.error')
+        ) {
+          const {line, column} = sourceFile.getLineAndColumnAtPos(stmt.getStart())
+          violations.push({
+            ruleId: BUILTIN_RULE_IDS.SIDE_EFFECT,
+            location: {filePath, line, column},
+            message: 'Console call at module initialization level is a side effect',
+            suggestion: 'Move console calls inside functions or wrap in conditional checks',
+          })
+        }
+      }
+
+      if (options.checkGlobalAssignments && expr.getKind() === SyntaxKind.BinaryExpression) {
+        const text = expr.getText()
+        if (text.includes('window.') || text.includes('globalThis.') || text.includes('global.')) {
+          const {line, column} = sourceFile.getLineAndColumnAtPos(stmt.getStart())
+          violations.push({
+            ruleId: BUILTIN_RULE_IDS.SIDE_EFFECT,
+            location: {filePath, line, column},
+            message: 'Global assignment at module initialization level is a side effect',
+            suggestion: 'Wrap global assignments in initialization functions',
+          })
+        }
+      }
+    }
+
+    if (stmt.getKind() === SyntaxKind.ImportDeclaration) {
+      const importDecl = stmt.asKind(SyntaxKind.ImportDeclaration)
+      if (importDecl !== undefined) {
+        const namedBindings = importDecl.getImportClause()?.getNamedBindings()
+        const defaultImport = importDecl.getImportClause()?.getDefaultImport()
+
+        if (namedBindings === undefined && defaultImport === undefined) {
+          const {line, column} = sourceFile.getLineAndColumnAtPos(stmt.getStart())
+          const moduleSpecifier = importDecl.getModuleSpecifierValue()
+          violations.push({
+            ruleId: BUILTIN_RULE_IDS.SIDE_EFFECT,
+            location: {filePath, line, column},
+            message: `Side-effect only import '${moduleSpecifier}' may affect tree-shaking`,
+            suggestion:
+              'Ensure this import is necessary and consider if it could be moved to an entry point',
+            metadata: {moduleSpecifier},
+          })
+        }
+      }
+    }
+  }
+}
+
+function findMatchingAlias(
+  specifier: string,
+  paths: Readonly<Record<string, readonly string[]>>,
+): string | undefined {
+  for (const [alias, targets] of Object.entries(paths)) {
+    for (const target of targets) {
+      const normalizedTarget = target.replaceAll('*', '')
+      if (specifier.includes(normalizedTarget)) {
+        return alias.replace('*', specifier.replace(normalizedTarget, ''))
+      }
+    }
+  }
+  return undefined
+}
+
+function isValidPathAlias(
+  specifier: string,
+  paths: Readonly<Record<string, readonly string[]>>,
+): boolean {
+  if (isRelativeImport(specifier)) return true
+  if (specifier.startsWith('@') && !Object.keys(paths).some(p => specifier.startsWith(p))) {
+    return false
+  }
+  return true
+}
+
+function getPackageNameFromImport(specifier: string): string | undefined {
+  if (specifier.startsWith('@')) {
+    const parts = specifier.split('/')
+    if (parts.length >= 2) {
+      return `${parts[0]}/${parts[1]}`
+    }
+  }
+  return specifier.split('/')[0]
+}
+
+function isExportedSubpath(pkg: {packageJson: {exports?: unknown}}, subpath: string): boolean {
+  const exports = pkg.packageJson.exports
+
+  if (exports === null || exports === undefined) {
+    return true
+  }
+
+  if (typeof exports === 'string') {
+    return subpath === ''
+  }
+
+  if (typeof exports === 'object') {
+    const exportKey = `./${subpath}`
+    return exportKey in (exports as Record<string, unknown>)
+  }
+
+  return false
+}

--- a/packages/workspace-analyzer/src/rules/index.ts
+++ b/packages/workspace-analyzer/src/rules/index.ts
@@ -1,0 +1,52 @@
+/**
+ * Rules module exports for architectural analysis.
+ *
+ * Provides the rule engine infrastructure and built-in rules for detecting
+ * architectural anti-patterns and enforcing best practices.
+ */
+
+export type {
+  BarrelExportRuleOptions,
+  LayerViolationRuleOptions,
+  PackageBoundaryRuleOptions,
+  PathAliasRuleOptions,
+  PublicApiRuleOptions,
+  SideEffectRuleOptions,
+} from './builtin-rules'
+export {
+  barrelExportRuleMetadata,
+  createBarrelExportRule,
+  createLayerViolationRule,
+  createPackageBoundaryRule,
+  createPathAliasRule,
+  createPublicApiRule,
+  createSideEffectRule,
+  layerViolationRuleMetadata,
+  packageBoundaryRuleMetadata,
+  pathAliasRuleMetadata,
+  publicApiRuleMetadata,
+  sideEffectRuleMetadata,
+} from './builtin-rules'
+
+export type {
+  LayerConfiguration,
+  LayerDefinition,
+  LayerPattern,
+  Rule,
+  RuleContext,
+  RuleEngine,
+  RuleEngineError,
+  RuleFactory,
+  RuleMetadata,
+  RuleOptions,
+  RuleRegistration,
+  RuleResult,
+  RuleViolation,
+} from './rule-engine'
+export {
+  BUILTIN_RULE_IDS,
+  createRuleEngine,
+  DEFAULT_LAYER_CONFIG,
+  getFileLayer,
+  isLayerImportAllowed,
+} from './rule-engine'

--- a/packages/workspace-analyzer/src/rules/rule-engine.ts
+++ b/packages/workspace-analyzer/src/rules/rule-engine.ts
@@ -1,0 +1,409 @@
+/**
+ * Architectural rule engine for validating code patterns and enforcing best practices.
+ *
+ * Provides a plugin architecture for extensible analysis rules that detect
+ * architectural violations, anti-patterns, and best practice deviations.
+ */
+
+import type {SourceFile} from 'ts-morph'
+
+import type {WorkspacePackage} from '../scanner/workspace-scanner'
+import type {Issue, IssueLocation, Severity} from '../types/index'
+import type {Result} from '../types/result'
+
+import {ok} from '@bfra.me/es/result'
+
+import {matchPattern, normalizePath} from '../utils/pattern-matcher'
+
+/**
+ * Context provided to rules during evaluation.
+ */
+export interface RuleContext {
+  /** The source file being evaluated */
+  readonly sourceFile: SourceFile
+  /** The package containing the source file */
+  readonly pkg: WorkspacePackage
+  /** Root path of the workspace */
+  readonly workspacePath: string
+  /** All packages in the workspace for cross-package analysis */
+  readonly allPackages: readonly WorkspacePackage[]
+  /** Resolved tsconfig paths for alias validation */
+  readonly tsconfigPaths?: Readonly<Record<string, readonly string[]>>
+  /** Layer configuration for architectural validation */
+  readonly layerConfig?: LayerConfiguration
+  /** Report progress during evaluation */
+  readonly reportProgress?: (message: string) => void
+}
+
+/**
+ * Layer configuration for enforcing architectural boundaries.
+ */
+export interface LayerConfiguration {
+  /** Layer definitions with allowed dependencies */
+  readonly layers: readonly LayerDefinition[]
+  /** File patterns to layer mapping */
+  readonly patterns: readonly LayerPattern[]
+}
+
+/**
+ * Defines an architectural layer with its allowed dependencies.
+ */
+export interface LayerDefinition {
+  /** Layer name (e.g., 'domain', 'application', 'infrastructure') */
+  readonly name: string
+  /** Other layers this layer can import from */
+  readonly allowedDependencies: readonly string[]
+}
+
+/**
+ * Maps file patterns to architectural layers.
+ */
+export interface LayerPattern {
+  /** Glob pattern to match files */
+  readonly pattern: string
+  /** Layer this pattern belongs to */
+  readonly layer: string
+}
+
+/**
+ * Result of a single rule violation.
+ */
+export interface RuleViolation {
+  /** Rule that was violated */
+  readonly ruleId: string
+  /** Location of the violation */
+  readonly location: IssueLocation
+  /** Human-readable message explaining the violation */
+  readonly message: string
+  /** Suggested fix for the violation */
+  readonly suggestion?: string
+  /** Related locations (e.g., the imported module) */
+  readonly relatedLocations?: readonly IssueLocation[]
+  /** Additional metadata for machine processing */
+  readonly metadata?: Readonly<Record<string, unknown>>
+}
+
+/**
+ * Result of evaluating a rule on a source file.
+ */
+export interface RuleResult {
+  /** Violations found */
+  readonly violations: readonly RuleViolation[]
+  /** Whether the evaluation completed successfully */
+  readonly success: boolean
+  /** Error message if evaluation failed */
+  readonly error?: string
+}
+
+/**
+ * Metadata describing a rule.
+ */
+export interface RuleMetadata {
+  /** Unique identifier for the rule */
+  readonly id: string
+  /** Human-readable name */
+  readonly name: string
+  /** Description of what the rule checks */
+  readonly description: string
+  /** Default severity for violations */
+  readonly defaultSeverity: Severity
+  /** Category for grouping */
+  readonly category: 'layer-violation' | 'barrel-export' | 'public-api' | 'side-effect' | 'boundary'
+  /** Documentation URL */
+  readonly docsUrl?: string
+}
+
+/**
+ * Configuration options for a rule.
+ */
+export interface RuleOptions {
+  /** Whether the rule is enabled */
+  readonly enabled?: boolean
+  /** Severity override */
+  readonly severity?: Severity
+  /** File patterns to include */
+  readonly include?: readonly string[]
+  /** File patterns to exclude */
+  readonly exclude?: readonly string[]
+  /** Rule-specific options */
+  readonly options?: Readonly<Record<string, unknown>>
+}
+
+/**
+ * Core interface that all architectural rules must implement.
+ */
+export interface Rule {
+  /** Metadata describing the rule */
+  readonly metadata: RuleMetadata
+  /**
+   * Evaluate the rule against a source file.
+   *
+   * @param context - Rule evaluation context
+   * @returns Result containing violations found
+   */
+  readonly evaluate: (context: RuleContext) => Promise<RuleResult>
+}
+
+/**
+ * Factory function signature for creating rules.
+ */
+export type RuleFactory = (options?: RuleOptions) => Rule
+
+/**
+ * Registration entry for a rule in the engine.
+ */
+export interface RuleRegistration {
+  /** The rule instance or factory */
+  readonly rule: Rule | RuleFactory
+  /** Whether the rule is enabled */
+  readonly enabled: boolean
+  /** Priority for execution order (lower runs first) */
+  readonly priority: number
+  /** Configuration options */
+  readonly options?: RuleOptions
+}
+
+/**
+ * Rule engine for managing and executing architectural rules.
+ */
+export interface RuleEngine {
+  /** Register a rule */
+  readonly register: (id: string, registration: RuleRegistration) => void
+  /** Unregister a rule */
+  readonly unregister: (id: string) => boolean
+  /** Get a registered rule */
+  readonly get: (id: string) => RuleRegistration | undefined
+  /** Get all registered rules */
+  readonly getAll: () => Map<string, RuleRegistration>
+  /** Get enabled rules sorted by priority */
+  readonly getEnabled: () => Rule[]
+  /** Check if a rule is registered */
+  readonly has: (id: string) => boolean
+  /** Evaluate all enabled rules against a source file */
+  readonly evaluateFile: (
+    context: RuleContext,
+  ) => Promise<Result<readonly Issue[], RuleEngineError>>
+  /** Evaluate all enabled rules against multiple source files */
+  readonly evaluateFiles: (
+    contexts: readonly RuleContext[],
+  ) => Promise<Result<readonly Issue[], RuleEngineError>>
+}
+
+/**
+ * Error from rule engine operations.
+ */
+export interface RuleEngineError {
+  /** Error code for programmatic handling */
+  readonly code: 'RULE_EXECUTION_ERROR' | 'RULE_NOT_FOUND' | 'INVALID_CONFIGURATION'
+  /** Human-readable error message */
+  readonly message: string
+  /** Rule ID that caused the error (if applicable) */
+  readonly ruleId?: string
+  /** Additional context about the error */
+  readonly context?: Readonly<Record<string, unknown>>
+}
+
+/**
+ * Resolves a rule registration to a Rule instance.
+ */
+function resolveRule(registration: RuleRegistration): Rule {
+  if (typeof registration.rule === 'function') {
+    return registration.rule(registration.options)
+  }
+  return registration.rule
+}
+
+/**
+ * Converts a rule violation to an Issue.
+ */
+function violationToIssue(violation: RuleViolation, rule: Rule): Issue {
+  return {
+    id: violation.ruleId,
+    title: `${rule.metadata.name}: ${violation.message.slice(0, 60)}${violation.message.length > 60 ? '...' : ''}`,
+    description: violation.message,
+    severity: rule.metadata.defaultSeverity,
+    category: 'architecture',
+    location: violation.location,
+    relatedLocations: violation.relatedLocations,
+    suggestion: violation.suggestion,
+    metadata: violation.metadata,
+  }
+}
+
+/**
+ * Creates a new rule engine instance.
+ *
+ * @example
+ * ```ts
+ * const engine = createRuleEngine()
+ *
+ * engine.register('no-barrel-exports', {
+ *   rule: createBarrelExportRule(),
+ *   enabled: true,
+ *   priority: 10,
+ * })
+ *
+ * const issues = await engine.evaluateFile(context)
+ * ```
+ */
+export function createRuleEngine(): RuleEngine {
+  const registrations = new Map<string, RuleRegistration>()
+
+  return {
+    register(id: string, registration: RuleRegistration): void {
+      registrations.set(id, registration)
+    },
+
+    unregister(id: string): boolean {
+      return registrations.delete(id)
+    },
+
+    get(id: string): RuleRegistration | undefined {
+      return registrations.get(id)
+    },
+
+    getAll(): Map<string, RuleRegistration> {
+      return new Map(registrations)
+    },
+
+    getEnabled(): Rule[] {
+      return Array.from(registrations.entries())
+        .filter(([, reg]) => reg.enabled)
+        .sort((a, b) => a[1].priority - b[1].priority)
+        .map(([, reg]) => resolveRule(reg))
+    },
+
+    has(id: string): boolean {
+      return registrations.has(id)
+    },
+
+    async evaluateFile(context: RuleContext): Promise<Result<readonly Issue[], RuleEngineError>> {
+      const issues: Issue[] = []
+      const enabledRules = this.getEnabled()
+
+      for (const rule of enabledRules) {
+        try {
+          const result = await rule.evaluate(context)
+          if (result.success) {
+            for (const violation of result.violations) {
+              issues.push(violationToIssue(violation, rule))
+            }
+          }
+        } catch (error) {
+          return {
+            success: false,
+            error: {
+              code: 'RULE_EXECUTION_ERROR',
+              message: `Rule ${rule.metadata.id} threw an error: ${error instanceof Error ? error.message : String(error)}`,
+              ruleId: rule.metadata.id,
+            },
+          }
+        }
+      }
+
+      return ok(issues)
+    },
+
+    async evaluateFiles(
+      contexts: readonly RuleContext[],
+    ): Promise<Result<readonly Issue[], RuleEngineError>> {
+      const allIssues: Issue[] = []
+
+      for (const context of contexts) {
+        const result = await this.evaluateFile(context)
+        if (!result.success) {
+          return result
+        }
+        allIssues.push(...result.data)
+      }
+
+      return ok(allIssues)
+    },
+  }
+}
+
+/**
+ * Default layer configuration for typical TypeScript projects.
+ */
+export const DEFAULT_LAYER_CONFIG: LayerConfiguration = {
+  layers: [
+    {name: 'domain', allowedDependencies: []},
+    {name: 'application', allowedDependencies: ['domain']},
+    {name: 'infrastructure', allowedDependencies: ['domain', 'application']},
+    {name: 'presentation', allowedDependencies: ['domain', 'application']},
+    {name: 'shared', allowedDependencies: []},
+  ],
+  patterns: [
+    {pattern: '**/domain/**', layer: 'domain'},
+    {pattern: '**/models/**', layer: 'domain'},
+    {pattern: '**/entities/**', layer: 'domain'},
+    {pattern: '**/application/**', layer: 'application'},
+    {pattern: '**/services/**', layer: 'application'},
+    {pattern: '**/use-cases/**', layer: 'application'},
+    {pattern: '**/infrastructure/**', layer: 'infrastructure'},
+    {pattern: '**/adapters/**', layer: 'infrastructure'},
+    {pattern: '**/repositories/**', layer: 'infrastructure'},
+    {pattern: '**/presentation/**', layer: 'presentation'},
+    {pattern: '**/ui/**', layer: 'presentation'},
+    {pattern: '**/components/**', layer: 'presentation'},
+    {pattern: '**/shared/**', layer: 'shared'},
+    {pattern: '**/utils/**', layer: 'shared'},
+    {pattern: '**/lib/**', layer: 'shared'},
+  ],
+}
+
+/**
+ * Determines the architectural layer for a file path based on patterns.
+ *
+ * @param filePath - File path to check
+ * @param config - Layer configuration
+ * @returns Layer name or undefined if no match
+ */
+export function getFileLayer(filePath: string, config: LayerConfiguration): string | undefined {
+  const normalizedPath = normalizePath(filePath)
+
+  for (const {pattern, layer} of config.patterns) {
+    if (matchPattern(normalizedPath, pattern)) {
+      return layer
+    }
+  }
+
+  return undefined
+}
+
+/**
+ * Checks if an import from one layer to another is allowed.
+ *
+ * @param sourceLayer - Layer of the importing file
+ * @param targetLayer - Layer of the imported module
+ * @param config - Layer configuration
+ * @returns Whether the import is allowed
+ */
+export function isLayerImportAllowed(
+  sourceLayer: string,
+  targetLayer: string,
+  config: LayerConfiguration,
+): boolean {
+  if (sourceLayer === targetLayer) {
+    return true
+  }
+
+  const sourceLayerDef = config.layers.find(l => l.name === sourceLayer)
+  if (sourceLayerDef === undefined) {
+    return true
+  }
+
+  return sourceLayerDef.allowedDependencies.includes(targetLayer)
+}
+
+/**
+ * Built-in rule IDs.
+ */
+export const BUILTIN_RULE_IDS = {
+  LAYER_VIOLATION: 'layer-violation',
+  BARREL_EXPORT: 'barrel-export',
+  PUBLIC_API: 'public-api',
+  SIDE_EFFECT: 'side-effect',
+  PATH_ALIAS: 'path-alias',
+  PACKAGE_BOUNDARY: 'package-boundary',
+} as const

--- a/packages/workspace-analyzer/src/utils/index.ts
+++ b/packages/workspace-analyzer/src/utils/index.ts
@@ -1,0 +1,7 @@
+/**
+ * Utility module exports.
+ *
+ * Provides shared utility functions used across the workspace analyzer package.
+ */
+
+export {matchAnyPattern, matchPattern, normalizePath} from './pattern-matcher'

--- a/packages/workspace-analyzer/src/utils/pattern-matcher.ts
+++ b/packages/workspace-analyzer/src/utils/pattern-matcher.ts
@@ -1,0 +1,48 @@
+/**
+ * Pattern matching utilities for glob-style file path matching.
+ *
+ * Provides simple glob pattern matching supporting ** (any path segments)
+ * and * (single segment) without external dependencies.
+ */
+
+/**
+ * Matches a file path against a glob pattern.
+ *
+ * Supported patterns:
+ * - `**` matches any number of path segments
+ * - `*` matches any characters except path separator
+ */
+export function matchPattern(filePath: string, pattern: string): boolean {
+  const normalizedPath = normalizePath(filePath)
+
+  const DOUBLE_STAR_PLACEHOLDER = '\0DOUBLE_STAR\0'
+  const regexPattern = pattern
+    .replaceAll('**', DOUBLE_STAR_PLACEHOLDER)
+    .replaceAll('*', '[^/]*')
+    .replaceAll(DOUBLE_STAR_PLACEHOLDER, '.*')
+    .replaceAll('/', String.raw`\/`)
+
+  const regex = new RegExp(regexPattern)
+  return regex.test(normalizedPath)
+}
+
+/**
+ * Checks if a file path matches any of the given patterns.
+ */
+export function matchAnyPattern(filePath: string, patterns: readonly string[]): boolean {
+  for (const pattern of patterns) {
+    if (matchPattern(filePath, pattern)) {
+      return true
+    }
+  }
+  return false
+}
+
+/**
+ * Normalizes a file path for consistent pattern matching.
+ *
+ * Converts backslashes to forward slashes for cross-platform compatibility.
+ */
+export function normalizePath(filePath: string): string {
+  return filePath.replaceAll('\\', '/')
+}

--- a/packages/workspace-analyzer/test/utils/pattern-matcher.test.ts
+++ b/packages/workspace-analyzer/test/utils/pattern-matcher.test.ts
@@ -1,0 +1,75 @@
+import {describe, expect, it} from 'vitest'
+
+import {matchAnyPattern, matchPattern, normalizePath} from '../../src/utils/pattern-matcher'
+
+describe('pattern-matcher', () => {
+  describe('normalizePath', () => {
+    it.concurrent('should convert backslashes to forward slashes', () => {
+      expect(normalizePath(String.raw`src\utils\index.ts`)).toBe('src/utils/index.ts')
+    })
+
+    it.concurrent('should preserve forward slashes', () => {
+      expect(normalizePath('src/utils/index.ts')).toBe('src/utils/index.ts')
+    })
+
+    it.concurrent('should handle mixed slashes', () => {
+      expect(normalizePath(String.raw`src\utils/test\file.ts`)).toBe('src/utils/test/file.ts')
+    })
+  })
+
+  describe('matchPattern', () => {
+    it.concurrent('should match exact paths', () => {
+      expect(matchPattern('src/index.ts', 'src/index.ts')).toBe(true)
+    })
+
+    it.concurrent('should match with single asterisk wildcard', () => {
+      expect(matchPattern('src/utils.ts', 'src/*.ts')).toBe(true)
+      expect(matchPattern('src/helpers.ts', 'src/*.ts')).toBe(true)
+      expect(matchPattern('lib/utils.ts', 'src/*.ts')).toBe(false)
+    })
+
+    it.concurrent('should match with double asterisk wildcard', () => {
+      expect(matchPattern('src/components/Button.tsx', '**/Button.tsx')).toBe(true)
+      expect(matchPattern('deep/nested/path/Button.tsx', '**/Button.tsx')).toBe(true)
+    })
+
+    it.concurrent('should match directory patterns', () => {
+      expect(matchPattern('src/domain/models/user.ts', '**/domain/**')).toBe(true)
+      expect(matchPattern('src/application/services/auth.ts', '**/application/**')).toBe(true)
+      expect(matchPattern('src/other/file.ts', '**/domain/**')).toBe(false)
+    })
+
+    it.concurrent('should handle index.ts patterns', () => {
+      expect(matchPattern('src/index.ts', '**/index.ts')).toBe(true)
+      expect(matchPattern('packages/es/src/index.ts', '**/index.ts')).toBe(true)
+    })
+
+    it.concurrent('should normalize Windows-style paths', () => {
+      expect(matchPattern(String.raw`src\domain\user.ts`, '**/domain/**')).toBe(true)
+    })
+  })
+
+  describe('matchAnyPattern', () => {
+    it.concurrent('should return true if any pattern matches', () => {
+      const patterns = ['**/node_modules/**', '**/dist/**', '**/coverage/**']
+      expect(matchAnyPattern('path/to/node_modules/lodash/index.js', patterns)).toBe(true)
+      expect(matchAnyPattern('output/dist/bundle.js', patterns)).toBe(true)
+    })
+
+    it.concurrent('should return false if no pattern matches', () => {
+      const patterns = ['**/node_modules/**', '**/dist/**']
+      expect(matchAnyPattern('src/utils/helpers.ts', patterns)).toBe(false)
+    })
+
+    it.concurrent('should handle empty patterns array', () => {
+      expect(matchAnyPattern('src/file.ts', [])).toBe(false)
+    })
+
+    it.concurrent('should match allowed file patterns', () => {
+      const allowedPatterns = ['**/index.ts', '**/*.d.ts']
+      expect(matchAnyPattern('src/index.ts', allowedPatterns)).toBe(true)
+      expect(matchAnyPattern('types/global.d.ts', allowedPatterns)).toBe(true)
+      expect(matchAnyPattern('src/utils.ts', allowedPatterns)).toBe(false)
+    })
+  })
+})


### PR DESCRIPTION
- Introduce built-in architectural rules for workspace analysis.
- Implement layer violation, barrel export, public API, side effect, path alias, and package boundary rules.
- Create a rule engine to manage and evaluate architectural rules.
- Enhance the analyzer registry to include architectural analyzers.
- Update index files to export new architectural rule types and functions.

Closes #2401.