### PR TITLE
fix(docs): disable Astro telemetry

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -1,6 +1,10 @@
 // @ts-check
+import process from 'node:process'
 import starlight from '@astrojs/starlight'
 import {defineConfig} from 'astro/config'
+
+// Disable Astro telemetry — no defineConfig() option exists for this
+process.env.ASTRO_TELEMETRY_DISABLED = '1'
 
 // https://astro.build/config
 export default defineConfig({


### PR DESCRIPTION
## Summary

- Sets `ASTRO_TELEMETRY_DISABLED=1` in `docs/astro.config.mjs` to prevent the Astro CLI from phoning home to `telemetry.astro.build`
- Resolves firewall blocks encountered by the Copilot coding agent during `astro sync` (see [#2857](https://github.com/bfra-me/works/pull/2857#issue-4078089721))
- Aligns with the project's privacy-first policy (telemetry should be opt-in, not opt-out)

## Details

Astro has no `defineConfig()` option for telemetry. The supported project-level mechanism is the `ASTRO_TELEMETRY_DISABLED` environment variable, set here at config load time so it applies to all environments (local dev, CI, Copilot agents) without per-machine setup.