### PR TITLE
ci: add build step for workspace-analyzer package in CI workflow

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -91,6 +91,9 @@ jobs:
       - name: Prepare job
         uses: ./.github/actions/pnpm-install
 
+      - name: Build workspace-analyzer package
+        run: pnpm --filter @bfra.me/workspace-analyzer run prepack
+
       - name: Run workspace analysis
         run: pnpm run analyze --json > workspace-analysis.json
         continue-on-error: true

--- a/packages/workspace-analyzer/package.json
+++ b/packages/workspace-analyzer/package.json
@@ -84,6 +84,7 @@
     }
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   }
 }


### PR DESCRIPTION
- Add a step to build the workspace-analyzer package before analysis
- Enable provenance in the publish configuration of workspace-analyzer