### PR TITLE
feat(workspace-analyzer): add reporting for workspace analysis

### DIFF
--- a/.ai/plan/feature-workspace-analyzer-1.md
+++ b/.ai/plan/feature-workspace-analyzer-1.md
@@ -2,7 +2,7 @@
 goal: Create @bfra.me/workspace-analyzer Package for Comprehensive Monorepo Static Analysis
 version: 1.2
 date_created: 2025-11-29
-last_updated: 2025-12-06
+last_updated: 2025-12-07
 owner: marcusrbrown
 status: 'In Progress'
 tags: ['feature', 'package', 'typescript', 'static-analysis', 'ast', 'monorepo', 'architecture', 'cli']
@@ -168,14 +168,14 @@ Create a new `@bfra.me/workspace-analyzer` package in the bfra.me/works monorepo
 
 | Task | Description | Completed | Date |
 |------|-------------|-----------|------|
-| TASK-053 | Create report generator interface in `src/reporters/reporter.ts` | | |
-| TASK-054 | Implement `JsonReporter` in `src/reporters/json-reporter.ts` for machine-readable output | | |
-| TASK-055 | Implement `MarkdownReporter` in `src/reporters/markdown-reporter.ts` for human-readable summaries | | |
-| TASK-056 | Implement `ConsoleReporter` in `src/reporters/console-reporter.ts` using consola for colored terminal output | | |
-| TASK-057 | Add severity filtering and grouping options | | |
-| TASK-058 | Implement fix suggestions in report output where applicable | | |
-| TASK-059 | Create summary statistics (total issues, by category, by severity) | | |
-| TASK-060 | Add file-based issue location with line/column numbers | | |
+| TASK-053 | Create report generator interface in `src/reporters/reporter.ts` | ✅ | 2025-12-07 |
+| TASK-054 | Implement `JsonReporter` in `src/reporters/json-reporter.ts` for machine-readable output | ✅ | 2025-12-07 |
+| TASK-055 | Implement `MarkdownReporter` in `src/reporters/markdown-reporter.ts` for human-readable summaries | ✅ | 2025-12-07 |
+| TASK-056 | Implement `ConsoleReporter` in `src/reporters/console-reporter.ts` using consola for colored terminal output | ✅ | 2025-12-07 |
+| TASK-057 | Add severity filtering and grouping options | ✅ | 2025-12-07 |
+| TASK-058 | Implement fix suggestions in report output where applicable | ✅ | 2025-12-07 |
+| TASK-059 | Create summary statistics (total issues, by category, by severity) | ✅ | 2025-12-07 |
+| TASK-060 | Add file-based issue location with line/column numbers | ✅ | 2025-12-07 |
 
 ### Implementation Phase 8: Caching and Incremental Analysis
 

--- a/packages/workspace-analyzer/src/index.ts
+++ b/packages/workspace-analyzer/src/index.ts
@@ -196,6 +196,40 @@ export type {
   TreeShakingSavingsEstimate,
 } from './performance/index'
 
+// Reporter utilities (Phase 7)
+export {
+  calculateSummary,
+  CATEGORY_CONFIG,
+  createConsoleReporter,
+  createJsonReporter,
+  createMarkdownReporter,
+  DEFAULT_REPORT_OPTIONS,
+  filterIssuesForReport,
+  formatDuration,
+  formatLocation,
+  getRelativePath,
+  groupIssues,
+  SEVERITY_CONFIG,
+  truncateText,
+} from './reporters/index'
+
+export type {
+  ConsoleReporterOptions,
+  GroupedIssues,
+  JsonReport,
+  JsonReporterOptions,
+  JsonReportGroup,
+  JsonReportIssue,
+  JsonReportLocation,
+  JsonReportMetadata,
+  MarkdownReporterOptions,
+  Reporter,
+  ReporterFactory,
+  ReportFormat,
+  ReportOptions,
+  ReportSummary,
+} from './reporters/index'
+
 // Rules engine and built-in rules (Phase 5)
 export {
   barrelExportRuleMetadata,
@@ -287,6 +321,7 @@ export {
 } from './types/index'
 
 export type {Err, Ok, Result} from './types/index'
+
 // Utility functions
 export {matchAnyPattern, matchPattern, normalizePath} from './utils/index'
 

--- a/packages/workspace-analyzer/src/reporters/console-reporter.ts
+++ b/packages/workspace-analyzer/src/reporters/console-reporter.ts
@@ -1,0 +1,355 @@
+/**
+ * Console reporter for terminal output with colors and formatting.
+ *
+ * Generates colorful terminal output using consola and @clack/prompts
+ * for interactive analysis feedback and CI/CD integration.
+ */
+
+import type {AnalysisResult, Issue, Severity} from '../types/index'
+import type {GroupedIssues, Reporter, ReportOptions, ReportSummary} from './reporter'
+
+import * as p from '@clack/prompts'
+import {consola} from 'consola'
+
+import {
+  calculateSummary,
+  CATEGORY_CONFIG,
+  DEFAULT_REPORT_OPTIONS,
+  filterIssuesForReport,
+  formatDuration,
+  getRelativePath,
+  groupIssues,
+  SEVERITY_CONFIG,
+  truncateText,
+} from './reporter'
+
+/**
+ * Options specific to console reporter.
+ */
+export interface ConsoleReporterOptions extends ReportOptions {
+  /** Whether to use colors (auto-detected by default) */
+  readonly colors?: boolean
+  /** Whether to show verbose output with full descriptions */
+  readonly verbose?: boolean
+  /** Whether to show compact output (one line per issue) */
+  readonly compact?: boolean
+  /** Maximum width for text wrapping */
+  readonly maxWidth?: number
+  /** Whether to use @clack/prompts styling */
+  readonly useClack?: boolean
+}
+
+/**
+ * Create a console reporter instance.
+ *
+ * @example
+ * ```ts
+ * const reporter = createConsoleReporter({verbose: true})
+ * reporter.generate(analysisResult) // Outputs to console
+ * ```
+ */
+export function createConsoleReporter(defaultOptions?: ConsoleReporterOptions): Reporter {
+  return {
+    id: 'console',
+    name: 'Console Reporter',
+    generate(result: AnalysisResult, options?: ReportOptions): string {
+      const mergedOptions: ConsoleReporterOptions = {
+        ...DEFAULT_REPORT_OPTIONS,
+        ...defaultOptions,
+        ...options,
+      }
+
+      const output = generateConsoleOutput(result, mergedOptions)
+      printToConsole(output, mergedOptions)
+      return output.join('\n')
+    },
+    stream(result: AnalysisResult, write: (chunk: string) => void, options?: ReportOptions): void {
+      const output = this.generate(result, options)
+      write(output)
+    },
+  }
+}
+
+/**
+ * Generate console output lines.
+ */
+function generateConsoleOutput(result: AnalysisResult, options: ConsoleReporterOptions): string[] {
+  const lines: string[] = []
+  const filteredIssues = filterIssuesForReport(result.issues, options)
+  const summary = calculateSummary({...result, issues: filteredIssues})
+  const grouped = groupIssues(filteredIssues, options.groupBy)
+
+  lines.push(...generateHeader(summary))
+  lines.push('')
+
+  if (options.includeSummary) {
+    lines.push(...generateSummary(summary))
+    lines.push('')
+  }
+
+  lines.push(...generateIssuesList(grouped, result.workspacePath, options))
+
+  lines.push('')
+  lines.push(...generateFooter(summary, result))
+
+  return lines
+}
+
+/**
+ * Generate header section.
+ */
+function generateHeader(summary: ReportSummary): string[] {
+  const lines: string[] = []
+  const status = getStatusIcon(summary.highestSeverity)
+  const statusText =
+    summary.totalIssues === 0 ? 'No issues found' : `${summary.totalIssues} issue(s) found`
+
+  lines.push('─'.repeat(60))
+  lines.push(`${status} Workspace Analysis Report`)
+  lines.push(`   ${statusText}`)
+  lines.push('─'.repeat(60))
+
+  return lines
+}
+
+/**
+ * Generate summary section.
+ */
+function generateSummary(summary: ReportSummary): string[] {
+  const lines: string[] = []
+
+  lines.push('📊 Summary')
+  lines.push('')
+
+  const severityCounts: string[] = []
+  for (const severity of ['critical', 'error', 'warning', 'info'] as const) {
+    const count = summary.bySeverity[severity]
+    if (count > 0) {
+      const icon = SEVERITY_CONFIG[severity].emoji
+      severityCounts.push(`${icon} ${count} ${severity}`)
+    }
+  }
+
+  if (severityCounts.length > 0) {
+    lines.push(`   ${severityCounts.join('  |  ')}`)
+  } else {
+    lines.push('   ✅ No issues!')
+  }
+
+  lines.push('')
+  lines.push(
+    `   📦 ${summary.packagesAnalyzed} packages  |  📄 ${summary.filesAnalyzed} files  |  ⏱️  ${formatDuration(summary.durationMs)}`,
+  )
+
+  return lines
+}
+
+/**
+ * Generate issues list.
+ */
+function generateIssuesList(
+  groups: readonly GroupedIssues[],
+  workspacePath: string,
+  options: ConsoleReporterOptions,
+): string[] {
+  const lines: string[] = []
+
+  if (groups.length === 0 || groups.every(g => g.count === 0)) {
+    lines.push('✅ No issues to report!')
+    return lines
+  }
+
+  for (const group of groups) {
+    if (group.count === 0) {
+      continue
+    }
+
+    lines.push('')
+    lines.push(...generateGroupSection(group, workspacePath, options))
+  }
+
+  return lines
+}
+
+/**
+ * Generate a group section.
+ */
+function generateGroupSection(
+  group: GroupedIssues,
+  workspacePath: string,
+  options: ConsoleReporterOptions,
+): string[] {
+  const lines: string[] = []
+
+  const groupIcon = getGroupIcon(group.key, options.groupBy)
+  lines.push(`${groupIcon} ${group.label} (${group.count})`)
+  lines.push('')
+
+  const maxIssues = options.maxIssuesPerGroup ?? 50
+  const issuesToShow = group.issues.slice(0, maxIssues)
+  const remainingCount = group.count - issuesToShow.length
+
+  for (const issue of issuesToShow) {
+    if (options.compact) {
+      lines.push(formatCompactIssue(issue, workspacePath))
+    } else {
+      lines.push(...formatDetailedIssue(issue, workspacePath, options))
+    }
+  }
+
+  if (remainingCount > 0) {
+    lines.push(`   ... and ${remainingCount} more issue(s)`)
+  }
+
+  return lines
+}
+
+/**
+ * Format an issue in compact mode (single line).
+ */
+function formatCompactIssue(issue: Issue, workspacePath: string): string {
+  const icon = SEVERITY_CONFIG[issue.severity].emoji
+  const relativePath = getRelativePath(issue.location.filePath, workspacePath)
+  const location =
+    issue.location.line === undefined ? relativePath : `${relativePath}:${issue.location.line}`
+  const title = truncateText(issue.title, 50)
+
+  return `   ${icon} ${location}: ${title}`
+}
+
+/**
+ * Format an issue in detailed mode.
+ */
+function formatDetailedIssue(
+  issue: Issue,
+  workspacePath: string,
+  options: ConsoleReporterOptions,
+): string[] {
+  const lines: string[] = []
+  const icon = SEVERITY_CONFIG[issue.severity].emoji
+  const severityLabel = SEVERITY_CONFIG[issue.severity].label.toUpperCase()
+
+  lines.push(`   ${icon} [${severityLabel}] ${issue.title}`)
+
+  const relativePath = getRelativePath(issue.location.filePath, workspacePath)
+  let location = `      📍 ${relativePath}`
+  if (issue.location.line !== undefined) {
+    location += `:${issue.location.line}`
+    if (issue.location.column !== undefined) {
+      location += `:${issue.location.column}`
+    }
+  }
+  lines.push(location)
+
+  if (options.verbose) {
+    const maxWidth = options.maxWidth ?? 80
+    const wrappedDesc = wrapText(issue.description, maxWidth - 9)
+    for (const line of wrappedDesc) {
+      lines.push(`         ${line}`)
+    }
+  }
+
+  if (options.includeSuggestions && issue.suggestion !== undefined) {
+    lines.push(`      💡 ${issue.suggestion}`)
+  }
+
+  lines.push('')
+
+  return lines
+}
+
+/**
+ * Generate footer section.
+ */
+function generateFooter(summary: ReportSummary, result: AnalysisResult): string[] {
+  const lines: string[] = []
+
+  lines.push('─'.repeat(60))
+
+  if (summary.totalIssues === 0) {
+    lines.push('✅ Your workspace looks great!')
+  } else {
+    const recommendations: string[] = []
+    if (summary.bySeverity.critical > 0 || summary.bySeverity.error > 0) {
+      recommendations.push('Fix critical and error issues first')
+    }
+    if (summary.bySeverity.warning > 0) {
+      recommendations.push('Review warnings for potential improvements')
+    }
+
+    if (recommendations.length > 0) {
+      lines.push('💡 Recommendations:')
+      for (const rec of recommendations) {
+        lines.push(`   • ${rec}`)
+      }
+    }
+  }
+
+  const duration = formatDuration(result.completedAt.getTime() - result.startedAt.getTime())
+  lines.push('')
+  lines.push(`Analysis completed in ${duration}`)
+
+  return lines
+}
+
+/**
+ * Print output to console using appropriate method.
+ */
+function printToConsole(lines: string[], options: ConsoleReporterOptions): void {
+  if (options.useClack) {
+    p.log.message(lines.join('\n'))
+  } else {
+    for (const line of lines) {
+      consola.log(line)
+    }
+  }
+}
+
+/**
+ * Get status icon based on severity.
+ */
+function getStatusIcon(severity: Severity | null): string {
+  if (severity === null) {
+    return '✅'
+  }
+  return SEVERITY_CONFIG[severity].emoji
+}
+
+/**
+ * Get group icon based on groupBy option.
+ */
+function getGroupIcon(key: string, groupBy: ReportOptions['groupBy']): string {
+  if (groupBy === 'severity') {
+    return SEVERITY_CONFIG[key as Severity]?.emoji ?? '📋'
+  }
+  if (groupBy === 'category') {
+    return CATEGORY_CONFIG[key as keyof typeof CATEGORY_CONFIG]?.emoji ?? '📋'
+  }
+  return '📄'
+}
+
+/**
+ * Wrap text to specified width.
+ */
+function wrapText(text: string, maxWidth: number): string[] {
+  const words = text.split(/\s+/)
+  const lines: string[] = []
+  let currentLine = ''
+
+  for (const word of words) {
+    if (currentLine.length + word.length + 1 <= maxWidth) {
+      currentLine += (currentLine.length > 0 ? ' ' : '') + word
+    } else {
+      if (currentLine.length > 0) {
+        lines.push(currentLine)
+      }
+      currentLine = word
+    }
+  }
+
+  if (currentLine.length > 0) {
+    lines.push(currentLine)
+  }
+
+  return lines
+}

--- a/packages/workspace-analyzer/src/reporters/index.ts
+++ b/packages/workspace-analyzer/src/reporters/index.ts
@@ -1,0 +1,49 @@
+/**
+ * Reporter exports for workspace analysis output.
+ *
+ * Provides a unified API for generating analysis reports in various formats:
+ * - JSON: Machine-readable output for CI/CD integration
+ * - Markdown: Human-readable reports for documentation and review
+ * - Console: Terminal output with colors for interactive feedback
+ */
+
+// Console reporter exports
+export type {ConsoleReporterOptions} from './console-reporter'
+export {createConsoleReporter} from './console-reporter'
+
+// JSON reporter exports
+export type {
+  JsonReport,
+  JsonReporterOptions,
+  JsonReportGroup,
+  JsonReportIssue,
+  JsonReportLocation,
+  JsonReportMetadata,
+} from './json-reporter'
+export {createJsonReporter} from './json-reporter'
+
+// Markdown reporter exports
+export type {MarkdownReporterOptions} from './markdown-reporter'
+export {createMarkdownReporter} from './markdown-reporter'
+
+// Core reporter types and utilities
+export type {
+  GroupedIssues,
+  Reporter,
+  ReporterFactory,
+  ReportFormat,
+  ReportOptions,
+  ReportSummary,
+} from './reporter'
+export {
+  calculateSummary,
+  CATEGORY_CONFIG,
+  DEFAULT_REPORT_OPTIONS,
+  filterIssuesForReport,
+  formatDuration,
+  formatLocation,
+  getRelativePath,
+  groupIssues,
+  SEVERITY_CONFIG,
+  truncateText,
+} from './reporter'

--- a/packages/workspace-analyzer/src/reporters/json-reporter.ts
+++ b/packages/workspace-analyzer/src/reporters/json-reporter.ts
@@ -1,0 +1,273 @@
+/**
+ * JSON reporter for machine-readable analysis output.
+ *
+ * Generates structured JSON reports suitable for CI/CD integration,
+ * programmatic processing, and data analysis tools.
+ */
+
+import type {AnalysisResult, Issue} from '../types/index'
+import type {Reporter, ReportOptions, ReportSummary} from './reporter'
+
+import {
+  calculateSummary,
+  DEFAULT_REPORT_OPTIONS,
+  filterIssuesForReport,
+  getRelativePath,
+  groupIssues,
+} from './reporter'
+
+/**
+ * JSON report structure for serialization.
+ */
+export interface JsonReport {
+  /** Schema version for compatibility checking */
+  readonly $schema?: string
+  /** Report metadata */
+  readonly metadata: JsonReportMetadata
+  /** Summary statistics */
+  readonly summary: ReportSummary
+  /** All issues (filtered based on options) */
+  readonly issues: readonly JsonReportIssue[]
+  /** Issues grouped by the specified key */
+  readonly groupedIssues?: readonly JsonReportGroup[]
+}
+
+/**
+ * Report metadata for provenance tracking.
+ */
+export interface JsonReportMetadata {
+  /** Report generation timestamp (ISO 8601) */
+  readonly generatedAt: string
+  /** Analysis start timestamp (ISO 8601) */
+  readonly analysisStartedAt: string
+  /** Analysis completion timestamp (ISO 8601) */
+  readonly analysisCompletedAt: string
+  /** Workspace path that was analyzed */
+  readonly workspacePath: string
+  /** Report options used for generation */
+  readonly reportOptions: Partial<ReportOptions>
+  /** Analyzer version (if available) */
+  readonly version?: string
+}
+
+/**
+ * Issue representation in JSON report.
+ */
+export interface JsonReportIssue {
+  /** Issue identifier */
+  readonly id: string
+  /** Issue title */
+  readonly title: string
+  /** Issue description */
+  readonly description: string
+  /** Severity level */
+  readonly severity: Issue['severity']
+  /** Issue category */
+  readonly category: Issue['category']
+  /** File location */
+  readonly location: JsonReportLocation
+  /** Related locations (for multi-file issues like circular imports) */
+  readonly relatedLocations?: readonly JsonReportLocation[]
+  /** Suggested fix */
+  readonly suggestion?: string
+  /** Additional metadata */
+  readonly metadata?: Readonly<Record<string, unknown>>
+}
+
+/**
+ * Location representation in JSON report.
+ */
+export interface JsonReportLocation {
+  /** File path (relative to workspace root) */
+  readonly file: string
+  /** Absolute file path */
+  readonly absolutePath: string
+  /** Line number (1-indexed) */
+  readonly line?: number
+  /** Column number (1-indexed) */
+  readonly column?: number
+  /** End line number (1-indexed) */
+  readonly endLine?: number
+  /** End column number (1-indexed) */
+  readonly endColumn?: number
+}
+
+/**
+ * Grouped issues in JSON report.
+ */
+export interface JsonReportGroup {
+  /** Group key */
+  readonly key: string
+  /** Group label */
+  readonly label: string
+  /** Number of issues in group */
+  readonly count: number
+  /** Issues in this group */
+  readonly issues: readonly JsonReportIssue[]
+}
+
+/**
+ * Options specific to JSON reporter.
+ */
+export interface JsonReporterOptions extends ReportOptions {
+  /** Whether to pretty-print JSON output */
+  readonly prettyPrint?: boolean
+  /** Indentation size for pretty-printing (default: 2) */
+  readonly indentation?: number
+  /** Whether to include grouped issues section */
+  readonly includeGroupedIssues?: boolean
+  /** JSON schema URL for validation */
+  readonly schemaUrl?: string
+}
+
+/**
+ * Create a JSON reporter instance.
+ *
+ * @example
+ * ```ts
+ * const reporter = createJsonReporter({prettyPrint: true})
+ * const json = reporter.generate(analysisResult)
+ * await fs.writeFile('report.json', json)
+ * ```
+ */
+export function createJsonReporter(defaultOptions?: JsonReporterOptions): Reporter {
+  return {
+    id: 'json',
+    name: 'JSON Reporter',
+    generate(result: AnalysisResult, options?: ReportOptions): string {
+      const mergedOptions: JsonReporterOptions = {
+        ...DEFAULT_REPORT_OPTIONS,
+        ...defaultOptions,
+        ...options,
+      }
+
+      const report = generateJsonReport(result, mergedOptions)
+      const prettyPrint = mergedOptions.prettyPrint ?? true
+      const indentation = mergedOptions.indentation ?? 2
+
+      return prettyPrint ? JSON.stringify(report, null, indentation) : JSON.stringify(report)
+    },
+    stream(result: AnalysisResult, write: (chunk: string) => void, options?: ReportOptions): void {
+      const output = this.generate(result, options)
+      write(output)
+    },
+  }
+}
+
+/**
+ * Generate the complete JSON report structure.
+ */
+function generateJsonReport(result: AnalysisResult, options: JsonReporterOptions): JsonReport {
+  const filteredIssues = filterIssuesForReport(result.issues, options)
+  const summary = calculateSummary({...result, issues: filteredIssues})
+
+  const baseReport: JsonReport = {
+    metadata: generateMetadata(result, options),
+    summary,
+    issues: filteredIssues.map(issue => formatIssueForJson(issue, result.workspacePath, options)),
+  }
+
+  const report: JsonReport =
+    options.schemaUrl === undefined ? baseReport : {$schema: options.schemaUrl, ...baseReport}
+
+  if (options.includeGroupedIssues ?? options.groupBy !== 'none') {
+    const grouped = groupIssues(filteredIssues, options.groupBy)
+    return {
+      ...report,
+      groupedIssues: grouped.map(group => ({
+        key: group.key,
+        label: group.label,
+        count: group.count,
+        issues: group.issues.map(issue => formatIssueForJson(issue, result.workspacePath, options)),
+      })),
+    }
+  }
+
+  return report
+}
+
+/**
+ * Generate report metadata.
+ */
+function generateMetadata(
+  result: AnalysisResult,
+  options: JsonReporterOptions,
+): JsonReportMetadata {
+  const {schemaUrl, prettyPrint, indentation, includeGroupedIssues, ...reportOptions} = options
+
+  return {
+    generatedAt: new Date().toISOString(),
+    analysisStartedAt: result.startedAt.toISOString(),
+    analysisCompletedAt: result.completedAt.toISOString(),
+    workspacePath: result.workspacePath,
+    reportOptions,
+  }
+}
+
+/**
+ * Format a single issue for JSON output.
+ *
+ * Accumulates optional properties (relatedLocations, suggestion, metadata)
+ * based on issue data and report options.
+ */
+function formatIssueForJson(
+  issue: Issue,
+  workspacePath: string,
+  options: JsonReporterOptions,
+): JsonReportIssue {
+  let jsonIssue: JsonReportIssue = {
+    id: issue.id,
+    title: issue.title,
+    description: issue.description,
+    severity: issue.severity,
+    category: issue.category,
+    location: formatLocationForJson(issue.location, workspacePath, options),
+  }
+
+  if (issue.relatedLocations !== undefined && issue.relatedLocations.length > 0) {
+    jsonIssue = {
+      ...jsonIssue,
+      relatedLocations: issue.relatedLocations.map(loc =>
+        formatLocationForJson(loc, workspacePath, options),
+      ),
+    }
+  }
+
+  if (options.includeSuggestions === true && issue.suggestion !== undefined) {
+    jsonIssue = {...jsonIssue, suggestion: issue.suggestion}
+  }
+
+  if (options.includeMetadata === true && issue.metadata !== undefined) {
+    jsonIssue = {...jsonIssue, metadata: issue.metadata}
+  }
+
+  return jsonIssue
+}
+
+/**
+ * Format a location for JSON output.
+ */
+function formatLocationForJson(
+  location: Issue['location'],
+  workspacePath: string,
+  options: JsonReporterOptions,
+): JsonReportLocation {
+  const baseLocation: JsonReportLocation = {
+    file: getRelativePath(location.filePath, workspacePath),
+    absolutePath: location.filePath,
+  }
+
+  if (!options.includeLocation) {
+    return baseLocation
+  }
+
+  const result: JsonReportLocation = {
+    ...baseLocation,
+    ...(location.line === undefined ? {} : {line: location.line}),
+    ...(location.column === undefined ? {} : {column: location.column}),
+    ...(location.endLine === undefined ? {} : {endLine: location.endLine}),
+    ...(location.endColumn === undefined ? {} : {endColumn: location.endColumn}),
+  }
+
+  return result
+}

--- a/packages/workspace-analyzer/src/reporters/markdown-reporter.ts
+++ b/packages/workspace-analyzer/src/reporters/markdown-reporter.ts
@@ -1,0 +1,349 @@
+/**
+ * Markdown reporter for human-readable analysis output.
+ *
+ * Generates well-formatted Markdown reports suitable for GitHub issues,
+ * pull request comments, documentation, and team review.
+ */
+
+import type {AnalysisResult, Issue, Severity} from '../types/index'
+import type {GroupedIssues, Reporter, ReportOptions, ReportSummary} from './reporter'
+
+import {
+  calculateSummary,
+  CATEGORY_CONFIG,
+  DEFAULT_REPORT_OPTIONS,
+  filterIssuesForReport,
+  formatDuration,
+  getRelativePath,
+  groupIssues,
+  SEVERITY_CONFIG,
+} from './reporter'
+
+/**
+ * Options specific to Markdown reporter.
+ */
+export interface MarkdownReporterOptions extends ReportOptions {
+  /** Whether to use GitHub-flavored Markdown features (checkboxes, alerts) */
+  readonly githubFlavored?: boolean
+  /** Title for the report document */
+  readonly title?: string
+  /** Whether to include table of contents */
+  readonly includeTableOfContents?: boolean
+  /** Whether to use emoji in headers and status */
+  readonly useEmoji?: boolean
+  /** Whether to use collapsible sections for issue details */
+  readonly collapsibleDetails?: boolean
+  /** Maximum issues to show per group before truncating */
+  readonly maxIssuesPerGroup?: number
+}
+
+/**
+ * Create a Markdown reporter instance.
+ *
+ * @example
+ * ```ts
+ * const reporter = createMarkdownReporter({githubFlavored: true})
+ * const markdown = reporter.generate(analysisResult)
+ * await fs.writeFile('report.md', markdown)
+ * ```
+ */
+export function createMarkdownReporter(defaultOptions?: MarkdownReporterOptions): Reporter {
+  return {
+    id: 'markdown',
+    name: 'Markdown Reporter',
+    generate(result: AnalysisResult, options?: ReportOptions): string {
+      const mergedOptions: MarkdownReporterOptions = {
+        ...DEFAULT_REPORT_OPTIONS,
+        ...defaultOptions,
+        ...options,
+      }
+
+      return generateMarkdownReport(result, mergedOptions)
+    },
+    stream(result: AnalysisResult, write: (chunk: string) => void, options?: ReportOptions): void {
+      const output = this.generate(result, options)
+      write(output)
+    },
+  }
+}
+
+/**
+ * Generate the complete Markdown report.
+ */
+function generateMarkdownReport(result: AnalysisResult, options: MarkdownReporterOptions): string {
+  const lines: string[] = []
+  const filteredIssues = filterIssuesForReport(result.issues, options)
+  const summary = calculateSummary({...result, issues: filteredIssues})
+  const grouped = groupIssues(filteredIssues, options.groupBy)
+  const useEmoji = options.useEmoji ?? true
+
+  lines.push(generateTitle(options, summary, useEmoji))
+  lines.push('')
+
+  if (options.githubFlavored) {
+    lines.push(generateGitHubAlert(summary))
+    lines.push('')
+  }
+
+  if (options.includeTableOfContents && grouped.length > 1) {
+    lines.push(generateTableOfContents(grouped, options))
+    lines.push('')
+  }
+
+  if (options.includeSummary) {
+    lines.push(generateSummarySection(summary, result, options, useEmoji))
+    lines.push('')
+  }
+
+  lines.push(generateIssuesSection(grouped, result.workspacePath, options, useEmoji))
+
+  return lines.join('\n')
+}
+
+/**
+ * Generate report title.
+ */
+function generateTitle(
+  options: MarkdownReporterOptions,
+  summary: ReportSummary,
+  useEmoji: boolean,
+): string {
+  const title = options.title ?? 'Workspace Analysis Report'
+  const statusEmoji = getStatusEmoji(summary.highestSeverity, useEmoji)
+  return `# ${statusEmoji} ${title}`
+}
+
+/**
+ * Generate GitHub alert box based on severity.
+ */
+function generateGitHubAlert(summary: ReportSummary): string {
+  if (summary.totalIssues === 0) {
+    return '> [!TIP]\n> No issues found! Your workspace is in great shape.'
+  }
+
+  if (summary.highestSeverity === 'critical' || summary.highestSeverity === 'error') {
+    return `> [!CAUTION]\n> Found ${summary.totalIssues} issue(s) requiring attention.`
+  }
+
+  if (summary.highestSeverity === 'warning') {
+    return `> [!WARNING]\n> Found ${summary.totalIssues} issue(s) to review.`
+  }
+
+  return `> [!NOTE]\n> Found ${summary.totalIssues} informational issue(s).`
+}
+
+/**
+ * Generate table of contents.
+ */
+function generateTableOfContents(
+  groups: readonly GroupedIssues[],
+  options: MarkdownReporterOptions,
+): string {
+  const lines: string[] = ['## Table of Contents', '']
+
+  if (options.includeSummary) {
+    lines.push('- [Summary](#summary)')
+  }
+
+  for (const group of groups) {
+    const anchor = group.label.toLowerCase().replaceAll(/[^a-z0-9]+/g, '-')
+    lines.push(`- [${group.label}](#${anchor}) (${group.count})`)
+  }
+
+  return lines.join('\n')
+}
+
+/**
+ * Generate summary statistics section.
+ */
+function generateSummarySection(
+  summary: ReportSummary,
+  _result: AnalysisResult,
+  _options: MarkdownReporterOptions,
+  useEmoji: boolean,
+): string {
+  const lines: string[] = ['## Summary', '']
+
+  lines.push('### Overview', '')
+  lines.push(`| Metric | Value |`)
+  lines.push(`|--------|-------|`)
+  lines.push(`| Total Issues | ${summary.totalIssues} |`)
+  lines.push(`| Packages Analyzed | ${summary.packagesAnalyzed} |`)
+  lines.push(`| Files Analyzed | ${summary.filesAnalyzed} |`)
+  lines.push(`| Files with Issues | ${summary.filesWithIssues} |`)
+  lines.push(`| Duration | ${formatDuration(summary.durationMs)} |`)
+  lines.push('')
+
+  lines.push('### Issues by Severity', '')
+  lines.push(`| Severity | Count |`)
+  lines.push(`|----------|-------|`)
+  for (const severity of ['critical', 'error', 'warning', 'info'] as const) {
+    const count = summary.bySeverity[severity]
+    const config = SEVERITY_CONFIG[severity]
+    const emoji = useEmoji ? `${config.emoji} ` : ''
+    lines.push(`| ${emoji}${config.label} | ${count} |`)
+  }
+  lines.push('')
+
+  lines.push('### Issues by Category', '')
+  lines.push(`| Category | Count |`)
+  lines.push(`|----------|-------|`)
+  for (const [category, count] of Object.entries(summary.byCategory)) {
+    if (count > 0) {
+      const config = CATEGORY_CONFIG[category as keyof typeof CATEGORY_CONFIG]
+      const emoji = useEmoji ? `${config.emoji} ` : ''
+      lines.push(`| ${emoji}${config.label} | ${count} |`)
+    }
+  }
+
+  return lines.join('\n')
+}
+
+/**
+ * Generate issues section with grouping.
+ */
+function generateIssuesSection(
+  groups: readonly GroupedIssues[],
+  workspacePath: string,
+  options: MarkdownReporterOptions,
+  useEmoji: boolean,
+): string {
+  const lines: string[] = ['## Issues', '']
+
+  if (groups.length === 0 || groups.every(g => g.count === 0)) {
+    lines.push(useEmoji ? '✅ No issues found!' : 'No issues found!')
+    return lines.join('\n')
+  }
+
+  for (const group of groups) {
+    if (group.count === 0) {
+      continue
+    }
+
+    lines.push(generateGroupHeader(group, options, useEmoji))
+    lines.push('')
+
+    const maxIssues = options.maxIssuesPerGroup ?? 50
+    const issuesToShow = group.issues.slice(0, maxIssues)
+    const remainingCount = group.count - issuesToShow.length
+
+    for (const issue of issuesToShow) {
+      lines.push(formatIssueMarkdown(issue, workspacePath, options, useEmoji))
+      lines.push('')
+    }
+
+    if (remainingCount > 0) {
+      lines.push(`*...and ${remainingCount} more issue(s)*`)
+      lines.push('')
+    }
+  }
+
+  return lines.join('\n')
+}
+
+/**
+ * Generate group header.
+ */
+function generateGroupHeader(
+  group: GroupedIssues,
+  options: MarkdownReporterOptions,
+  useEmoji: boolean,
+): string {
+  let emoji = ''
+  if (useEmoji) {
+    if (options.groupBy === 'severity') {
+      const severityEmoji = SEVERITY_CONFIG[group.key as Severity]?.emoji
+      emoji = severityEmoji === undefined ? '' : `${severityEmoji} `
+    } else if (options.groupBy === 'category') {
+      const categoryEmoji = CATEGORY_CONFIG[group.key as keyof typeof CATEGORY_CONFIG]?.emoji
+      emoji = categoryEmoji === undefined ? '' : `${categoryEmoji} `
+    } else {
+      emoji = '📄 '
+    }
+  }
+
+  return `### ${emoji}${group.label} (${group.count})`
+}
+
+/**
+ * Format a single issue as Markdown.
+ */
+function formatIssueMarkdown(
+  issue: Issue,
+  workspacePath: string,
+  options: MarkdownReporterOptions,
+  useEmoji: boolean,
+): string {
+  const lines: string[] = []
+  const severityConfig = SEVERITY_CONFIG[issue.severity]
+  const emoji = useEmoji ? `${severityConfig.emoji} ` : ''
+
+  const severityBadge = `\`${severityConfig.label.toUpperCase()}\``
+  lines.push(`#### ${emoji}${issue.title}`)
+  lines.push('')
+  lines.push(
+    `**Severity:** ${severityBadge} | **Category:** ${CATEGORY_CONFIG[issue.category].label}`,
+  )
+  lines.push('')
+
+  if (options.includeLocation) {
+    const relativePath = getRelativePath(issue.location.filePath, workspacePath)
+    let location = `📍 \`${relativePath}\``
+    if (issue.location.line !== undefined) {
+      location += `:${issue.location.line}`
+      if (issue.location.column !== undefined) {
+        location += `:${issue.location.column}`
+      }
+    }
+    lines.push(location)
+    lines.push('')
+  }
+
+  if (options.collapsibleDetails) {
+    lines.push('<details>')
+    lines.push('<summary>Details</summary>')
+    lines.push('')
+  }
+
+  lines.push(issue.description)
+  lines.push('')
+
+  if (options.includeSuggestions && issue.suggestion !== undefined) {
+    lines.push(`> **💡 Suggestion:** ${issue.suggestion}`)
+    lines.push('')
+  }
+
+  if (issue.relatedLocations !== undefined && issue.relatedLocations.length > 0) {
+    lines.push('**Related locations:**')
+    for (const loc of issue.relatedLocations) {
+      const relativePath = getRelativePath(loc.filePath, workspacePath)
+      let locStr = `- \`${relativePath}\``
+      if (loc.line !== undefined) {
+        locStr += `:${loc.line}`
+      }
+      lines.push(locStr)
+    }
+    lines.push('')
+  }
+
+  if (options.collapsibleDetails) {
+    lines.push('</details>')
+  }
+
+  return lines.join('\n')
+}
+
+/**
+ * Get status emoji based on severity.
+ */
+function getStatusEmoji(severity: Severity | null, useEmoji: boolean): string {
+  if (!useEmoji) {
+    return ''
+  }
+
+  if (severity === null) {
+    return '✅'
+  }
+
+  return SEVERITY_CONFIG[severity].emoji
+}

--- a/packages/workspace-analyzer/src/reporters/reporter.ts
+++ b/packages/workspace-analyzer/src/reporters/reporter.ts
@@ -1,0 +1,399 @@
+/**
+ * Report generator interface and base types for workspace analysis output.
+ *
+ * Defines the contract for reporters that format analysis results into
+ * various output formats (JSON, Markdown, console, etc.).
+ */
+
+import type {AnalysisResult, Issue, IssueCategory, Severity} from '../types/index'
+
+/**
+ * Supported output formats for analysis reports.
+ */
+export type ReportFormat = 'json' | 'markdown' | 'console'
+
+/**
+ * Options for configuring report generation.
+ */
+export interface ReportOptions {
+  /** Minimum severity level to include in the report */
+  readonly minSeverity?: Severity
+  /** Categories of issues to include (empty means all) */
+  readonly categories?: readonly IssueCategory[]
+  /** Whether to include file location details (line/column numbers) */
+  readonly includeLocation?: boolean
+  /** Whether to include fix suggestions */
+  readonly includeSuggestions?: boolean
+  /** Whether to group issues by file, category, or severity */
+  readonly groupBy?: 'file' | 'category' | 'severity' | 'none'
+  /** Whether to include summary statistics */
+  readonly includeSummary?: boolean
+  /** Output file path (if writing to file) */
+  readonly outputPath?: string
+  /** Whether to use colors in output (for console reporter) */
+  readonly colors?: boolean
+  /** Maximum number of issues to display per group */
+  readonly maxIssuesPerGroup?: number
+  /** Whether to include metadata in output */
+  readonly includeMetadata?: boolean
+}
+
+/**
+ * Grouped issues organized by a specific key.
+ */
+export interface GroupedIssues {
+  /** The grouping key (file path, category name, or severity level) */
+  readonly key: string
+  /** Human-readable label for the group */
+  readonly label: string
+  /** Issues in this group */
+  readonly issues: readonly Issue[]
+  /** Number of issues in this group */
+  readonly count: number
+}
+
+/**
+ * Summary statistics for report output.
+ */
+export interface ReportSummary {
+  /** Total number of issues */
+  readonly totalIssues: number
+  /** Issues by severity */
+  readonly bySeverity: Readonly<Record<Severity, number>>
+  /** Issues by category */
+  readonly byCategory: Readonly<Record<IssueCategory, number>>
+  /** Number of packages analyzed */
+  readonly packagesAnalyzed: number
+  /** Number of files analyzed */
+  readonly filesAnalyzed: number
+  /** Duration in milliseconds */
+  readonly durationMs: number
+  /** Number of files with issues */
+  readonly filesWithIssues: number
+  /** Highest severity level found */
+  readonly highestSeverity: Severity | null
+}
+
+/**
+ * Reporter interface that all report generators must implement.
+ *
+ * @example
+ * ```ts
+ * const jsonReporter = createJsonReporter()
+ * const report = jsonReporter.generate(analysisResult)
+ * await fs.writeFile('report.json', report)
+ * ```
+ */
+export interface Reporter {
+  /** Unique identifier for this reporter */
+  readonly id: ReportFormat
+  /** Human-readable name for this reporter */
+  readonly name: string
+  /** Generate a report string from analysis results */
+  readonly generate: (result: AnalysisResult, options?: ReportOptions) => string
+  /** Stream report output to a writable stream (for large reports) */
+  readonly stream?: (
+    result: AnalysisResult,
+    write: (chunk: string) => void,
+    options?: ReportOptions,
+  ) => void
+}
+
+/**
+ * Factory function type for creating reporter instances.
+ */
+export type ReporterFactory = (options?: ReportOptions) => Reporter
+
+/**
+ * Default report options.
+ */
+export const DEFAULT_REPORT_OPTIONS: Required<
+  Omit<ReportOptions, 'outputPath' | 'categories' | 'minSeverity'>
+> = {
+  includeLocation: true,
+  includeSuggestions: true,
+  groupBy: 'file',
+  includeSummary: true,
+  colors: true,
+  maxIssuesPerGroup: 50,
+  includeMetadata: false,
+}
+
+/**
+ * Severity display configuration for consistent formatting.
+ */
+export const SEVERITY_CONFIG: Readonly<
+  Record<
+    Severity,
+    {
+      label: string
+      emoji: string
+      color: string
+      priority: number
+    }
+  >
+> = {
+  critical: {label: 'Critical', emoji: '🚨', color: 'red', priority: 4},
+  error: {label: 'Error', emoji: '❌', color: 'red', priority: 3},
+  warning: {label: 'Warning', emoji: '⚠️', color: 'yellow', priority: 2},
+  info: {label: 'Info', emoji: 'ℹ️', color: 'blue', priority: 1},
+}
+
+/**
+ * Category display configuration for consistent formatting.
+ */
+export const CATEGORY_CONFIG: Readonly<
+  Record<
+    IssueCategory,
+    {
+      label: string
+      emoji: string
+      description: string
+    }
+  >
+> = {
+  configuration: {
+    label: 'Configuration',
+    emoji: '⚙️',
+    description: 'Package and project configuration issues',
+  },
+  dependency: {
+    label: 'Dependency',
+    emoji: '📦',
+    description: 'Package dependency issues',
+  },
+  architecture: {
+    label: 'Architecture',
+    emoji: '🏗️',
+    description: 'Architectural pattern violations',
+  },
+  performance: {
+    label: 'Performance',
+    emoji: '🚀',
+    description: 'Performance optimization opportunities',
+  },
+  'circular-import': {
+    label: 'Circular Import',
+    emoji: '🔄',
+    description: 'Circular import chains',
+  },
+  'unused-export': {
+    label: 'Unused Export',
+    emoji: '📤',
+    description: 'Exported but unused code',
+  },
+  'type-safety': {
+    label: 'Type Safety',
+    emoji: '🔒',
+    description: 'Type system issues',
+  },
+}
+
+/**
+ * Filter issues based on report options.
+ */
+export function filterIssuesForReport(
+  issues: readonly Issue[],
+  options: ReportOptions,
+): readonly Issue[] {
+  const severityOrder: Record<Severity, number> = {
+    info: 0,
+    warning: 1,
+    error: 2,
+    critical: 3,
+  }
+
+  return issues.filter(issue => {
+    if (
+      options.minSeverity !== undefined &&
+      severityOrder[issue.severity] < severityOrder[options.minSeverity]
+    ) {
+      return false
+    }
+
+    if (
+      options.categories !== undefined &&
+      options.categories.length > 0 &&
+      !options.categories.includes(issue.category)
+    ) {
+      return false
+    }
+
+    return true
+  })
+}
+
+/**
+ * Group issues by the specified key.
+ */
+export function groupIssues(
+  issues: readonly Issue[],
+  groupBy: ReportOptions['groupBy'],
+): readonly GroupedIssues[] {
+  if (groupBy === 'none' || groupBy === undefined) {
+    return [{key: 'all', label: 'All Issues', issues, count: issues.length}]
+  }
+
+  const groups = new Map<string, Issue[]>()
+
+  for (const issue of issues) {
+    let key: string
+    switch (groupBy) {
+      case 'file':
+        key = issue.location.filePath
+        break
+      case 'category':
+        key = issue.category
+        break
+      case 'severity':
+        key = issue.severity
+        break
+    }
+
+    const existing = groups.get(key) ?? []
+    existing.push(issue)
+    groups.set(key, existing)
+  }
+
+  const result: GroupedIssues[] = []
+  for (const [key, groupIssues] of groups) {
+    let label: string
+    switch (groupBy) {
+      case 'file':
+        label = key
+        break
+      case 'category':
+        label = CATEGORY_CONFIG[key as IssueCategory]?.label ?? key
+        break
+      case 'severity':
+        label = SEVERITY_CONFIG[key as Severity]?.label ?? key
+        break
+    }
+
+    result.push({key, label, issues: groupIssues, count: groupIssues.length})
+  }
+
+  if (groupBy === 'severity') {
+    result.sort((a, b) => {
+      const priorityA = SEVERITY_CONFIG[a.key as Severity]?.priority ?? 0
+      const priorityB = SEVERITY_CONFIG[b.key as Severity]?.priority ?? 0
+      return priorityB - priorityA
+    })
+  } else if (groupBy === 'category') {
+    result.sort((a, b) => a.label.localeCompare(b.label))
+  } else {
+    result.sort((a, b) => b.count - a.count)
+  }
+
+  return result
+}
+
+/**
+ * Calculate summary statistics from analysis results.
+ */
+export function calculateSummary(result: AnalysisResult): ReportSummary {
+  const bySeverity: Record<Severity, number> = {
+    info: 0,
+    warning: 0,
+    error: 0,
+    critical: 0,
+  }
+
+  const byCategory: Record<IssueCategory, number> = {
+    configuration: 0,
+    dependency: 0,
+    architecture: 0,
+    performance: 0,
+    'circular-import': 0,
+    'unused-export': 0,
+    'type-safety': 0,
+  }
+
+  const filesWithIssues = new Set<string>()
+  let highestSeverity: Severity | null = null
+  const severityOrder: Record<Severity, number> = {
+    info: 0,
+    warning: 1,
+    error: 2,
+    critical: 3,
+  }
+
+  for (const issue of result.issues) {
+    bySeverity[issue.severity]++
+    byCategory[issue.category]++
+    filesWithIssues.add(issue.location.filePath)
+
+    if (
+      highestSeverity === null ||
+      severityOrder[issue.severity] > severityOrder[highestSeverity]
+    ) {
+      highestSeverity = issue.severity
+    }
+  }
+
+  return {
+    totalIssues: result.summary.totalIssues,
+    bySeverity,
+    byCategory,
+    packagesAnalyzed: result.summary.packagesAnalyzed,
+    filesAnalyzed: result.summary.filesAnalyzed,
+    durationMs: result.summary.durationMs,
+    filesWithIssues: filesWithIssues.size,
+    highestSeverity,
+  }
+}
+
+/**
+ * Format a file location for display.
+ */
+export function formatLocation(
+  location: Issue['location'],
+  options?: {includeColumn?: boolean},
+): string {
+  let result = location.filePath
+
+  if (location.line !== undefined) {
+    result += `:${location.line}`
+    if (options?.includeColumn && location.column !== undefined) {
+      result += `:${location.column}`
+    }
+  }
+
+  return result
+}
+
+/**
+ * Format duration for human-readable display.
+ */
+export function formatDuration(ms: number): string {
+  if (ms < 1000) {
+    return `${ms}ms`
+  }
+  if (ms < 60000) {
+    return `${(ms / 1000).toFixed(2)}s`
+  }
+  const minutes = Math.floor(ms / 60000)
+  const seconds = ((ms % 60000) / 1000).toFixed(0)
+  return `${minutes}m ${seconds}s`
+}
+
+/**
+ * Truncate text to a maximum length with ellipsis.
+ */
+export function truncateText(text: string, maxLength: number): string {
+  if (text.length <= maxLength) {
+    return text
+  }
+  return `${text.slice(0, maxLength - 3)}...`
+}
+
+/**
+ * Get relative path from workspace root.
+ */
+export function getRelativePath(filePath: string, workspacePath: string): string {
+  if (filePath.startsWith(workspacePath)) {
+    const relative = filePath.slice(workspacePath.length)
+    return relative.startsWith('/') ? relative.slice(1) : relative
+  }
+  return filePath
+}

--- a/packages/workspace-analyzer/test/reporters/console-reporter.test.ts
+++ b/packages/workspace-analyzer/test/reporters/console-reporter.test.ts
@@ -1,0 +1,201 @@
+/**
+ * Tests for Console reporter.
+ */
+
+import type {AnalysisResult, Issue, IssueCategory, Severity} from '../../src/types/index'
+
+import {describe, expect, it, vi} from 'vitest'
+
+import {createConsoleReporter} from '../../src/reporters/console-reporter'
+
+function createMockIssue(overrides: Partial<Issue> = {}): Issue {
+  return {
+    id: 'test-issue',
+    title: 'Test Issue',
+    description: 'A test issue description',
+    severity: 'warning' as Severity,
+    category: 'configuration' as IssueCategory,
+    location: {
+      filePath: '/workspace/src/test.ts',
+      line: 10,
+      column: 5,
+    },
+    ...overrides,
+  }
+}
+
+function createMockAnalysisResult(issues: Issue[]): AnalysisResult {
+  return {
+    issues,
+    summary: {
+      totalIssues: issues.length,
+      bySeverity: {
+        info: issues.filter(i => i.severity === 'info').length,
+        warning: issues.filter(i => i.severity === 'warning').length,
+        error: issues.filter(i => i.severity === 'error').length,
+        critical: issues.filter(i => i.severity === 'critical').length,
+      },
+      byCategory: {
+        configuration: issues.filter(i => i.category === 'configuration').length,
+        dependency: issues.filter(i => i.category === 'dependency').length,
+        architecture: issues.filter(i => i.category === 'architecture').length,
+        performance: issues.filter(i => i.category === 'performance').length,
+        'circular-import': issues.filter(i => i.category === 'circular-import').length,
+        'unused-export': issues.filter(i => i.category === 'unused-export').length,
+        'type-safety': issues.filter(i => i.category === 'type-safety').length,
+      },
+      packagesAnalyzed: 5,
+      filesAnalyzed: 100,
+      durationMs: 1500,
+    },
+    workspacePath: '/workspace',
+    startedAt: new Date('2025-01-01T00:00:00Z'),
+    completedAt: new Date('2025-01-01T00:00:01.5Z'),
+  }
+}
+
+describe('createConsoleReporter', () => {
+  it.concurrent('should create a valid reporter', () => {
+    const reporter = createConsoleReporter()
+    expect(reporter.id).toBe('console')
+    expect(reporter.name).toBe('Console Reporter')
+    expect(typeof reporter.generate).toBe('function')
+  })
+
+  it.concurrent('should generate output with header', () => {
+    const reporter = createConsoleReporter()
+    const result = createMockAnalysisResult([createMockIssue()])
+
+    const output = reporter.generate(result)
+
+    expect(output).toContain('Workspace Analysis Report')
+  })
+
+  it.concurrent('should show issue count in header', () => {
+    const reporter = createConsoleReporter()
+    const result = createMockAnalysisResult([createMockIssue(), createMockIssue()])
+
+    const output = reporter.generate(result)
+
+    expect(output).toContain('2 issue(s) found')
+  })
+
+  it.concurrent('should show no issues message', () => {
+    const reporter = createConsoleReporter()
+    const result = createMockAnalysisResult([])
+
+    const output = reporter.generate(result)
+
+    expect(output).toContain('No issues')
+  })
+
+  it.concurrent('should include summary when enabled', () => {
+    const reporter = createConsoleReporter({includeSummary: true})
+    const result = createMockAnalysisResult([
+      createMockIssue({severity: 'error'}),
+      createMockIssue({severity: 'warning'}),
+    ])
+
+    const output = reporter.generate(result)
+
+    expect(output).toContain('Summary')
+    expect(output).toContain('packages')
+    expect(output).toContain('files')
+  })
+
+  it.concurrent('should format issues in compact mode', () => {
+    const reporter = createConsoleReporter({compact: true})
+    const issue = createMockIssue({
+      title: 'Test Configuration Issue',
+      location: {filePath: '/workspace/src/test.ts', line: 42},
+    })
+    const result = createMockAnalysisResult([issue])
+
+    const output = reporter.generate(result)
+
+    expect(output).toContain('src/test.ts:42')
+  })
+
+  it.concurrent('should format issues in detailed mode', () => {
+    const reporter = createConsoleReporter({compact: false, verbose: true})
+    const issue = createMockIssue({
+      title: 'Test Configuration Issue',
+      description: 'This is a longer description of the issue',
+    })
+    const result = createMockAnalysisResult([issue])
+
+    const output = reporter.generate(result)
+
+    expect(output).toContain('Test Configuration Issue')
+    expect(output).toContain('longer description')
+  })
+
+  it.concurrent('should include suggestions when enabled', () => {
+    const reporter = createConsoleReporter({includeSuggestions: true})
+    const issue = createMockIssue({suggestion: 'Update the configuration file'})
+    const result = createMockAnalysisResult([issue])
+
+    const output = reporter.generate(result)
+
+    expect(output).toContain('Update the configuration file')
+  })
+
+  it.concurrent('should filter issues by severity', () => {
+    const reporter = createConsoleReporter()
+    const issues = [
+      createMockIssue({id: 'info-1', title: 'Info Issue', severity: 'info'}),
+      createMockIssue({id: 'error-1', title: 'Error Issue', severity: 'error'}),
+    ]
+    const result = createMockAnalysisResult(issues)
+
+    const output = reporter.generate(result, {minSeverity: 'error'})
+
+    expect(output).toContain('Error Issue')
+    expect(output).not.toContain('Info Issue')
+  })
+
+  it.concurrent('should include footer with recommendations', () => {
+    const reporter = createConsoleReporter()
+    const result = createMockAnalysisResult([createMockIssue({severity: 'error'})])
+
+    const output = reporter.generate(result)
+
+    expect(output).toContain('Recommendations')
+  })
+
+  it.concurrent('should show success message for no issues', () => {
+    const reporter = createConsoleReporter()
+    const result = createMockAnalysisResult([])
+
+    const output = reporter.generate(result)
+
+    expect(output).toContain('looks great')
+  })
+
+  it.concurrent('should truncate long issue lists', () => {
+    const reporter = createConsoleReporter({maxIssuesPerGroup: 2})
+    const issues = [
+      createMockIssue({id: '1'}),
+      createMockIssue({id: '2'}),
+      createMockIssue({id: '3'}),
+      createMockIssue({id: '4'}),
+    ]
+    const result = createMockAnalysisResult(issues)
+
+    const output = reporter.generate(result)
+
+    expect(output).toContain('more issue(s)')
+  })
+
+  it.concurrent('should support stream method', () => {
+    const reporter = createConsoleReporter()
+    const result = createMockAnalysisResult([createMockIssue()])
+    const chunks: string[] = []
+    const write = vi.fn((chunk: string) => chunks.push(chunk))
+
+    reporter.stream?.(result, write)
+
+    expect(write).toHaveBeenCalled()
+    expect(chunks.join('')).toContain('Workspace Analysis Report')
+  })
+})

--- a/packages/workspace-analyzer/test/reporters/json-reporter.test.ts
+++ b/packages/workspace-analyzer/test/reporters/json-reporter.test.ts
@@ -1,0 +1,169 @@
+/**
+ * Tests for JSON reporter.
+ */
+
+import type {JsonReport} from '../../src/reporters/json-reporter'
+import type {AnalysisResult, Issue, IssueCategory, Severity} from '../../src/types/index'
+
+import {describe, expect, it} from 'vitest'
+
+import {createJsonReporter} from '../../src/reporters/json-reporter'
+
+function createMockIssue(overrides: Partial<Issue> = {}): Issue {
+  return {
+    id: 'test-issue',
+    title: 'Test Issue',
+    description: 'A test issue description',
+    severity: 'warning' as Severity,
+    category: 'configuration' as IssueCategory,
+    location: {
+      filePath: '/workspace/src/test.ts',
+      line: 10,
+      column: 5,
+    },
+    ...overrides,
+  }
+}
+
+function createMockAnalysisResult(issues: Issue[]): AnalysisResult {
+  return {
+    issues,
+    summary: {
+      totalIssues: issues.length,
+      bySeverity: {
+        info: issues.filter(i => i.severity === 'info').length,
+        warning: issues.filter(i => i.severity === 'warning').length,
+        error: issues.filter(i => i.severity === 'error').length,
+        critical: issues.filter(i => i.severity === 'critical').length,
+      },
+      byCategory: {
+        configuration: issues.filter(i => i.category === 'configuration').length,
+        dependency: issues.filter(i => i.category === 'dependency').length,
+        architecture: issues.filter(i => i.category === 'architecture').length,
+        performance: issues.filter(i => i.category === 'performance').length,
+        'circular-import': issues.filter(i => i.category === 'circular-import').length,
+        'unused-export': issues.filter(i => i.category === 'unused-export').length,
+        'type-safety': issues.filter(i => i.category === 'type-safety').length,
+      },
+      packagesAnalyzed: 5,
+      filesAnalyzed: 100,
+      durationMs: 1500,
+    },
+    workspacePath: '/workspace',
+    startedAt: new Date('2025-01-01T00:00:00Z'),
+    completedAt: new Date('2025-01-01T00:00:01.5Z'),
+  }
+}
+
+describe('createJsonReporter', () => {
+  it.concurrent('should create a valid reporter', () => {
+    const reporter = createJsonReporter()
+    expect(reporter.id).toBe('json')
+    expect(reporter.name).toBe('JSON Reporter')
+    expect(typeof reporter.generate).toBe('function')
+  })
+
+  it.concurrent('should generate valid JSON', () => {
+    const reporter = createJsonReporter()
+    const issues = [createMockIssue()]
+    const result = createMockAnalysisResult(issues)
+
+    const output = reporter.generate(result)
+    expect(() => JSON.parse(output)).not.toThrow()
+  })
+
+  it.concurrent('should include metadata in output', () => {
+    const reporter = createJsonReporter()
+    const result = createMockAnalysisResult([createMockIssue()])
+
+    const output = reporter.generate(result)
+    const report: JsonReport = JSON.parse(output)
+
+    expect(report.metadata).toBeDefined()
+    expect(report.metadata.workspacePath).toBe('/workspace')
+    expect(report.metadata.analysisStartedAt).toBeDefined()
+    expect(report.metadata.analysisCompletedAt).toBeDefined()
+    expect(report.metadata.generatedAt).toBeDefined()
+  })
+
+  it.concurrent('should include summary in output', () => {
+    const reporter = createJsonReporter()
+    const issues = [createMockIssue({severity: 'error'}), createMockIssue({severity: 'warning'})]
+    const result = createMockAnalysisResult(issues)
+
+    const output = reporter.generate(result)
+    const report: JsonReport = JSON.parse(output)
+
+    expect(report.summary.totalIssues).toBe(2)
+    expect(report.summary.bySeverity.error).toBe(1)
+    expect(report.summary.bySeverity.warning).toBe(1)
+  })
+
+  it.concurrent('should include issues with location', () => {
+    const reporter = createJsonReporter({includeLocation: true})
+    const issue = createMockIssue({
+      location: {filePath: '/workspace/src/test.ts', line: 42, column: 10},
+    })
+    const result = createMockAnalysisResult([issue])
+
+    const output = reporter.generate(result)
+    const report: JsonReport = JSON.parse(output)
+
+    expect(report.issues).toHaveLength(1)
+    expect(report.issues[0]?.location.file).toBe('src/test.ts')
+    expect(report.issues[0]?.location.line).toBe(42)
+    expect(report.issues[0]?.location.column).toBe(10)
+  })
+
+  it.concurrent('should respect pretty print option', () => {
+    const compactReporter = createJsonReporter({prettyPrint: false})
+    const prettyReporter = createJsonReporter({prettyPrint: true})
+    const result = createMockAnalysisResult([createMockIssue()])
+
+    const compactOutput = compactReporter.generate(result)
+    const prettyOutput = prettyReporter.generate(result)
+
+    expect(compactOutput).not.toContain('\n')
+    expect(prettyOutput).toContain('\n')
+  })
+
+  it.concurrent('should filter issues by severity', () => {
+    const reporter = createJsonReporter()
+    const issues = [
+      createMockIssue({id: 'info-1', severity: 'info'}),
+      createMockIssue({id: 'error-1', severity: 'error'}),
+    ]
+    const result = createMockAnalysisResult(issues)
+
+    const output = reporter.generate(result, {minSeverity: 'error'})
+    const report: JsonReport = JSON.parse(output)
+
+    expect(report.issues).toHaveLength(1)
+    expect(report.issues[0]?.id).toBe('error-1')
+  })
+
+  it.concurrent('should include grouped issues when enabled', () => {
+    const reporter = createJsonReporter({includeGroupedIssues: true})
+    const issues = [
+      createMockIssue({location: {filePath: '/workspace/a.ts'}}),
+      createMockIssue({location: {filePath: '/workspace/b.ts'}}),
+    ]
+    const result = createMockAnalysisResult(issues)
+
+    const output = reporter.generate(result, {groupBy: 'file'})
+    const report: JsonReport = JSON.parse(output)
+
+    expect(report.groupedIssues).toBeDefined()
+    expect(report.groupedIssues).toHaveLength(2)
+  })
+
+  it.concurrent('should include $schema when schemaUrl provided', () => {
+    const reporter = createJsonReporter({schemaUrl: 'https://example.com/schema.json'})
+    const result = createMockAnalysisResult([])
+
+    const output = reporter.generate(result)
+    const report: JsonReport = JSON.parse(output)
+
+    expect(report.$schema).toBe('https://example.com/schema.json')
+  })
+})

--- a/packages/workspace-analyzer/test/reporters/markdown-reporter.test.ts
+++ b/packages/workspace-analyzer/test/reporters/markdown-reporter.test.ts
@@ -1,0 +1,204 @@
+/**
+ * Tests for Markdown reporter.
+ */
+
+import type {AnalysisResult, Issue, IssueCategory, Severity} from '../../src/types/index'
+
+import {describe, expect, it} from 'vitest'
+
+import {createMarkdownReporter} from '../../src/reporters/markdown-reporter'
+
+function createMockIssue(overrides: Partial<Issue> = {}): Issue {
+  return {
+    id: 'test-issue',
+    title: 'Test Issue',
+    description: 'A test issue description',
+    severity: 'warning' as Severity,
+    category: 'configuration' as IssueCategory,
+    location: {
+      filePath: '/workspace/src/test.ts',
+      line: 10,
+      column: 5,
+    },
+    ...overrides,
+  }
+}
+
+function createMockAnalysisResult(issues: Issue[]): AnalysisResult {
+  return {
+    issues,
+    summary: {
+      totalIssues: issues.length,
+      bySeverity: {
+        info: issues.filter(i => i.severity === 'info').length,
+        warning: issues.filter(i => i.severity === 'warning').length,
+        error: issues.filter(i => i.severity === 'error').length,
+        critical: issues.filter(i => i.severity === 'critical').length,
+      },
+      byCategory: {
+        configuration: issues.filter(i => i.category === 'configuration').length,
+        dependency: issues.filter(i => i.category === 'dependency').length,
+        architecture: issues.filter(i => i.category === 'architecture').length,
+        performance: issues.filter(i => i.category === 'performance').length,
+        'circular-import': issues.filter(i => i.category === 'circular-import').length,
+        'unused-export': issues.filter(i => i.category === 'unused-export').length,
+        'type-safety': issues.filter(i => i.category === 'type-safety').length,
+      },
+      packagesAnalyzed: 5,
+      filesAnalyzed: 100,
+      durationMs: 1500,
+    },
+    workspacePath: '/workspace',
+    startedAt: new Date('2025-01-01T00:00:00Z'),
+    completedAt: new Date('2025-01-01T00:00:01.5Z'),
+  }
+}
+
+describe('createMarkdownReporter', () => {
+  it.concurrent('should create a valid reporter', () => {
+    const reporter = createMarkdownReporter()
+    expect(reporter.id).toBe('markdown')
+    expect(reporter.name).toBe('Markdown Reporter')
+    expect(typeof reporter.generate).toBe('function')
+  })
+
+  it.concurrent('should generate valid Markdown with title', () => {
+    const reporter = createMarkdownReporter({title: 'My Analysis Report'})
+    const result = createMockAnalysisResult([createMockIssue()])
+
+    const output = reporter.generate(result)
+
+    expect(output).toContain('# ')
+    expect(output).toContain('My Analysis Report')
+  })
+
+  it.concurrent('should include summary section', () => {
+    const reporter = createMarkdownReporter({includeSummary: true})
+    const result = createMockAnalysisResult([
+      createMockIssue({severity: 'error'}),
+      createMockIssue({severity: 'warning'}),
+    ])
+
+    const output = reporter.generate(result)
+
+    expect(output).toContain('## Summary')
+    expect(output).toContain('Total Issues')
+    expect(output).toContain('Issues by Severity')
+  })
+
+  it.concurrent('should include issues section', () => {
+    const reporter = createMarkdownReporter()
+    const issue = createMockIssue({
+      title: 'Test Configuration Issue',
+      description: 'This is a detailed description',
+    })
+    const result = createMockAnalysisResult([issue])
+
+    const output = reporter.generate(result)
+
+    expect(output).toContain('## Issues')
+    expect(output).toContain('Test Configuration Issue')
+  })
+
+  it.concurrent('should include GitHub alert when enabled', () => {
+    const reporter = createMarkdownReporter({githubFlavored: true})
+    const result = createMockAnalysisResult([createMockIssue({severity: 'error'})])
+
+    const output = reporter.generate(result)
+
+    expect(output).toContain('[!CAUTION]')
+  })
+
+  it.concurrent('should show success message for no issues', () => {
+    const reporter = createMarkdownReporter({githubFlavored: true})
+    const result = createMockAnalysisResult([])
+
+    const output = reporter.generate(result)
+
+    expect(output).toContain('[!TIP]')
+    expect(output).toContain('No issues found')
+  })
+
+  it.concurrent('should include file location', () => {
+    const reporter = createMarkdownReporter({includeLocation: true})
+    const issue = createMockIssue({
+      location: {filePath: '/workspace/src/test.ts', line: 42, column: 10},
+    })
+    const result = createMockAnalysisResult([issue])
+
+    const output = reporter.generate(result)
+
+    expect(output).toContain('src/test.ts')
+    expect(output).toContain(':42')
+  })
+
+  it.concurrent('should include suggestion when enabled', () => {
+    const reporter = createMarkdownReporter({includeSuggestions: true})
+    const issue = createMockIssue({suggestion: 'Fix by updating the config'})
+    const result = createMockAnalysisResult([issue])
+
+    const output = reporter.generate(result)
+
+    expect(output).toContain('Suggestion')
+    expect(output).toContain('Fix by updating the config')
+  })
+
+  it.concurrent('should use emoji when enabled', () => {
+    const reporter = createMarkdownReporter({useEmoji: true})
+    const result = createMockAnalysisResult([createMockIssue({severity: 'warning'})])
+
+    const output = reporter.generate(result)
+
+    expect(output).toContain('⚠️')
+  })
+
+  it.concurrent('should not use emoji when disabled', () => {
+    const reporter = createMarkdownReporter({useEmoji: false})
+    const result = createMockAnalysisResult([createMockIssue({severity: 'warning'})])
+
+    const output = reporter.generate(result)
+
+    expect(output).not.toContain('⚠️')
+  })
+
+  it.concurrent('should include table of contents when enabled', () => {
+    const reporter = createMarkdownReporter({
+      includeTableOfContents: true,
+      groupBy: 'category',
+    })
+    const issues = [
+      createMockIssue({category: 'configuration'}),
+      createMockIssue({category: 'dependency'}),
+    ]
+    const result = createMockAnalysisResult(issues)
+
+    const output = reporter.generate(result)
+
+    expect(output).toContain('Table of Contents')
+  })
+
+  it.concurrent('should use collapsible details when enabled', () => {
+    const reporter = createMarkdownReporter({collapsibleDetails: true})
+    const result = createMockAnalysisResult([createMockIssue()])
+
+    const output = reporter.generate(result)
+
+    expect(output).toContain('<details>')
+    expect(output).toContain('<summary>')
+    expect(output).toContain('</details>')
+  })
+
+  it.concurrent('should filter issues by severity', () => {
+    const reporter = createMarkdownReporter()
+    const issues = [
+      createMockIssue({id: 'info-1', title: 'Info Issue', severity: 'info'}),
+      createMockIssue({id: 'error-1', title: 'Error Issue', severity: 'error'}),
+    ]
+    const result = createMockAnalysisResult(issues)
+
+    const output = reporter.generate(result, {minSeverity: 'error'})
+
+    expect(output).toContain('Error Issue')
+    expect(output).not.toContain('Info Issue')
+  })
+})

--- a/packages/workspace-analyzer/test/reporters/reporter.test.ts
+++ b/packages/workspace-analyzer/test/reporters/reporter.test.ts
@@ -1,0 +1,259 @@
+/**
+ * Tests for reporter interface utilities and helper functions.
+ */
+
+import type {AnalysisResult, Issue, IssueCategory, Severity} from '../../src/types/index'
+
+import {describe, expect, it} from 'vitest'
+
+import {
+  calculateSummary,
+  filterIssuesForReport,
+  formatDuration,
+  formatLocation,
+  getRelativePath,
+  groupIssues,
+  truncateText,
+} from '../../src/reporters/reporter'
+
+function createMockIssue(overrides: Partial<Issue> = {}): Issue {
+  return {
+    id: 'test-issue',
+    title: 'Test Issue',
+    description: 'A test issue description',
+    severity: 'warning' as Severity,
+    category: 'configuration' as IssueCategory,
+    location: {
+      filePath: '/workspace/src/test.ts',
+      line: 10,
+      column: 5,
+    },
+    ...overrides,
+  }
+}
+
+function createMockAnalysisResult(issues: Issue[]): AnalysisResult {
+  return {
+    issues,
+    summary: {
+      totalIssues: issues.length,
+      bySeverity: {
+        info: issues.filter(i => i.severity === 'info').length,
+        warning: issues.filter(i => i.severity === 'warning').length,
+        error: issues.filter(i => i.severity === 'error').length,
+        critical: issues.filter(i => i.severity === 'critical').length,
+      },
+      byCategory: {
+        configuration: issues.filter(i => i.category === 'configuration').length,
+        dependency: issues.filter(i => i.category === 'dependency').length,
+        architecture: issues.filter(i => i.category === 'architecture').length,
+        performance: issues.filter(i => i.category === 'performance').length,
+        'circular-import': issues.filter(i => i.category === 'circular-import').length,
+        'unused-export': issues.filter(i => i.category === 'unused-export').length,
+        'type-safety': issues.filter(i => i.category === 'type-safety').length,
+      },
+      packagesAnalyzed: 5,
+      filesAnalyzed: 100,
+      durationMs: 1500,
+    },
+    workspacePath: '/workspace',
+    startedAt: new Date('2025-01-01T00:00:00Z'),
+    completedAt: new Date('2025-01-01T00:00:01.5Z'),
+  }
+}
+
+describe('filterIssuesForReport', () => {
+  const issues: Issue[] = [
+    createMockIssue({id: 'info-1', severity: 'info', category: 'configuration'}),
+    createMockIssue({id: 'warning-1', severity: 'warning', category: 'dependency'}),
+    createMockIssue({id: 'error-1', severity: 'error', category: 'architecture'}),
+    createMockIssue({id: 'critical-1', severity: 'critical', category: 'performance'}),
+  ]
+
+  it.concurrent('should return all issues when no filters applied', () => {
+    const filtered = filterIssuesForReport(issues, {})
+    expect(filtered).toHaveLength(4)
+  })
+
+  it.concurrent('should filter by minimum severity', () => {
+    const filtered = filterIssuesForReport(issues, {minSeverity: 'warning'})
+    expect(filtered).toHaveLength(3)
+    expect(filtered.every(i => i.severity !== 'info')).toBe(true)
+  })
+
+  it.concurrent('should filter by category', () => {
+    const filtered = filterIssuesForReport(issues, {categories: ['configuration', 'dependency']})
+    expect(filtered).toHaveLength(2)
+    expect(filtered.map(i => i.category)).toEqual(['configuration', 'dependency'])
+  })
+
+  it.concurrent('should combine severity and category filters', () => {
+    const filtered = filterIssuesForReport(issues, {
+      minSeverity: 'error',
+      categories: ['architecture', 'performance'],
+    })
+    expect(filtered).toHaveLength(2)
+  })
+})
+
+describe('groupIssues', () => {
+  const issues: Issue[] = [
+    createMockIssue({
+      id: 'issue-1',
+      severity: 'warning',
+      category: 'configuration',
+      location: {filePath: '/workspace/src/a.ts'},
+    }),
+    createMockIssue({
+      id: 'issue-2',
+      severity: 'error',
+      category: 'configuration',
+      location: {filePath: '/workspace/src/a.ts'},
+    }),
+    createMockIssue({
+      id: 'issue-3',
+      severity: 'warning',
+      category: 'dependency',
+      location: {filePath: '/workspace/src/b.ts'},
+    }),
+  ]
+
+  it.concurrent('should group by file', () => {
+    const groups = groupIssues(issues, 'file')
+    expect(groups).toHaveLength(2)
+    expect(groups.find(g => g.key === '/workspace/src/a.ts')?.count).toBe(2)
+    expect(groups.find(g => g.key === '/workspace/src/b.ts')?.count).toBe(1)
+  })
+
+  it.concurrent('should group by severity', () => {
+    const groups = groupIssues(issues, 'severity')
+    expect(groups).toHaveLength(2)
+    expect(groups.find(g => g.key === 'warning')?.count).toBe(2)
+    expect(groups.find(g => g.key === 'error')?.count).toBe(1)
+  })
+
+  it.concurrent('should group by category', () => {
+    const groups = groupIssues(issues, 'category')
+    expect(groups).toHaveLength(2)
+    expect(groups.find(g => g.key === 'configuration')?.count).toBe(2)
+    expect(groups.find(g => g.key === 'dependency')?.count).toBe(1)
+  })
+
+  it.concurrent('should return single group when groupBy is none', () => {
+    const groups = groupIssues(issues, 'none')
+    expect(groups).toHaveLength(1)
+    expect(groups[0]?.count).toBe(3)
+  })
+})
+
+describe('calculateSummary', () => {
+  it.concurrent('should calculate summary statistics correctly', () => {
+    const issues: Issue[] = [
+      createMockIssue({severity: 'error', category: 'configuration'}),
+      createMockIssue({severity: 'warning', category: 'dependency'}),
+      createMockIssue({severity: 'warning', category: 'dependency'}),
+    ]
+    const result = createMockAnalysisResult(issues)
+
+    const summary = calculateSummary(result)
+
+    expect(summary.totalIssues).toBe(3)
+    expect(summary.bySeverity.error).toBe(1)
+    expect(summary.bySeverity.warning).toBe(2)
+    expect(summary.byCategory.dependency).toBe(2)
+    expect(summary.highestSeverity).toBe('error')
+  })
+
+  it.concurrent('should handle empty issues', () => {
+    const result = createMockAnalysisResult([])
+    const summary = calculateSummary(result)
+
+    expect(summary.totalIssues).toBe(0)
+    expect(summary.highestSeverity).toBeNull()
+  })
+
+  it.concurrent('should count files with issues', () => {
+    const issues: Issue[] = [
+      createMockIssue({location: {filePath: '/a.ts'}}),
+      createMockIssue({location: {filePath: '/a.ts'}}),
+      createMockIssue({location: {filePath: '/b.ts'}}),
+    ]
+    const result = createMockAnalysisResult(issues)
+
+    const summary = calculateSummary(result)
+    expect(summary.filesWithIssues).toBe(2)
+  })
+})
+
+describe('formatLocation', () => {
+  it.concurrent('should format file path only', () => {
+    const location = formatLocation({filePath: '/workspace/src/test.ts'})
+    expect(location).toBe('/workspace/src/test.ts')
+  })
+
+  it.concurrent('should format with line number', () => {
+    const location = formatLocation({filePath: '/workspace/src/test.ts', line: 42})
+    expect(location).toBe('/workspace/src/test.ts:42')
+  })
+
+  it.concurrent('should format with line and column', () => {
+    const location = formatLocation(
+      {filePath: '/workspace/src/test.ts', line: 42, column: 10},
+      {includeColumn: true},
+    )
+    expect(location).toBe('/workspace/src/test.ts:42:10')
+  })
+
+  it.concurrent('should not include column without flag', () => {
+    const location = formatLocation({filePath: '/workspace/src/test.ts', line: 42, column: 10})
+    expect(location).toBe('/workspace/src/test.ts:42')
+  })
+})
+
+describe('formatDuration', () => {
+  it.concurrent('should format milliseconds', () => {
+    expect(formatDuration(500)).toBe('500ms')
+    expect(formatDuration(999)).toBe('999ms')
+  })
+
+  it.concurrent('should format seconds', () => {
+    expect(formatDuration(1500)).toBe('1.50s')
+    expect(formatDuration(30000)).toBe('30.00s')
+  })
+
+  it.concurrent('should format minutes and seconds', () => {
+    expect(formatDuration(60000)).toBe('1m 0s')
+    expect(formatDuration(90000)).toBe('1m 30s')
+  })
+})
+
+describe('truncateText', () => {
+  it.concurrent('should not truncate short text', () => {
+    expect(truncateText('Hello', 10)).toBe('Hello')
+  })
+
+  it.concurrent('should truncate long text with ellipsis', () => {
+    expect(truncateText('Hello World', 8)).toBe('Hello...')
+  })
+
+  it.concurrent('should handle exact length', () => {
+    expect(truncateText('Hello', 5)).toBe('Hello')
+  })
+})
+
+describe('getRelativePath', () => {
+  it.concurrent('should return relative path from workspace', () => {
+    const relative = getRelativePath('/workspace/src/test.ts', '/workspace')
+    expect(relative).toBe('src/test.ts')
+  })
+
+  it.concurrent('should return original path if not in workspace', () => {
+    const relative = getRelativePath('/other/path/test.ts', '/workspace')
+    expect(relative).toBe('/other/path/test.ts')
+  })
+
+  it.concurrent('should handle trailing slash in workspace path', () => {
+    const relative = getRelativePath('/workspace/src/test.ts', '/workspace/')
+    expect(relative).toBe('src/test.ts')
+  })
+})


### PR DESCRIPTION
- Implement reporter interface and base types for analysis output.
- Create console, JSON, and Markdown reporters with tests.
- Add utility functions for filtering, grouping, and summarizing issues.
- Develop tests for reporter utilities and ensure coverage for various scenarios.

Closes #2406.