### PR TITLE
ci(workflows): avoid canceling release runs

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,7 +19,7 @@ permissions:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   manage-release:


### PR DESCRIPTION
- disable cancel-in-progress for Release workflow