### PR TITLE
ci(tsconfig): add explicit node types for test tsconfig

### DIFF
--- a/packages/tsconfig/test/tsconfig.json
+++ b/packages/tsconfig/test/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../tsconfig.json",
   "compilerOptions": {
+    "types": ["node"],
     "noEmit": true
   },
   "include": ["*.test.ts"]


### PR DESCRIPTION
## Summary

Adds explicit `types: ["node"]` to the test tsconfig at `packages/tsconfig/test/tsconfig.json` to fix lint errors with TypeScript 6.

## Problem

PR #3050 introduces `peerDependencyRules.allowedVersions` for TypeScript 6 to support eslint-react packages. This causes pnpm to resolve TypeScript 6.0.2 for `typescript-eslint`, which has stricter module resolution behavior. Node.js built-in types (`process`, `path`, `assert`) fail to resolve in the test file, causing lint errors.

## Solution

Add `types: ["node"]` to the **test-specific** tsconfig only:

```json
// packages/tsconfig/test/tsconfig.json
{
  "compilerOptions": {
    "types": ["node"],
    "noEmit": true
  }
}
```

This constrains the fix to this project's test infrastructure without affecting the published `@bfra.me/tsconfig` package or downstream consumers.

## Why not modify the published package?

Per Fro Bot's review, modifying the published `@bfra.me/tsconfig` would require:
1. Adding `@types/node` as a peer dependency
2. A breaking change (major bump) since consumers would silently fail without `@types/node`

The test tsconfig is not published, so this change has no downstream impact.

## Verification

- [x] `pnpm lint` passes
- [x] No changeset needed (no published package changes)

## Related

- Fixes lint failure in #3050
- Addresses feedback from Fro Bot review