### PR TITLE
chore(tsconfig): bump lib from ES2023 to ES2024

### DIFF
--- a/.changeset/bump-lib-es2024.md
+++ b/.changeset/bump-lib-es2024.md
@@ -1,0 +1,5 @@
+---
+'@bfra.me/tsconfig': minor
+---
+
+Bump `lib` from `ES2023` to `ES2024`, exposing ES2024 built-in type definitions (`Object.groupBy`, `Promise.withResolvers`, `Map.groupBy`, etc.) for all consumers.

--- a/packages/tsconfig/tsconfig.json
+++ b/packages/tsconfig/tsconfig.json
@@ -4,7 +4,7 @@
   "compilerOptions": {
     // Language and Environment
     "target": "ES2022",
-    "lib": ["ES2023"],
+    "lib": ["ES2024"],
 
     // Modules
     "module": "Preserve",


### PR DESCRIPTION
## Summary

Bumps `lib` from `["ES2023"]` to `["ES2024"]` in `@bfra.me/tsconfig`, exposing ES2024 built-in type definitions for all consumers.

## What this enables

TypeScript will now recognize ES2024 globals:
- `Object.groupBy()`, `Map.groupBy()`
- `Promise.withResolvers()`
- `ArrayBuffer.prototype.transfer()`
- `Atomics.waitAsync()`

## What this does NOT change

- **`target` remains `ES2022`** — consumers override this in their own `tsconfig.build.json` as needed
- No runtime behavior change — only type definitions are affected
- Non-breaking for existing consumers (additive change)

## Context

The `bfra-me/.github` actions already target ES2024/node24 in their build configs but inherit `lib: ["ES2023"]` from this shared config, leaving a type-checking gap for ES2024 built-ins.